### PR TITLE
Skip tests on win, plus fix some skipped tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,4 @@ filterwarnings =
     ignore::DeprecationWarning:marshmallow.*:
     ignore::DeprecationWarning:werkzeug.*:
 
+norecursedirs=tests/helpers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
+sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
 
 import pytest
 from testplan import TestplanMock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
 """Shared PyTest fixtures."""
 
 import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
+
 import pytest
 from testplan import TestplanMock
 from testplan.common.utils import path

--- a/tests/functional/exporters/testing/test_webserver.py
+++ b/tests/functional/exporters/testing/test_webserver.py
@@ -9,10 +9,9 @@ from six.moves import queue
 import pytest
 import requests
 
-pytestmark = pytest.mark.skipif(
-    os.name != "posix",
-    reason="Subprocess based approach is problematic on windows.",
-)
+from pytest_test_filters import skip_on_windows
+
+pytestmark = skip_on_windows(reason="Subprocess based approach is problematic on windows.")
 
 from testplan.common.utils.process import kill_process
 

--- a/tests/functional/exporters/testing/test_webserver.py
+++ b/tests/functional/exporters/testing/test_webserver.py
@@ -11,7 +11,9 @@ import requests
 
 from pytest_test_filters import skip_on_windows
 
-pytestmark = skip_on_windows(reason="Subprocess based approach is problematic on windows.")
+pytestmark = skip_on_windows(
+    reason="Subprocess based approach is problematic on windows."
+)
 
 from testplan.common.utils.process import kill_process
 

--- a/tests/functional/testplan/runnable/interactive/test_api.py
+++ b/tests/functional/testplan/runnable/interactive/test_api.py
@@ -23,6 +23,7 @@ from testplan.exporters.testing import XMLExporter
 
 from tests.unit.testplan.runnable.interactive import test_api
 
+
 @multitest.testsuite
 class ExampleSuite(object):
     """Example test suite."""
@@ -62,7 +63,9 @@ class ExampleSuite(object):
 def plan(tmpdir):
     """Yield an interactive testplan."""
 
-    with patch('testplan.runnable.interactive.reloader.ModuleReloader') as MockReloader:
+    with patch(
+        "testplan.runnable.interactive.reloader.ModuleReloader"
+    ) as MockReloader:
         MockReloader.return_value = None
 
         plan = testplan.TestplanMock(
@@ -74,7 +77,8 @@ def plan(tmpdir):
 
         logfile = tmpdir / "attached_log.txt"
         logfile.write_text(
-            "This text will be written into the attached file.", encoding="utf8"
+            "This text will be written into the attached file.",
+            encoding="utf8",
         )
 
         plan.add(

--- a/tests/functional/testplan/runnable/interactive/test_api.py
+++ b/tests/functional/testplan/runnable/interactive/test_api.py
@@ -5,11 +5,11 @@ from __future__ import division
 from __future__ import absolute_import
 
 from future import standard_library
+from mock import patch
 
 standard_library.install_aliases()
 import functools
 
-import os
 import pytest
 import requests
 import six
@@ -22,10 +22,6 @@ from testplan.common import entity
 from testplan.exporters.testing import XMLExporter
 
 from tests.unit.testplan.runnable.interactive import test_api
-
-# TODO: skipping interacive test for now, cannot figure out why it fails
-pytestmark = pytest.mark.skip(reason="test failing for unknown reason")
-
 
 @multitest.testsuite
 class ExampleSuite(object):
@@ -65,32 +61,36 @@ class ExampleSuite(object):
 @pytest.fixture
 def plan(tmpdir):
     """Yield an interactive testplan."""
-    plan = testplan.TestplanMock(
-        name=six.ensure_str("InteractiveAPITest"),
-        interactive_port=0,
-        interactive_block=False,
-        exporters=[XMLExporter(xml_dir=tmpdir / "xml_exporter")],
-    )
 
-    logfile = tmpdir / "attached_log.txt"
-    logfile.write_text(
-        "This text will be written into the attached file.", encoding="utf8"
-    )
+    with patch('testplan.runnable.interactive.reloader.ModuleReloader') as MockReloader:
+        MockReloader.return_value = None
 
-    plan.add(
-        multitest.MultiTest(
-            name=six.ensure_str("ExampleMTest"),
-            suites=[ExampleSuite(str(logfile))],
+        plan = testplan.TestplanMock(
+            name=six.ensure_str("InteractiveAPITest"),
+            interactive_port=0,
+            interactive_block=False,
+            exporters=[XMLExporter(xml_dir=str(tmpdir / "xml_exporter"))],
         )
-    )
-    plan.run()
-    timing.wait(
-        lambda: plan.interactive.http_handler_info is not None,
-        300,
-        raise_on_timeout=True,
-    )
-    yield plan
-    plan.abort()
+
+        logfile = tmpdir / "attached_log.txt"
+        logfile.write_text(
+            "This text will be written into the attached file.", encoding="utf8"
+        )
+
+        plan.add(
+            multitest.MultiTest(
+                name=six.ensure_str("ExampleMTest"),
+                suites=[ExampleSuite(str(logfile))],
+            )
+        )
+        plan.run()
+        timing.wait(
+            lambda: plan.interactive.http_handler_info is not None,
+            300,
+            raise_on_timeout=True,
+        )
+        yield plan
+        plan.abort()
 
 
 # Expected JSON to be returned from each API resource at start of day, before
@@ -729,13 +729,13 @@ def test_export_report(plan):
     rsp = requests.get(export_url)
     assert rsp.status_code == 200
     result = rsp.json()
-    assert result["history"].length == 0
-    assert "XMLExporter" in result["available"]
+    assert len(result["history"]) == 0
+    assert "XML exporter" in result["available"]
 
-    rsp = requests.post(export_url, json={"exporters": ["XMLExporter"]})
+    rsp = requests.post(export_url, json={"exporters": ["XML exporter"]})
     assert rsp.status_code == 200
     result = rsp.json()
-    assert result["history"].length == 1
+    assert len(result["history"]) == 1
 
 
 def test_run_param_testcase(plan):

--- a/tests/functional/testplan/runnable/interactive/test_interactive.py
+++ b/tests/functional/testplan/runnable/interactive/test_interactive.py
@@ -11,7 +11,6 @@ standard_library.install_aliases()
 import os
 import re
 
-import pytest
 import six
 import requests
 import pytest
@@ -28,8 +27,7 @@ from testplan.testing.multitest import MultiTest, testsuite, testcase
 from testplan.environment import LocalEnvironment
 from testplan.testing.multitest.driver.tcp import TCPServer, TCPClient
 
-from testplan.common.utils.testing import log_propagation_disabled
-from testplan.common.utils.logger import TESTPLAN_LOGGER
+from pytest_test_filters import skip_on_windows
 
 
 THIS_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
@@ -273,9 +271,8 @@ def post_request(url, data):
     return requests.post(url, headers=headers, json=data)
 
 
-@pytest.mark.skipif(
-    os.name != "posix", reason="Failing on windows, disable for now"
-)
+
+@skip_on_windows(reason="Failing on windows, disable for now")
 def test_http_operate_tests_sync():
     with InteractivePlan(
         name="InteractivePlan",
@@ -400,9 +397,7 @@ def test_http_operate_tests_sync():
         assert compare(response, expected_response)[0] is True
 
 
-@pytest.mark.skipif(
-    os.name != "posix", reason="Failing on windows, disable for now"
-)
+@skip_on_windows(reason="Failing on windows, disable for now")
 def test_http_operate_tests_async():
     with InteractivePlan(
         name="InteractivePlan",
@@ -466,9 +461,7 @@ def test_http_operate_tests_async():
         assert compare(response, expected_response)[0] is True
 
 
-@pytest.mark.skipif(
-    os.name != "posix", reason="Failing on windows, disable for now"
-)
+@skip_on_windows(reason="Failing on windows, disable for now")
 def test_http_dynamic_environments():
     def add_second_client_after_environment_started():
         # ADD A DRIVER IN EXISTING RUNNING ENVIRONMENT

--- a/tests/functional/testplan/runnable/interactive/test_interactive.py
+++ b/tests/functional/testplan/runnable/interactive/test_interactive.py
@@ -271,7 +271,6 @@ def post_request(url, data):
     return requests.post(url, headers=headers, json=data)
 
 
-
 @skip_on_windows(reason="Failing on windows, disable for now")
 def test_http_operate_tests_sync():
     with InteractivePlan(

--- a/tests/functional/testplan/runners/pools/test_pool_remote.py
+++ b/tests/functional/testplan/runners/pools/test_pool_remote.py
@@ -2,7 +2,6 @@
 
 import os
 import pytest
-import platform
 import shutil
 import tempfile
 import subprocess
@@ -12,7 +11,7 @@ from testplan.runners.pools import RemotePool
 from testplan.common.utils.remote import copy_cmd
 from .func_pool_base_tasks import schedule_tests_to_pool
 
-IS_WIN = platform.system() == "Windows"
+from pytest_test_filters import skip_on_windows
 
 
 def mock_ssh(host, command):
@@ -81,7 +80,7 @@ def setup_workspace():
     return workspace, schedule_path
 
 
-@pytest.mark.skipif(IS_WIN, reason="Remote pool is skipped on Windows.")
+@skip_on_windows(reason="Remote pool is skipped on Windows.")
 @pytest.mark.parametrize("remote_pool_type", ("thread", "process"))
 def test_pool_basic(mockplan, remote_pool_type):
     """Basic test scheduling."""

--- a/tests/functional/testplan/testing/cpp/test_cppunit.py
+++ b/tests/functional/testplan/testing/cpp/test_cppunit.py
@@ -1,9 +1,6 @@
 import os
-import platform
-
 import pytest
 
-from testplan import TestplanMock
 from testplan.common.utils.testing import (
     log_propagation_disabled,
     check_report,
@@ -13,6 +10,8 @@ from testplan.testing.cpp import Cppunit
 from testplan.report import Status
 
 from tests.functional.testplan.testing.fixtures.cpp import cppunit
+
+from pytest_test_filters import skip_on_windows
 
 fixture_root = os.path.join(
     os.path.dirname(os.path.dirname(__file__)), "fixtures", "cpp", "cppunit"
@@ -24,9 +23,7 @@ You need to compile the files at "{binary_dir}" to be able to run this test.
 """
 
 
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="Cppunit is skipped on Windows."
-)
+@skip_on_windows(reason="Cppunit is skipped on Windows.")
 @pytest.mark.parametrize(
     "binary_dir, expected_report, report_status",
     (

--- a/tests/functional/testplan/testing/cpp/test_gtest.py
+++ b/tests/functional/testplan/testing/cpp/test_gtest.py
@@ -13,6 +13,8 @@ from testplan.report import Status
 
 from tests.functional.testplan.testing.fixtures.cpp import gtest
 
+from pytest_test_filters import skip_on_windows
+
 fixture_root = os.path.join(
     os.path.dirname(os.path.dirname(__file__)), "fixtures", "cpp", "gtest"
 )
@@ -23,9 +25,7 @@ You need to compile the files at "{binary_dir}" to be able to run this test.
 """
 
 
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="GTest is skipped on Windows."
-)
+@skip_on_windows(reason="GTest is skipped on Windows.")
 @pytest.mark.parametrize(
     "binary_dir, expected_report, report_status",
     (

--- a/tests/functional/testplan/testing/cpp/test_hobbestest.py
+++ b/tests/functional/testplan/testing/cpp/test_hobbestest.py
@@ -15,6 +15,8 @@ from testplan.testing.cpp import HobbesTest
 
 from tests.functional.testplan.testing.fixtures.cpp import hobbestest
 
+from pytest_test_filters import skip_on_windows
+
 fixture_root = os.path.join(
     os.path.dirname(os.path.dirname(__file__)), "fixtures", "cpp", "hobbestest"
 )
@@ -25,9 +27,7 @@ You can either use the mock test binary or replace it with a link to the actual 
 """
 
 
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="HobbesTest is skipped on Windows."
-)
+@skip_on_windows(reason="HobbesTest is skipped on Windows.")
 @pytest.mark.parametrize(
     "binary_dir, expected_report",
     (
@@ -65,9 +65,7 @@ def test_hobbestest(mockplan, binary_dir, expected_report):
     check_report(expected=expected_report, actual=mockplan.report)
 
 
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="HobbesTest is skipped on Windows."
-)
+@skip_on_windows(reason="HobbesTest is skipped on Windows.")
 @pytest.mark.parametrize(
     "binary_dir, expected_output",
     (

--- a/tests/functional/testplan/testing/test_base.py
+++ b/tests/functional/testplan/testing/test_base.py
@@ -18,6 +18,7 @@ from .fixtures import base
 
 from pytest_test_filters import skip_on_windows
 
+
 class MyDriverConfig(DriverConfig):
     @classmethod
     def get_options(cls):

--- a/tests/functional/testplan/testing/test_base.py
+++ b/tests/functional/testplan/testing/test_base.py
@@ -16,6 +16,7 @@ from testplan.common.utils.logger import TESTPLAN_LOGGER
 
 from .fixtures import base
 
+from pytest_test_filters import skip_on_windows
 
 class MyDriverConfig(DriverConfig):
     @classmethod
@@ -49,9 +50,7 @@ class DummyTest(ProcessRunnerTest):
 fixture_root = os.path.join(os.path.dirname(__file__), "fixtures", "base")
 
 
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="Bash files skipped on Windows."
-)
+@skip_on_windows(reason="Bash files skipped on Windows.")
 @pytest.mark.parametrize(
     "binary_path, expected_report, test_kwargs",
     (

--- a/tests/helpers/pytest_test_filters.py
+++ b/tests/helpers/pytest_test_filters.py
@@ -1,0 +1,6 @@
+import sys
+from functools import partial
+
+import pytest
+
+skip_on_windows = partial(pytest.mark.skipif, sys.platform == 'win32')

--- a/tests/helpers/pytest_test_filters.py
+++ b/tests/helpers/pytest_test_filters.py
@@ -3,4 +3,4 @@ from functools import partial
 
 import pytest
 
-skip_on_windows = partial(pytest.mark.skipif, sys.platform == 'win32')
+skip_on_windows = partial(pytest.mark.skipif, sys.platform == "win32")

--- a/tests/unit/testplan/common/utils/test_path.py
+++ b/tests/unit/testplan/common/utils/test_path.py
@@ -40,6 +40,7 @@ def test_hashfile(tmpdir):
         )
         ref_sha = re.match(r"\\?([0-9a-f]+)\s+.*", sha_output).group(1)
     except OSError:
+        # TODO: rewrite this with hardcoded hash
         pytest.skip("Cannot call sha1sum to generate reference SHA.")
         return
 

--- a/tests/unit/testplan/runnable/interactive/test_api.py
+++ b/tests/unit/testplan/runnable/interactive/test_api.py
@@ -111,7 +111,9 @@ def api_env(example_report):
     mock_target = mock.MagicMock()
     mock_target.cfg.name = "Interactive API Test"
 
-    with mock.patch('testplan.runnable.interactive.reloader.ModuleReloader') as MockReloader:
+    with mock.patch(
+        "testplan.runnable.interactive.reloader.ModuleReloader"
+    ) as MockReloader:
         MockReloader.return_value = None
 
         ihandler = base.TestRunnerIHandler(target=mock_target)

--- a/tests/unit/testplan/runnable/interactive/test_irunner.py
+++ b/tests/unit/testplan/runnable/interactive/test_irunner.py
@@ -43,7 +43,11 @@ def test_startup():
     target = runnable.TestRunner(name="TestRunner")
     mock_server = mock.MagicMock()
 
-    with mock.patch("cheroot.wsgi.Server", return_value=mock_server), mock.patch('testplan.runnable.interactive.reloader.ModuleReloader') as MockReloader:
+    with mock.patch(
+        "cheroot.wsgi.Server", return_value=mock_server
+    ), mock.patch(
+        "testplan.runnable.interactive.reloader.ModuleReloader"
+    ) as MockReloader:
         MockReloader.return_value = None
 
         irunner = base.TestRunnerIHandler(target)
@@ -85,7 +89,9 @@ def irunner():
 
     target.resources.add(local_runner)
 
-    with mock.patch("cheroot.wsgi.Server"), mock.patch('testplan.runnable.interactive.reloader.ModuleReloader') as MockReloader:
+    with mock.patch("cheroot.wsgi.Server"), mock.patch(
+        "testplan.runnable.interactive.reloader.ModuleReloader"
+    ) as MockReloader:
         MockReloader.return_value = None
 
         irunner = base.TestRunnerIHandler(target)

--- a/tests/unit/testplan/runnable/interactive/test_irunner.py
+++ b/tests/unit/testplan/runnable/interactive/test_irunner.py
@@ -20,9 +20,6 @@ from testplan.runnable.interactive import base
 from testplan.testing.multitest import driver
 from testplan.common.utils.path import default_runpath
 
-# TODO: skipping interacive test for now, cannot figure out why it fails
-pytestmark = pytest.mark.skip(reason="test failing for unknown reason")
-
 
 @multitest.testsuite
 class Suite(object):
@@ -46,7 +43,9 @@ def test_startup():
     target = runnable.TestRunner(name="TestRunner")
     mock_server = mock.MagicMock()
 
-    with mock.patch("cheroot.wsgi.Server", return_value=mock_server):
+    with mock.patch("cheroot.wsgi.Server", return_value=mock_server), mock.patch('testplan.runnable.interactive.reloader.ModuleReloader') as MockReloader:
+        MockReloader.return_value = None
+
         irunner = base.TestRunnerIHandler(target)
 
         irunner.setup()
@@ -86,7 +85,9 @@ def irunner():
 
     target.resources.add(local_runner)
 
-    with mock.patch("cheroot.wsgi.Server"):
+    with mock.patch("cheroot.wsgi.Server"), mock.patch('testplan.runnable.interactive.reloader.ModuleReloader') as MockReloader:
+        MockReloader.return_value = None
+
         irunner = base.TestRunnerIHandler(target)
         irunner.setup()
 

--- a/tests/unit/testplan/web_ui/testing/test_jest.py
+++ b/tests/unit/testplan/web_ui/testing/test_jest.py
@@ -1,11 +1,11 @@
 """Run tests for the UI code."""
 import subprocess
-import platform
 import os
 
 import pytest
 
 from testplan import web_ui
+from pytest_test_filters import skip_on_windows
 
 TESTPLAN_UI_DIR = os.path.abspath(
     os.path.join(os.path.dirname(web_ui.__file__), "testing")
@@ -42,11 +42,10 @@ def test_testplan_ui():
         "yarn test", shell=True, cwd=TESTPLAN_UI_DIR, env=env
     )
 
-
+@skip_on_windows(reason="We run this on linux only")
 @pytest.mark.skipif(
-    platform.system() == "Windows"
-    or (not (yarn_installed() and tp_ui_installed())),
-    reason="requires yarn & testplan UI on Linux to have been installed.",
+    not (yarn_installed() and tp_ui_installed()),
+    reason="requires yarn & testplan UI have been installed.",
 )
 def test_eslint():
     """Run eslint over the UI source code."""

--- a/tests/unit/testplan/web_ui/testing/test_jest.py
+++ b/tests/unit/testplan/web_ui/testing/test_jest.py
@@ -42,6 +42,7 @@ def test_testplan_ui():
         "yarn test", shell=True, cwd=TESTPLAN_UI_DIR, env=env
     )
 
+
 @skip_on_windows(reason="We run this on linux only")
 @pytest.mark.skipif(
     not (yarn_installed() and tp_ui_installed()),


### PR DESCRIPTION
## Bug / Requirement Description
the desision to skip a test on windows is done in many different way, it can be consolidated
also there are many skiped testcases which are simple to fix

## Solution description
- make a consolidated partial decorator to skip on windows
- use the new decorator when something skiped on windows

- with mock reloader get the interactive unittests to work again

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
