### PR TITLE
Attachment supports custom file path

### DIFF
--- a/testplan/common/utils/path.py
+++ b/testplan/common/utils/path.py
@@ -315,7 +315,7 @@ def archive(path, timestamp):
     """
     Append a timestamp to an existing file's name.
 
-    :param path: path to a file that should be archived
+    :param path: Path to a file that should be archived
     :type path: ``str``
     :param timestamp: timestamp
     :type timestamp: ``str``
@@ -327,3 +327,40 @@ def archive(path, timestamp):
     if os.path.isfile(path):
         os.rename(path, new_path)
     return new_path
+
+
+def traverse_dir(directory, topdown=True, include_subdir=True):
+    """
+    Recursively traverse all files in a directory and get a list of relative
+    file paths.
+
+    :param directory: Path to a directory that will be traversed
+    :type directory: ``str``
+    :param topdown: Browse the directory in a top-down approach.
+    :type topdown: ``bool``
+    :param include_subdir: Include all sub directories and files if True, or
+        exclude directories in the result.
+    :type include_subdir: ``bool``
+    :return: A list of relative file paths
+    :rtype: ``list`` of ``str``
+    """
+    result = []
+
+    for dirpath, dirnames, filenames in os.walk(directory, topdown=topdown):
+
+        if include_subdir:
+            for dname in dirnames:
+                dpath = os.path.join(dirpath, dname)
+                _, _, relpath = dpath.partition(directory)
+                while relpath.startswith(os.sep):
+                    relpath = relpath[len(os.sep) :]
+                result.append(relpath)
+
+        for fname in filenames:
+            fpath = os.path.join(dirpath, fname)
+            _, _, relpath = fpath.partition(directory)
+            while relpath.startswith(os.sep):
+                relpath = relpath[len(os.sep) :]
+            result.append(relpath)
+
+    return result

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -408,7 +408,7 @@ class ProcessRunnerTest(Test):
 
     :param name: Test instance name, often used as uid of test entity.
     :type name: ``str``
-    :param binary: Path the to application binary or script.
+    :param binary: Path to the application binary or script.
     :type binary: ``str``
     :param description: Description of test instance.
     :type description: ``str``

--- a/testplan/testing/cpp/cppunit.py
+++ b/testplan/testing/cpp/cppunit.py
@@ -139,7 +139,7 @@ class Cppunit(ProcessRunnerTest):
 
     :param name: Test instance name, often used as uid of test entity.
     :type name: ``str``
-    :param binary: Path the to application binary or script.
+    :param binary: Path to the application binary or script.
     :type binary: ``str``
     :param description: Description of test instance.
     :type description: ``str``

--- a/testplan/testing/cpp/gtest.py
+++ b/testplan/testing/cpp/gtest.py
@@ -63,7 +63,7 @@ class GTest(ProcessRunnerTest):
 
     :param name: Test instance name, often used as uid of test entity.
     :type name: ``str``
-    :param binary: Path the to application binary or script.
+    :param binary: Path to the application binary or script.
     :type binary: ``str``
     :param description: Description of test instance.
     :type description: ``str``

--- a/testplan/testing/cpp/hobbestest.py
+++ b/testplan/testing/cpp/hobbestest.py
@@ -38,7 +38,7 @@ class HobbesTest(ProcessRunnerTest):
 
     :param name: Test instance name, often used as uid of test entity.
     :type name: ``str``
-    :param binary: Path the to application binary or script.
+    :param binary: Path to the application binary or script.
     :type binary: ``str``
     :param description: Description of test instance.
     :type description: ``str``

--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -53,7 +53,7 @@ class App(Driver):
 
     :param name: Driver name. Also uid.
     :type name: ``str``
-    :param binary: Path the to application binary.
+    :param binary: Path to the application binary.
     :type binary: ``str``
     :param pre_args: Arguments to be prepended to binary command. An argument
         can be a :py:class:`~testplan.common.utils.context.ContextValue`

--- a/testplan/testing/multitest/entries/base.py
+++ b/testplan/testing/multitest/entries/base.py
@@ -14,7 +14,7 @@ from testplan.common.utils.timing import utcnow
 from testplan.common.utils.table import TableEntry
 from testplan.common.utils.reporting import fmt
 from testplan.common.utils.convert import flatten_formatted_object
-from testplan.common.utils import path as path_utils
+from testplan.common.utils.path import hash_file
 from testplan import defaults
 
 
@@ -349,16 +349,21 @@ class Graph(BaseEntry):
 class Attachment(BaseEntry):
     """Entry representing a file attached to the report."""
 
-    def __init__(self, filepath, description):
+    def __init__(self, filepath, description, dst_path=None):
         self.source_path = filepath
-        self.hash = path_utils.hash_file(filepath)
         self.orig_filename = os.path.basename(filepath)
+        self.hash = hash_file(filepath)
         self.filesize = os.path.getsize(filepath)
-
-        basename, ext = os.path.splitext(self.orig_filename)
-        self.dst_path = "{basename}-{hash}-{filesize}{ext}".format(
-            basename=basename, hash=self.hash, filesize=self.filesize, ext=ext
-        )
+        if dst_path:
+            self.dst_path = dst_path
+        else:
+            basename, ext = os.path.splitext(self.orig_filename)
+            self.dst_path = "{basename}-{hash}-{filesize}{ext}".format(
+                basename=basename,
+                hash=self.hash,
+                filesize=self.filesize,
+                ext=ext,
+            )
         super(Attachment, self).__init__(description=description)
 
 

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -2162,13 +2162,23 @@ class Result(object):
         return entry
 
     def attach(self, filepath, description=None):
-        """Attaches a file to the report."""
+        """
+        Attaches a file to the report.
+
+        :param filepath: Path to the file be to attached.
+        :type filepath: ``str``
+        :param description: Text description for the assertion.
+        :type description: ``str``
+        :return: Always returns True, this is not an assertion so it cannot
+                 fail.
+        :rtype: ``bool``
+        """
         filename = os.path.basename(filepath)
         try:
             # will best effort make a copy of the file
             copy_of_file = os.path.join(self._scratch, filename)
             shutil.copyfile(filepath, copy_of_file)
-        except Exception as exc:
+        except Exception:
             copy_of_file = filepath
 
         attachment = base.Attachment(copy_of_file, description)

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/AttachmentAssertionCardHeader.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/AttachmentAssertionCardHeader.js
@@ -4,9 +4,19 @@ import { GetApp } from "@material-ui/icons";
 import _ from "lodash";
 
 function AttachmentAssertionCardHeader(props) {
+  const idx = props.file_name.lastIndexOf(".");
+  const ext_name = (idx === -1) ? "" : props.file_name.substring(
+    idx+1, props.file_name.length).toLowerCase();
+
   return (
     <CardHeader
-      title={props.file_name}
+      title={
+        (ext_name === "htm" || ext_name === "html" || ext_name === "xml")
+        ? <a href={props.src} target="_blank" rel="noreferrer">
+            {props.file_name}
+          </a>
+        : props.file_name
+      }
       subheader={_.round(props.file_size / 1024, 2) + "kb"}
       action={
         <>
@@ -24,4 +34,5 @@ function AttachmentAssertionCardHeader(props) {
     />
   );
 }
+
 export default AttachmentAssertionCardHeader;


### PR DESCRIPTION
* All files attached in each testcase will finally be collected and
  put in the main report's attachment list, in an `Attachment` object
  the original file path is recored in `source_path`, and `dst_path`
  records the new name (with hash value to avoid name conflict).
  However in some circumstance we need to specify the destination
  file path. A new argument is added for this purpose.
* A new utility help to traverse a directory and get a list of all
  sub directories and files by their relative path to that home dir.
* Fix typo.