### PR TITLE
Add stdout/pdf render of some assertions

### DIFF
--- a/testplan/exporters/testing/pdf/renderers/constants.py
+++ b/testplan/exporters/testing/pdf/renderers/constants.py
@@ -111,3 +111,9 @@ WRAP_LIMITS = {
     FONT_SIZE_SMALLEST: 200,
     FONT_SIZE_LARGE: 80,
 }
+
+# Max lines of PDF renderer
+MAX_LINES = 50
+
+# Max string length of PDF renderer
+MAX_LENGTH = 1000

--- a/testplan/exporters/testing/pdf/renderers/entries/assertions.py
+++ b/testplan/exporters/testing/pdf/renderers/entries/assertions.py
@@ -26,19 +26,16 @@ from .. import constants as const
 from ..base import RowData
 
 
-MAX_LENGTH = 1000
-
-
 def _format_text(text, colour=None, bold=False, truncate_reverse=False):
-    if len(text) > MAX_LENGTH:
+    if len(text) > const.MAX_LENGTH:
         try:
             text = repr(text)
         except Exception:
             text = object.__repr__(text)
         if truncate_reverse:
-            text = "...[truncated]" + text[-MAX_LENGTH:]
+            text = "...[truncated]" + text[-const.MAX_LENGTH :]
         else:
-            text = text[:MAX_LENGTH] + "[truncated]..."
+            text = text[: const.MAX_LENGTH] + "[truncated]..."
     if colour:
         text = "<font color={colour}>{text}</font>".format(
             text=text, colour=colour

--- a/testplan/testing/multitest/entries/stdout/base.py
+++ b/testplan/testing/multitest/entries/stdout/base.py
@@ -99,6 +99,20 @@ class LogRenderer(BaseRenderer):
             return pprint.pformat(entry.message)
 
 
+@registry.bind(base.CodeLog)
+class CodeLogRenderer(BaseRenderer):
+    def get_header(self, entry):
+        return entry.description or "CodeLog Language: {}".format(
+            entry.language
+        )
+
+
+@registry.bind(base.Markdown)
+class MarkdownRenderer(BaseRenderer):
+    def get_header(self, entry):
+        return entry.description or "Markdown"
+
+
 @registry.bind(base.MatPlot)
 class MatPlotRenderer(BaseRenderer):
     def get_details(self, entry):


### PR DESCRIPTION
## Bug / Requirement Description
Add stdout of CodeLog and Markdown(only display description)
Add PDF render of CodeLog and Markdown

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
