### PR TITLE
Fix several bugs in interactive mode

### DIFF
--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -827,16 +827,14 @@ class MultiTest(testing_base.Test):
     def _setup_testsuite(self, testsuite):
         """
         Run the setup for a testsuite, logging any exceptions.
-
-        :return: Testcase report for setup, or None if no setup is required.
+        Return Testcase report for setup, or None if no setup is required.
         """
         return self._run_suite_related(testsuite, "setup")
 
     def _teardown_testsuite(self, testsuite):
         """
-        Run the teardown for a testsuite.
-
-        :return: Testcase report for teardown, or None if no setup is required.
+        Run the teardown for a testsuite, logging any exceptions.
+        Return Testcase report for teardown, or None if no setup is required.
         """
         return self._run_suite_related(testsuite, "teardown")
 
@@ -871,6 +869,7 @@ class MultiTest(testing_base.Test):
         method_report.extend(case_result.serialized_entries)
         method_report.attachments.extend(case_result.attachments)
         method_report.pass_if_empty()
+        method_report.runtime_status = RuntimeStatus.FINISHED
 
         return method_report
 
@@ -1006,11 +1005,11 @@ class MultiTest(testing_base.Test):
     def _run_testsuite_iter(self, testsuite, testcases):
         """Runs a testsuite object and returns its report."""
         _check_testcases(testcases)
-        setup_report = self._setup_testsuite(testsuite)
-        testsuite_uid = testsuite.name
+        testsuite_uid = testsuite.name  # Unique suite name in Multitest as UID
 
+        setup_report = self._setup_testsuite(testsuite)
         if setup_report is not None:
-            yield setup_report, [self.name, testsuite_uid]
+            yield setup_report, [self.uid(), testsuite_uid]
 
             if setup_report.failed:
                 return
@@ -1022,7 +1021,7 @@ class MultiTest(testing_base.Test):
 
         teardown_report = self._teardown_testsuite(testsuite)
         if teardown_report is not None:
-            yield teardown_report, [self.name, testsuite_uid]
+            yield teardown_report, [self.uid(), testsuite_uid]
 
     def _run_testcases_iter(self, testsuite, testcases):
         """
@@ -1033,7 +1032,7 @@ class MultiTest(testing_base.Test):
         """
         pre_testcase = getattr(testsuite, "pre_testcase", None)
         post_testcase = getattr(testsuite, "post_testcase", None)
-        testsuite_uid = testsuite.name
+        testsuite_uid = testsuite.name  # Unique suite name in Multitest as UID
 
         for testcase in testcases:
             if not self.active:
@@ -1048,12 +1047,12 @@ class MultiTest(testing_base.Test):
             )
             if param_template:
                 parent_uids = [
-                    self.name,
+                    self.uid(),
                     testsuite_uid,
                     testcase._parametrization_template,
                 ]
             else:
-                parent_uids = [self.name, testsuite_uid]
+                parent_uids = [self.uid(), testsuite_uid]
 
             yield testcase_report, parent_uids
 

--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -93,6 +93,7 @@ class App(Driver):
         shell=False,
         env=None,
         binary_strategy="link",
+        logname=None,
         app_dir_name=None,
         working_dir=None,
         **options

--- a/testplan/web_ui/testing/src/Common/utils.js
+++ b/testplan/web_ui/testing/src/Common/utils.js
@@ -90,6 +90,15 @@ function domToString(dom) {
   return tmp.innerHTML;
 }
 
+/**
+ * Get encoded URI Component from an an encoded URI Component
+ * @param {string} uid - string to be encoded
+ * @returns {string}
+ */
+function encodeURIComponent2 (str) {
+  return encodeURIComponent(encodeURIComponent(str));
+}
+
 export {
   getNavEntryDisplayData,
   any,
@@ -97,6 +106,7 @@ export {
   uniqueId,
   hashCode,
   domToString,
+  encodeURIComponent2,
 };
 
 /**

--- a/testplan/web_ui/testing/src/Nav/InteractiveNavEntry.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNavEntry.js
@@ -13,6 +13,8 @@ import {
 import {
   RED,
   GREEN,
+  ORANGE,
+  BLACK,
   LIGHT_GREY,
   MEDIUM_GREY,
   CATEGORY_ICONS,
@@ -236,19 +238,38 @@ const styles = StyleSheet.create({
     padding: '0.7em 0em 0.7em 0em',
     transition: 'all 0.3s ease-out 0s',
   },
+  badge: {
+    opacity: 0.5,
+  },
   passedBadge: {
     backgroundColor: GREEN,
-    opacity: 0.5,
   },
   failedBadge: {
     backgroundColor: RED,
-    opacity: 0.5,
+  },
+  errorBadge: {
+    backgroundColor: RED,
+  },
+  unstableBadge: {
+    backgroundColor: ORANGE,
+  },
+  unknownBadge: {
+    backgroundColor: BLACK,
   },
   passed: {
     color: GREEN,
   },
   failed: {
     color: RED,
+  },
+  error: {
+    color: RED,
+  },
+  unstable: {
+    color: ORANGE,
+  },
+  unknown: {
+    color: BLACK,
   },
 });
 

--- a/testplan/web_ui/testing/src/Nav/InteractiveNavList.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNavList.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import _ from "lodash";
 
 import InteractiveNavEntry from './InteractiveNavEntry';
 import {CreateNavButtons, GetNavColumn} from './navUtils.js';
@@ -14,7 +15,7 @@ const InteractiveNavList = (props) => {
     props,
     (entry) => (
       <InteractiveNavEntry
-        name={entry.name}
+        name={_.isEmpty(entry.part) ? entry.name : entry.uid}
         description={entry.description}
         status={entry.status}
         runtime_status={entry.runtime_status}

--- a/testplan/web_ui/testing/src/Nav/NavBreadcrumbs.js
+++ b/testplan/web_ui/testing/src/Nav/NavBreadcrumbs.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {StyleSheet, css} from 'aphrodite';
+import _ from "lodash";
 
 import NavEntry from './NavEntry';
 import {
@@ -33,7 +34,7 @@ return (
     onClick={((e) => props.handleNavClick(e, entry, depth))}>
     <div className={css(styles.breadcrumbEntry, CommonStyles.unselectable)}>
       <NavEntry
-        name={entry.name}
+        name={_.isEmpty(entry.part) ? entry.name : entry.uid}
         description={entry.description}
         status={entry.status}
         type={entry.category}

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
@@ -1,161 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`InteractiveNavEntry renders a testcase in "failed" state 1`] = `
-<div
-  className="d-flex justify-content-between align-items-center"
-  style={
-    Object {
-      "height": "1.5em",
-    }
-  }
->
-  <div
-    className="entryName_1dd7qci-o_O-failed_11es5k7"
-    title="TestCaseDesc"
-  >
-    FakeTestcase
-  </div>
-  <div
-    className="entryIcons_195essn"
-  >
-    <i
-      className="entryIcon_9gb3m5"
-      title="passed/failed testcases"
-    >
-      <span
-        className="passed_1kh4m98"
-      >
-        8
-      </span>
-      /
-      <span
-        className="failed_11es5k7"
-      >
-        1
-      </span>
-    </i>
-    <Badge
-      className="entryIcon_9gb3m5-o_O-failedBadge_1wefnsd"
-      color="secondary"
-      pill={true}
-      tag="span"
-      title="testcase"
-    >
-      C
-    </Badge>
-    <FontAwesomeIcon
-      border={false}
-      className="entryButton_yr2g96"
-      fixedWidth={false}
-      flip={null}
-      icon={
-        Object {
-          "icon": Array [
-            512,
-            512,
-            Array [],
-            "f01e",
-            "M500.333 0h-47.411c-6.853 0-12.314 5.729-11.986 12.574l3.966 82.759C399.416 41.899 331.672 8 256.001 8 119.34 8 7.899 119.526 8 256.187 8.101 393.068 119.096 504 256 504c63.926 0 122.202-24.187 166.178-63.908 5.113-4.618 5.354-12.561.482-17.433l-33.971-33.971c-4.466-4.466-11.64-4.717-16.38-.543C341.308 415.448 300.606 432 256 432c-97.267 0-176-78.716-176-176 0-97.267 78.716-176 176-176 60.892 0 114.506 30.858 146.099 77.8l-101.525-4.865c-6.845-.328-12.574 5.133-12.574 11.986v47.411c0 6.627 5.373 12 12 12h200.333c6.627 0 12-5.373 12-12V12c0-6.627-5.373-12-12-12z",
-          ],
-          "iconName": "redo",
-          "prefix": "fas",
-        }
-      }
-      inverse={false}
-      listItem={false}
-      mask={null}
-      onClick={[Function]}
-      pull={null}
-      pulse={false}
-      rotation={null}
-      size={null}
-      spin={false}
-      symbol={false}
-      title="Run tests"
-      transform={null}
-    />
-  </div>
-</div>
-`;
-
-exports[`InteractiveNavEntry renders a testcase in "passed" state 1`] = `
-<div
-  className="d-flex justify-content-between align-items-center"
-  style={
-    Object {
-      "height": "1.5em",
-    }
-  }
->
-  <div
-    className="entryName_1dd7qci-o_O-passed_1kh4m98"
-    title="TestCaseDesc"
-  >
-    FakeTestcase
-  </div>
-  <div
-    className="entryIcons_195essn"
-  >
-    <i
-      className="entryIcon_9gb3m5"
-      title="passed/failed testcases"
-    >
-      <span
-        className="passed_1kh4m98"
-      >
-        9
-      </span>
-      /
-      <span
-        className="failed_11es5k7"
-      >
-        0
-      </span>
-    </i>
-    <Badge
-      className="entryIcon_9gb3m5-o_O-passedBadge_1gkx146"
-      color="secondary"
-      pill={true}
-      tag="span"
-      title="testcase"
-    >
-      C
-    </Badge>
-    <FontAwesomeIcon
-      border={false}
-      className="entryButton_yr2g96"
-      fixedWidth={false}
-      flip={null}
-      icon={
-        Object {
-          "icon": Array [
-            512,
-            512,
-            Array [],
-            "f01e",
-            "M500.333 0h-47.411c-6.853 0-12.314 5.729-11.986 12.574l3.966 82.759C399.416 41.899 331.672 8 256.001 8 119.34 8 7.899 119.526 8 256.187 8.101 393.068 119.096 504 256 504c63.926 0 122.202-24.187 166.178-63.908 5.113-4.618 5.354-12.561.482-17.433l-33.971-33.971c-4.466-4.466-11.64-4.717-16.38-.543C341.308 415.448 300.606 432 256 432c-97.267 0-176-78.716-176-176 0-97.267 78.716-176 176-176 60.892 0 114.506 30.858 146.099 77.8l-101.525-4.865c-6.845-.328-12.574 5.133-12.574 11.986v47.411c0 6.627 5.373 12 12 12h200.333c6.627 0 12-5.373 12-12V12c0-6.627-5.373-12-12-12z",
-          ],
-          "iconName": "redo",
-          "prefix": "fas",
-        }
-      }
-      inverse={false}
-      listItem={false}
-      mask={null}
-      onClick={[Function]}
-      pull={null}
-      pulse={false}
-      rotation={null}
-      size={null}
-      spin={false}
-      symbol={false}
-      title="Run tests"
-      transform={null}
-    />
-  </div>
-</div>
-`;
-
 exports[`InteractiveNavEntry renders a testcase in "ready" state 1`] = `
 <div
   className="d-flex justify-content-between align-items-center"
@@ -166,7 +10,7 @@ exports[`InteractiveNavEntry renders a testcase in "ready" state 1`] = `
   }
 >
   <div
-    className="entryName_1dd7qci"
+    className="entryName_1dd7qci-o_O-unknown_1qg7pkz"
     title="TestCaseDesc"
   >
     FakeTestcase
@@ -191,7 +35,7 @@ exports[`InteractiveNavEntry renders a testcase in "ready" state 1`] = `
       </span>
     </i>
     <Badge
-      className="entryIcon_9gb3m5"
+      className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
       color="secondary"
       pill={true}
       tag="span"
@@ -244,7 +88,7 @@ exports[`InteractiveNavEntry renders a testcase in "running" state 1`] = `
   }
 >
   <div
-    className="entryName_1dd7qci"
+    className="entryName_1dd7qci-o_O-unknown_1qg7pkz"
     title="TestCaseDesc"
   >
     FakeTestcase
@@ -269,7 +113,7 @@ exports[`InteractiveNavEntry renders a testcase in "running" state 1`] = `
       </span>
     </i>
     <Badge
-      className="entryIcon_9gb3m5"
+      className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
       color="secondary"
       pill={true}
       tag="span"
@@ -311,6 +155,162 @@ exports[`InteractiveNavEntry renders a testcase in "running" state 1`] = `
 </div>
 `;
 
+exports[`InteractiveNavEntry renders a testcase in "passed" state 1`] = `
+<div
+  className="d-flex justify-content-between align-items-center"
+  style={
+    Object {
+      "height": "1.5em",
+    }
+  }
+>
+  <div
+    className="entryName_1dd7qci-o_O-passed_1kh4m98"
+    title="TestCaseDesc"
+  >
+    FakeTestcase
+  </div>
+  <div
+    className="entryIcons_195essn"
+  >
+    <i
+      className="entryIcon_9gb3m5"
+      title="passed/failed testcases"
+    >
+      <span
+        className="passed_1kh4m98"
+      >
+        9
+      </span>
+      /
+      <span
+        className="failed_11es5k7"
+      >
+        0
+      </span>
+    </i>
+    <Badge
+      className="entryIcon_9gb3m5-o_O-passedBadge_1isorc2"
+      color="secondary"
+      pill={true}
+      tag="span"
+      title="testcase"
+    >
+      C
+    </Badge>
+    <FontAwesomeIcon
+      border={false}
+      className="entryButton_yr2g96"
+      fixedWidth={false}
+      flip={null}
+      icon={
+        Object {
+          "icon": Array [
+            512,
+            512,
+            Array [],
+            "f01e",
+            "M500.333 0h-47.411c-6.853 0-12.314 5.729-11.986 12.574l3.966 82.759C399.416 41.899 331.672 8 256.001 8 119.34 8 7.899 119.526 8 256.187 8.101 393.068 119.096 504 256 504c63.926 0 122.202-24.187 166.178-63.908 5.113-4.618 5.354-12.561.482-17.433l-33.971-33.971c-4.466-4.466-11.64-4.717-16.38-.543C341.308 415.448 300.606 432 256 432c-97.267 0-176-78.716-176-176 0-97.267 78.716-176 176-176 60.892 0 114.506 30.858 146.099 77.8l-101.525-4.865c-6.845-.328-12.574 5.133-12.574 11.986v47.411c0 6.627 5.373 12 12 12h200.333c6.627 0 12-5.373 12-12V12c0-6.627-5.373-12-12-12z",
+          ],
+          "iconName": "redo",
+          "prefix": "fas",
+        }
+      }
+      inverse={false}
+      listItem={false}
+      mask={null}
+      onClick={[Function]}
+      pull={null}
+      pulse={false}
+      rotation={null}
+      size={null}
+      spin={false}
+      symbol={false}
+      title="Run tests"
+      transform={null}
+    />
+  </div>
+</div>
+`;
+
+exports[`InteractiveNavEntry renders a testcase in "failed" state 1`] = `
+<div
+  className="d-flex justify-content-between align-items-center"
+  style={
+    Object {
+      "height": "1.5em",
+    }
+  }
+>
+  <div
+    className="entryName_1dd7qci-o_O-failed_11es5k7"
+    title="TestCaseDesc"
+  >
+    FakeTestcase
+  </div>
+  <div
+    className="entryIcons_195essn"
+  >
+    <i
+      className="entryIcon_9gb3m5"
+      title="passed/failed testcases"
+    >
+      <span
+        className="passed_1kh4m98"
+      >
+        8
+      </span>
+      /
+      <span
+        className="failed_11es5k7"
+      >
+        1
+      </span>
+    </i>
+    <Badge
+      className="entryIcon_9gb3m5-o_O-failedBadge_1i8mqax"
+      color="secondary"
+      pill={true}
+      tag="span"
+      title="testcase"
+    >
+      C
+    </Badge>
+    <FontAwesomeIcon
+      border={false}
+      className="entryButton_yr2g96"
+      fixedWidth={false}
+      flip={null}
+      icon={
+        Object {
+          "icon": Array [
+            512,
+            512,
+            Array [],
+            "f01e",
+            "M500.333 0h-47.411c-6.853 0-12.314 5.729-11.986 12.574l3.966 82.759C399.416 41.899 331.672 8 256.001 8 119.34 8 7.899 119.526 8 256.187 8.101 393.068 119.096 504 256 504c63.926 0 122.202-24.187 166.178-63.908 5.113-4.618 5.354-12.561.482-17.433l-33.971-33.971c-4.466-4.466-11.64-4.717-16.38-.543C341.308 415.448 300.606 432 256 432c-97.267 0-176-78.716-176-176 0-97.267 78.716-176 176-176 60.892 0 114.506 30.858 146.099 77.8l-101.525-4.865c-6.845-.328-12.574 5.133-12.574 11.986v47.411c0 6.627 5.373 12 12 12h200.333c6.627 0 12-5.373 12-12V12c0-6.627-5.373-12-12-12z",
+          ],
+          "iconName": "redo",
+          "prefix": "fas",
+        }
+      }
+      inverse={false}
+      listItem={false}
+      mask={null}
+      onClick={[Function]}
+      pull={null}
+      pulse={false}
+      rotation={null}
+      size={null}
+      spin={false}
+      symbol={false}
+      title="Run tests"
+      transform={null}
+    />
+  </div>
+</div>
+`;
+
 exports[`InteractiveNavEntry renders an entry with environment status STARTED 1`] = `
 <div
   className="d-flex justify-content-between align-items-center"
@@ -321,7 +321,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTED 1`
   }
 >
   <div
-    className="entryName_1dd7qci"
+    className="entryName_1dd7qci-o_O-unknown_1qg7pkz"
     title="TestCaseDesc"
   >
     FakeTestcase
@@ -346,7 +346,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTED 1`
       </span>
     </i>
     <Badge
-      className="entryIcon_9gb3m5"
+      className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
       color="secondary"
       pill={true}
       tag="span"
@@ -430,7 +430,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTING 1
   }
 >
   <div
-    className="entryName_1dd7qci"
+    className="entryName_1dd7qci-o_O-unknown_1qg7pkz"
     title="TestCaseDesc"
   >
     FakeTestcase
@@ -455,7 +455,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTING 1
       </span>
     </i>
     <Badge
-      className="entryIcon_9gb3m5"
+      className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
       color="secondary"
       pill={true}
       tag="span"
@@ -538,7 +538,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPED 1`
   }
 >
   <div
-    className="entryName_1dd7qci"
+    className="entryName_1dd7qci-o_O-unknown_1qg7pkz"
     title="TestCaseDesc"
   >
     FakeTestcase
@@ -563,7 +563,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPED 1`
       </span>
     </i>
     <Badge
-      className="entryIcon_9gb3m5"
+      className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
       color="secondary"
       pill={true}
       tag="span"
@@ -647,7 +647,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPING 1
   }
 >
   <div
-    className="entryName_1dd7qci"
+    className="entryName_1dd7qci-o_O-unknown_1qg7pkz"
     title="TestCaseDesc"
   >
     FakeTestcase
@@ -672,7 +672,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPING 1
       </span>
     </i>
     <Badge
-      className="entryIcon_9gb3m5"
+      className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
       color="secondary"
       pill={true}
       tag="span"

--- a/testplan/web_ui/testing/src/Report/InteractiveReport.js
+++ b/testplan/web_ui/testing/src/Report/InteractiveReport.js
@@ -23,6 +23,7 @@ import {
   GetCenterPane,
   GetSelectedEntries,
 } from './reportUtils.js';
+import {encodeURIComponent2} from '../Common/utils';
 
 const api_prefix = "/api/v1/interactive";
 
@@ -141,8 +142,9 @@ class InteractiveReport extends React.Component {
    * Get the suites owned by a particular test from the backend.
    */
   getSuites(newTest, existingTest) {
+    const encoded_test_uid = encodeURIComponent2(newTest.uid);
     return axios.get(
-      `/api/v1/interactive/report/tests/${newTest.uid}/suites`
+      `/api/v1/interactive/report/tests/${encoded_test_uid}/suites`
     ).then(response => {
       return Promise.all(response.data.map(
         newSuite => {
@@ -167,9 +169,11 @@ class InteractiveReport extends React.Component {
    * Get the testcases owned by a particular test suite from the backend.
    */
   getTestCases(test, newSuite, existingSuite) {
+    const encoded_test_uid = encodeURIComponent2(test.uid);
+    const encoded_suite_uid = encodeURIComponent2(newSuite.uid);
     return axios.get(
-      `/api/v1/interactive/report/tests/${test.uid}/suites/${newSuite.uid}/` +
-      `testcases`
+      `/api/v1/interactive/report/tests/${encoded_test_uid}/suites/` +
+      `${encoded_suite_uid}/testcases`
     ).then(response => {
       return Promise.all(response.data.map((newTestCase) => {
         switch (newTestCase.category) {
@@ -209,9 +213,12 @@ class InteractiveReport extends React.Component {
    * Get the parametrizations owned by a particular testcase from the backend.
    */
   getParametrizations(test, suite, testcase) {
+    const encoded_test_uid = encodeURIComponent2(test.uid);
+    const encoded_suite_uid = encodeURIComponent2(suite.uid);
+    const encoded_testcase_uid = encodeURIComponent2(testcase.uid);
     return axios.get(
-      `/api/v1/interactive/report/tests/${test.uid}/suites/${suite.uid}/` +
-      `testcases/${testcase.uid}/parametrizations`
+      `/api/v1/interactive/report/tests/${encoded_test_uid}/suites/` +
+      `${encoded_suite_uid}/testcases/${encoded_testcase_uid}/parametrizations`
     ).then(response => response.data);
   }
 
@@ -244,21 +251,23 @@ class InteractiveReport extends React.Component {
         return api_prefix + "/report";
 
       case 1: {
-        const test_uid = updatedReportEntry.uid;
+        const test_uid = encodeURIComponent2(updatedReportEntry.uid);
         return api_prefix + `/report/tests/${test_uid}`;
       }
 
       case 2: {
-        const test_uid = updatedReportEntry.parent_uids[1];
-        const suite_uid = updatedReportEntry.uid;
+        const test_uid = encodeURIComponent2(updatedReportEntry.parent_uids[1]);
+        const suite_uid = encodeURIComponent2(updatedReportEntry.uid);
 
         return api_prefix + `/report/tests/${test_uid}/suites/${suite_uid}`;
       }
 
       case 3: {
-        const test_uid = updatedReportEntry.parent_uids[1];
-        const suite_uid = updatedReportEntry.parent_uids[2];
-        const testcase_uid = updatedReportEntry.uid;
+        const test_uid = encodeURIComponent2(updatedReportEntry.parent_uids[1]);
+        const suite_uid = encodeURIComponent2(
+          updatedReportEntry.parent_uids[2]
+        );
+        const testcase_uid = encodeURIComponent2(updatedReportEntry.uid);
 
         return api_prefix + (
           `/report/tests/${test_uid}`
@@ -268,10 +277,14 @@ class InteractiveReport extends React.Component {
       }
 
       case 4: {
-        const test_uid = updatedReportEntry.parent_uids[1];
-        const suite_uid = updatedReportEntry.parent_uids[2];
-        const testcase_uid = updatedReportEntry.parent_uids[3];
-        const param_uid = updatedReportEntry.uid;
+        const test_uid = encodeURIComponent2(updatedReportEntry.parent_uids[1]);
+        const suite_uid = encodeURIComponent2(
+          updatedReportEntry.parent_uids[2]
+        );
+        const testcase_uid = encodeURIComponent2(
+          updatedReportEntry.parent_uids[3]
+        );
+        const param_uid = encodeURIComponent2(updatedReportEntry.uid);
 
         return api_prefix + (
           `/report/tests/${test_uid}`


### PR DESCRIPTION
* Make it support Multitest-parts: 1> Should correctly set Multitest UID
  in returned JSON report; 2> Multitest-part name should be correctly
  displayed (with part information) on NavEntry and NavBreadcrumbs.
* Deal with special symbol like "slash" in Multitest name or suite
  name, need to encode the URI strings and decode them on server side.
* For error result and unstable result, the NavEntry's color is still
  black, need to add some CSS style definition for interactive mode.
* If a test suite has 'setup' or 'teardown', after executing them the
  `runtime_status` should be set to "finished", or the test suite's
  `runtime_status` is still "running" and UI shows an incorrect icon.
