### PR TITLE
Interactive UI: Fix typo of tooltip

### DIFF
--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/AttachmentAssertionCardHeader.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/AttachmentAssertionCardHeader.js
@@ -12,7 +12,7 @@ function AttachmentAssertionCardHeader(props) {
     <CardHeader
       title={
         (ext_name === "htm" || ext_name === "html" || ext_name === "xml")
-        ? <a href={props.src} target="_blank" rel="noreferrer">
+        ? <a href={props.src} target="_blank" rel="noopener noreferrer">
             {props.file_name}
           </a>
         : props.file_name

--- a/testplan/web_ui/testing/src/Nav/InteractiveNavEntry.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNavEntry.js
@@ -160,7 +160,7 @@ const getEnvStatusIcon = (envStatus, envCtrlCallback) => {
           <FontAwesomeIcon
             className={css(styles.entryButton)}
             icon={faToggleOn}
-            title='Start environment'
+            title='Stop environment'
             onClick={(e) => envCtrlCallback(e, "stop")}
           />
         );

--- a/testplan/web_ui/testing/src/Nav/__tests__/InteractiveNavEntry.test.js
+++ b/testplan/web_ui/testing/src/Nav/__tests__/InteractiveNavEntry.test.js
@@ -132,14 +132,14 @@ describe('InteractiveNavEntry', () => {
     expect(handlePlayClick.mock.calls.length).toEqual(1);
   });
 
-  it('renders an entry with environment status STOPPED', () => {
+  it('renders an entry with environment status STARTED', () => {
     const renderedEntry = shallow(
       <InteractiveNavEntry
         name={'FakeTestcase'}
         description={'TestCaseDesc'}
         status={'unknown'}
         runtime_status={'ready'}
-        envStatus={'STOPPED'}
+        envStatus={'STARTED'}
         type={'multitest'}
         caseCountPassed={0}
         caseCountFailed={0}
@@ -168,14 +168,14 @@ describe('InteractiveNavEntry', () => {
     expect(renderedEntry).toMatchSnapshot();
   });
 
-  it('renders an entry with environment status STARTED', () => {
+  it('renders an entry with environment status STOPPED', () => {
     const renderedEntry = shallow(
       <InteractiveNavEntry
         name={'FakeTestcase'}
         description={'TestCaseDesc'}
         status={'unknown'}
         runtime_status={'ready'}
-        envStatus={'STARTED'}
+        envStatus={'STOPPED'}
         type={'multitest'}
         caseCountPassed={0}
         caseCountFailed={0}
@@ -258,7 +258,7 @@ describe('InteractiveNavEntry', () => {
     // controller - we do this by matching on the title text.
     const faIcons = renderedEntry.find(FontAwesomeIcon);
     expect(faIcons).toHaveLength(2);
-    faIcons.find({title: 'Start environment'}).simulate('click');
+    faIcons.find({title: 'Stop environment'}).simulate('click');
 
     // The callback should have been called once when the component was
     // clicked, and it should have been called with a single arg of "start"

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
@@ -382,7 +382,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTED 1`
       size={null}
       spin={false}
       symbol={false}
-      title="Start environment"
+      title="Stop environment"
       transform={null}
     />
     <FontAwesomeIcon


### PR DESCRIPTION
* After "Start environment" toggle is clicked then the tooltip should
  become "Stop environment".
* A small fix: adding `noopener` property for tag <a>.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
