### PR TITLE
Refactoring Transport example documentation for improved extensibility

### DIFF
--- a/doc/en/download/Transports.rst
+++ b/doc/en/download/Transports.rst
@@ -1,128 +1,17 @@
 Transports
 **********
 
-.. _example_tcp:
+..
+  KEEP IN ALPHABETICAL ORDER
+  Titles start with the primary name of the technology, e.g. Kafka
 
-TCP
----
+.. include:: Transports_FIX.rst
 
-Required files:
-  - :download:`test_plan.py <../../../examples/Transports/TCP/test_plan.py>`
-  - :download:`tcp_one_connection.py <../../../examples/Transports/TCP/tcp_one_connection.py>`
-  - :download:`tcp_multiple_connections.py <../../../examples/Transports/TCP/tcp_multiple_connections.py>`
+.. include:: Transports_HTTP.rst
 
-test_plan.py
-++++++++++++
-.. literalinclude:: ../../../examples/Transports/TCP/test_plan.py
+.. include:: Transports_Kafka.rst
 
-tcp_one_connection.py
-+++++++++++++++++++++
-.. literalinclude:: ../../../examples/Transports/TCP/tcp_one_connection.py
+.. include:: Transports_TCP.rst
 
-tcp_multiple_connections.py
-+++++++++++++++++++++++++++
-.. literalinclude:: ../../../examples/Transports/TCP/tcp_multiple_connections.py
+.. include:: Transports_ZMQ.rst
 
-.. _example_zmq:
-
-ZMQ
----
-
-Required files:
-  - :download:`test_plan.py <../../../examples/Transports/ZMQ/test_plan.py>`
-  - :download:`zmq_pair_connection.py <../../../examples/Transports/ZMQ/zmq_pair_connection.py>`
-  - :download:`zmq_publish_subscribe_connection.py <../../../examples/Transports/ZMQ/zmq_publish_subscribe_connection.py>`
-
-test_plan.py
-++++++++++++
-.. literalinclude:: ../../../examples/Transports/ZMQ/test_plan.py
-
-zmq_pair_connection.py
-++++++++++++++++++++++
-.. literalinclude:: ../../../examples/Transports/ZMQ/zmq_pair_connection.py
-
-zmq_publish_subscribe_connection.py
-+++++++++++++++++++++++++++++++++++
-.. literalinclude:: ../../../examples/Transports/ZMQ/zmq_publish_subscribe_connection.py
-
-.. _example_fix:
-
-FIX
----
-
-Required files:
-  - :download:`test_plan.py <../../../examples/Transports/FIX/test_plan.py>`
-  - :download:`over_one_session.py <../../../examples/Transports/FIX/over_one_session.py>`
-  - :download:`over_two_sessions.py <../../../examples/Transports/FIX/over_two_sessions.py>`
-
-test_plan.py
-++++++++++++
-.. literalinclude:: ../../../examples/Transports/FIX/test_plan.py
-
-over_one_session.py
-+++++++++++++++++++
-.. literalinclude:: ../../../examples/Transports/FIX/over_one_session.py
-
-over_two_sessions.py
-++++++++++++++++++++
-.. literalinclude:: ../../../examples/Transports/FIX/over_two_sessions.py
-
-PDF report
-++++++++++
-
-*Sample detailed PDF report.*
-
-.. image:: ../../images/pdf/fix_sessions_example.png
-
-.. _example_http:
-
-HTTP
-----
-
-Required files:
-  - :download:`test_plan.py <../../../examples/Transports/HTTP/test_plan.py>`
-  - :download:`http_basic.py <../../../examples/Transports/HTTP/http_basic.py>`
-  - :download:`http_custom_handler.py <../../../examples/Transports/HTTP/http_custom_handler.py>`
-  - :download:`custom_http_request_handler.py <../../../examples/Transports/HTTP/custom_http_request_handler.py>`
-  - :download:`test.txt <../../../examples/Transports/HTTP/test.txt>`
-
-test_plan.py
-++++++++++++
-.. literalinclude:: ../../../examples/Transports/HTTP/test_plan.py
-
-http_basic.py
-+++++++++++++
-.. literalinclude:: ../../../examples/Transports/HTTP/http_basic.py
-
-http_custom_handler.py
-++++++++++++++++++++++
-.. literalinclude:: ../../../examples/Transports/HTTP/http_custom_handler.py
-
-custom_http_request_handler.py
-++++++++++++++++++++++++++++++
-.. literalinclude:: ../../../examples/Transports/HTTP/custom_http_request_handler.py
-
-test.txt
-++++++++
-.. literalinclude:: ../../../examples/Transports/HTTP/test.txt
-
-.. _example_kafka:
-
-Kafka
------
-Required files:
-  - :download:`test_plan.py <../../../examples/Transports/Kafka/test_plan.py>`
-  - :download:`server_template.properties <../../../examples/Transports/Kafka/server_template.properties>`
-  - :download:`zoo_template.cfg <../../../examples/Transports/Kafka/zoo_template.cfg>`
-
-test_plan.py
-++++++++++++
-.. literalinclude:: ../../../examples/Transports/Kafka/test_plan.py
-
-server_template.properties
-++++++++++++++++++++++++++
-.. literalinclude:: ../../../examples/Transports/Kafka/server_template.properties
-
-zoo_template.cfg
-++++++++++++++++
-.. literalinclude:: ../../../examples/Transports/Kafka/zoo_template.cfg

--- a/doc/en/download/Transports_FIX.rst
+++ b/doc/en/download/Transports_FIX.rst
@@ -1,0 +1,28 @@
+.. _example_fix:
+
+FIX
+---
+
+Required files:
+  - :download:`test_plan.py <../../../examples/Transports/FIX/test_plan.py>`
+  - :download:`over_one_session.py <../../../examples/Transports/FIX/over_one_session.py>`
+  - :download:`over_two_sessions.py <../../../examples/Transports/FIX/over_two_sessions.py>`
+
+test_plan.py
+++++++++++++
+.. literalinclude:: ../../../examples/Transports/FIX/test_plan.py
+
+over_one_session.py
++++++++++++++++++++
+.. literalinclude:: ../../../examples/Transports/FIX/over_one_session.py
+
+over_two_sessions.py
+++++++++++++++++++++
+.. literalinclude:: ../../../examples/Transports/FIX/over_two_sessions.py
+
+PDF report
+++++++++++
+
+*Sample detailed PDF report.*
+
+.. image:: ../../images/pdf/fix_sessions_example.png

--- a/doc/en/download/Transports_HTTP.rst
+++ b/doc/en/download/Transports_HTTP.rst
@@ -1,0 +1,31 @@
+.. _example_http:
+
+HTTP
+----
+
+Required files:
+  - :download:`test_plan.py <../../../examples/Transports/HTTP/test_plan.py>`
+  - :download:`http_basic.py <../../../examples/Transports/HTTP/http_basic.py>`
+  - :download:`http_custom_handler.py <../../../examples/Transports/HTTP/http_custom_handler.py>`
+  - :download:`custom_http_request_handler.py <../../../examples/Transports/HTTP/custom_http_request_handler.py>`
+  - :download:`test.txt <../../../examples/Transports/HTTP/test.txt>`
+
+test_plan.py
+++++++++++++
+.. literalinclude:: ../../../examples/Transports/HTTP/test_plan.py
+
+http_basic.py
++++++++++++++
+.. literalinclude:: ../../../examples/Transports/HTTP/http_basic.py
+
+http_custom_handler.py
+++++++++++++++++++++++
+.. literalinclude:: ../../../examples/Transports/HTTP/http_custom_handler.py
+
+custom_http_request_handler.py
+++++++++++++++++++++++++++++++
+.. literalinclude:: ../../../examples/Transports/HTTP/custom_http_request_handler.py
+
+test.txt
+++++++++
+.. literalinclude:: ../../../examples/Transports/HTTP/test.txt

--- a/doc/en/download/Transports_Kafka.rst
+++ b/doc/en/download/Transports_Kafka.rst
@@ -1,0 +1,20 @@
+.. _example_kafka:
+
+Kafka
+-----
+Required files:
+  - :download:`test_plan.py <../../../examples/Transports/Kafka/test_plan.py>`
+  - :download:`server_template.properties <../../../examples/Transports/Kafka/server_template.properties>`
+  - :download:`zoo_template.cfg <../../../examples/Transports/Kafka/zoo_template.cfg>`
+
+test_plan.py
+++++++++++++
+.. literalinclude:: ../../../examples/Transports/Kafka/test_plan.py
+
+server_template.properties
+++++++++++++++++++++++++++
+.. literalinclude:: ../../../examples/Transports/Kafka/server_template.properties
+
+zoo_template.cfg
+++++++++++++++++
+.. literalinclude:: ../../../examples/Transports/Kafka/zoo_template.cfg

--- a/doc/en/download/Transports_TCP.rst
+++ b/doc/en/download/Transports_TCP.rst
@@ -1,0 +1,21 @@
+.. _example_tcp:
+
+TCP
+---
+
+Required files:
+  - :download:`test_plan.py <../../../examples/Transports/TCP/test_plan.py>`
+  - :download:`tcp_one_connection.py <../../../examples/Transports/TCP/tcp_one_connection.py>`
+  - :download:`tcp_multiple_connections.py <../../../examples/Transports/TCP/tcp_multiple_connections.py>`
+
+test_plan.py
+++++++++++++
+.. literalinclude:: ../../../examples/Transports/TCP/test_plan.py
+
+tcp_one_connection.py
++++++++++++++++++++++
+.. literalinclude:: ../../../examples/Transports/TCP/tcp_one_connection.py
+
+tcp_multiple_connections.py
++++++++++++++++++++++++++++
+.. literalinclude:: ../../../examples/Transports/TCP/tcp_multiple_connections.py

--- a/doc/en/download/Transports_ZMQ.rst
+++ b/doc/en/download/Transports_ZMQ.rst
@@ -1,0 +1,22 @@
+.. _example_zmq:
+
+ZMQ
+---
+
+Required files:
+  - :download:`test_plan.py <../../../examples/Transports/ZMQ/test_plan.py>`
+  - :download:`zmq_pair_connection.py <../../../examples/Transports/ZMQ/zmq_pair_connection.py>`
+  - :download:`zmq_publish_subscribe_connection.py <../../../examples/Transports/ZMQ/zmq_publish_subscribe_connection.py>`
+
+test_plan.py
+++++++++++++
+.. literalinclude:: ../../../examples/Transports/ZMQ/test_plan.py
+
+zmq_pair_connection.py
+++++++++++++++++++++++
+.. literalinclude:: ../../../examples/Transports/ZMQ/zmq_pair_connection.py
+
+zmq_publish_subscribe_connection.py
++++++++++++++++++++++++++++++++++++
+.. literalinclude:: ../../../examples/Transports/ZMQ/zmq_publish_subscribe_connection.py
+


### PR DESCRIPTION
## Bug / Requirement Description
Refactoring the layout of the Transport examples to improve the extensibility.
This is because when we merge the examples with other examples (internal to MS) the ordering was arbitrary and a problem.

## Solution description
I have split the examples into their own individual files. Then they can be included in order, with other examples (internally) injected, all in alphabetical sequence too.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [x] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
