### PR TITLE
Pass down os.environ to App driver.

### DIFF
--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -148,13 +148,16 @@ class App(Driver):
     @property
     def env(self):
         """Environment variables."""
+
+        env = os.environ.copy()
+
         if isinstance(self.cfg.env, dict):
-            return {
-                key: expand(val, self.context, str) if is_context(val) else val
-                for key, val in self.cfg.env.items()
-            }
-        else:
-            return self.cfg.env
+            env.update(self.cfg.env)
+
+        return {
+            key: expand(val, self.context, str) if is_context(val) else val
+            for key, val in env.items()
+        }
 
     @property
     def logname(self):

--- a/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
+++ b/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
@@ -65,6 +65,23 @@ def test_app_env(runpath):
         assert fobj.read().startswith("VALUE")
 
 
+def test_app_os_environ(runpath):
+    """Test that os.environ is passed down."""
+
+    os.environ["KEY"] = "VALUE"
+    app = App(
+        name="App",
+        binary="echo",
+        args=["%KEY%" if platform.system() == "Windows" else "$KEY"],
+        shell=True,
+        runpath=runpath,
+    )
+    with app:
+        app.proc.wait()
+    with open(app.std.out_path, "r") as fobj:
+        assert fobj.read().startswith("VALUE")
+
+
 def test_app_cwd(runpath):
     """Test working_dir usage."""
     tempdir = tempfile.gettempdir()


### PR DESCRIPTION
## Bug / Requirement Description
Passing down env var seem by testplan process to subprocess started by App driver.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
