### PR TITLE
Add highlight for EqualAssertion

### DIFF
--- a/testplan/testing/multitest/entries/assertions.py
+++ b/testplan/testing/multitest/entries/assertions.py
@@ -155,6 +155,16 @@ class Equal(FuncAssertion):
     label = "=="
     func = operator.eq
 
+    def __init__(self, first, second, description=None, category=None):
+        self.type_actual = type(first).__name__
+        self.type_expected = type(second).__name__
+        super(Equal, self).__init__(
+            first=first,
+            second=second,
+            description=description,
+            category=category,
+        )
+
 
 class NotEqual(FuncAssertion):
     label = "!="

--- a/testplan/testing/multitest/entries/schemas/assertions.py
+++ b/testplan/testing/multitest/entries/schemas/assertions.py
@@ -26,7 +26,6 @@ class RawAssertionSchema(AssertionSchema):
 
 
 @registry.bind(
-    asr.Equal,
     asr.NotEqual,
     asr.Less,
     asr.LessEqual,
@@ -38,6 +37,13 @@ class FuncAssertionSchema(AssertionSchema):
     first = custom_fields.NativeOrPretty()
     second = custom_fields.NativeOrPretty()
     label = fields.String()
+
+
+@registry.bind(asr.Equal)
+class EqualSchema(FuncAssertionSchema):
+
+    type_actual = fields.String()
+    type_expected = fields.String()
 
 
 @registry.bind(asr.IsClose)

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/GraphAssertions/DiscreteChartAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/GraphAssertions/DiscreteChartAssertion.js
@@ -14,13 +14,17 @@ import {
  * correctly (not generalised for other charts).
  */
 class DiscreteChartAssertion extends Component  {
-  components = {
-    Pie: RadialChart
-   }
+  constructor(props) {
+    super(props);
+    this.components = {
+      Pie: RadialChart
+     };
+  
+    this.state = {
+      value: null
+    };
+  }
 
-  state = {
-    value: null
-  };
 
   render(){
     let data = this.props.assertion.graph_data;

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/GraphAssertions/XYGraphAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/GraphAssertions/XYGraphAssertion.js
@@ -19,6 +19,14 @@ import {
   ChartLabel
 } from 'react-vis';
 
+const components = {
+  Line: LineSeries,
+  Hexbin: HexbinSeries,
+  Contour: ContourSeries,
+  Whisker: WhiskerSeries,
+  Bar: VerticalBarSeries,
+  Scatter: MarkSeries
+};
 
 /**
  * Component that are used to render a Graph (Data visualisations that require
@@ -29,7 +37,8 @@ class XYGraphAssertion extends Component {
     super(props);
 
     this.state = {
-      series_colour:{}
+      series_colour:{},
+      lastDrawLocation: null
     };
 
     let data = this.props.assertion.graph_data;
@@ -38,28 +47,12 @@ class XYGraphAssertion extends Component {
     this.state.series_colour = plot_colours;
   }
 
-
-  state = {
-    lastDrawLocation: null
-   };
-
-
-  components = {
-    Line: LineSeries,
-    Hexbin: HexbinSeries,
-    Contour: ContourSeries,
-    Whisker: WhiskerSeries,
-    Bar: VerticalBarSeries,
-    Scatter: MarkSeries
-  }
-
-
   render() {
     const data = this.props.assertion.graph_data;
     const graph_options = this.props.assertion.graph_options;
     const {lastDrawLocation} = this.state;
     const graph_type = this.props.assertion.graph_type;
-    const GraphComponent = this.components[graph_type];
+    const GraphComponent = components[graph_type];
 
     let legend = [];
     let plots = [];

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/GraphAssertions/__tests__/__snapshots__/XYGraphAssertion.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/GraphAssertions/__tests__/__snapshots__/XYGraphAssertion.test.js.snap
@@ -9,7 +9,9 @@ exports[`XYGraphAssertion shallow renders the correct HTML structure 1`] = `
     className=""
     height={500}
     width={750}
+    xDomain={null}
     xType="ordinal"
+    yDomain={null}
   >
     <HorizontalGridLines
       attr="y"

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/BasicAssertion.test.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/BasicAssertion.test.js
@@ -22,6 +22,26 @@ function propsEqual() {
   };
 }
 
+function propsHighlightEqual() {
+  return {
+    assertion: {
+      "category": "DEFAULT",
+      "machine_time": "2019-02-12T17:41:42.795536+00:00",
+      "description": "compare two string",
+      "line_no": 25,
+      "label": "==",
+      "second": "This is a short thing",
+      "meta_type": "assertion",
+      "passed": false,
+      "type": "Equal",
+      "utc_time": "2019-02-12T17:41:42.795530+00:00",
+      "first": "This is a long thing with some extra at the end",
+      "type_actual": "str",
+      "type_expected": "str"
+    }
+  };
+}
+
 function propsNotEqual() {
   return {
     assertion: {
@@ -549,6 +569,12 @@ describe('BasicAssertion', () => {
 
   it('shallow renders the Equal assertion', () => {
     props = propsEqual();
+    shallowComponent = shallow(<BasicAssertion {...props} />);
+    expect(shallowComponent).toMatchSnapshot();
+  });
+
+  it('shallow renders the highlight Equal assertion', () => {
+    props = propsHighlightEqual();
     shallowComponent = shallow(<BasicAssertion {...props} />);
     expect(shallowComponent).toMatchSnapshot();
   });

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/__snapshots__/BasicAssertion.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/__snapshots__/BasicAssertion.test.js.snap
@@ -634,9 +634,9 @@ exports[`BasicAssertion shallow renders the Equal assertion 1`] = `
       }
     >
       <span>
-        <span>
+        <pre>
           foo
-        </span>
+        </pre>
       </span>
     </Col>
     <Col
@@ -654,7 +654,9 @@ exports[`BasicAssertion shallow renders the Equal assertion 1`] = `
       }
     >
       <span>
-        foo
+        <pre>
+          foo
+        </pre>
       </span>
     </Col>
   </Row>
@@ -5198,6 +5200,209 @@ exports[`BasicAssertion shallow renders the XMLCheck assertion 1`] = `
 &lt;/Root&gt;
 
         </span>
+      </span>
+    </Col>
+  </Row>
+  <Row
+    tag="div"
+  >
+    <Col
+      lg="12"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <strong />
+    </Col>
+  </Row>
+  <Row
+    tag="div"
+  >
+    <Col
+      className="contentSpan_11nzg99"
+      lg="12"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    />
+  </Row>
+</Fragment>
+`;
+
+exports[`BasicAssertion shallow renders the highlight Equal assertion 1`] = `
+<Fragment>
+  <Row
+    tag="div"
+  >
+    <Col
+      lg="12"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <strong />
+    </Col>
+  </Row>
+  <Row
+    tag="div"
+  >
+    <Col
+      className="contentSpan_11nzg99"
+      lg="12"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    />
+  </Row>
+  <Row
+    tag="div"
+  >
+    <Col
+      lg="6"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <strong>
+        Expected:
+      </strong>
+    </Col>
+    <Col
+      lg="6"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <strong>
+        Value:
+      </strong>
+    </Col>
+  </Row>
+  <Row
+    tag="div"
+  >
+    <Col
+      className="contentSpan_11nzg99"
+      lg="6"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <span>
+        <pre>
+          <span
+            key="diffLeftEq"
+            style={
+              Object {
+                "color": "#228F1D",
+              }
+            }
+          >
+            This is a 
+          </span>
+          <span
+            key="diffLeftNe"
+            style={
+              Object {
+                "color": "#A2000C",
+                "fontWeight": "bold",
+                "textDecoration": "underline",
+              }
+            }
+          >
+            short thing
+          </span>
+        </pre>
+      </span>
+    </Col>
+    <Col
+      className="contentSpan_11nzg99"
+      lg="6"
+      tag="div"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      <span>
+        <pre>
+          <span
+            key="diffrightEq"
+            style={
+              Object {
+                "color": "#228F1D",
+              }
+            }
+          >
+            This is a 
+          </span>
+          <span
+            key="diffrightNe"
+            style={
+              Object {
+                "color": "#A2000C",
+                "fontWeight": "bold",
+                "textDecoration": "underline",
+              }
+            }
+          >
+            long thing with some extra at the end
+          </span>
+        </pre>
       </span>
     </Col>
   </Row>

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/basicAssertionUtils.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/basicAssertionUtils.js
@@ -1,5 +1,6 @@
 import React, {Fragment} from 'react';
 import {hashCode} from '../../Common/utils';
+import {GREEN, RED} from '../../Common/defaults';
 import _ from 'lodash';
 
 /** @module basicAssertionUtils */
@@ -66,13 +67,55 @@ function prepareLogContent(assertion, defaultContent) {
  * @private
  */
 function prepareEqualContent(assertion, defaultContent) {
-  const leftContent = <span>
-    {_.isNil(assertion.second) ? "" : String(assertion.second)}
-  </span>;
+  let leftContent;
+  let rightContent;
+  if (
+    assertion.type_actual === "str" && 
+    assertion.type_expected === "str" && 
+    !assertion.passed
+  ) {
+    const shortLength = Math.min(
+      assertion.first.length,
+      assertion.second.length
+    );
+    let diffPosition;
+    for (diffPosition=0; diffPosition<shortLength; diffPosition++) {
+      if (
+        assertion.first[diffPosition] !== assertion.second[diffPosition]
+      ) break;
+    }
+    
+    leftContent = [
+      <span
+        key="diffLeftEq"
+        style={{color: GREEN}}
+      >{assertion.second.substring(0, diffPosition)}</span>,
+      <span
+        key="diffLeftNe"
+        style={{color: RED, fontWeight: 'bold', textDecoration: "underline"}}
+      >{
+        assertion.second.substring(diffPosition, assertion.second.length)
+      }</span>
+    ];
+    rightContent = [
+      <span
+        key="diffrightEq"
+        style={{color: GREEN}}
+      >{assertion.first.substring(0, diffPosition)}</span>,
+      <span
+        key="diffrightNe"
+        style={{color: RED, fontWeight: 'bold', textDecoration: "underline"}}
+      >{assertion.first.substring(diffPosition, assertion.first.length)}</span>
+    ];
+  } else {
+    leftContent = _.isNil(assertion.second) ? "": String(assertion.second);
+    rightContent = _.isNil(assertion.first) ? "": String(assertion.first);
+  }
 
   return {
     ...defaultContent,
-    leftContent: leftContent,
+    leftContent: <pre>{leftContent}</pre>,
+    rightContent: <pre>{rightContent}</pre>,
   };
 }
 

--- a/testplan/web_ui/testing/src/Common/fakeReport.js
+++ b/testplan/web_ui/testing/src/Common/fakeReport.js
@@ -448,6 +448,21 @@ var fakeReportAssertions = {
                                 },
                                 {
                                     "category": "DEFAULT",
+                                    "description": null,
+                                    "meta_type": "assertion",
+                                    "label": "==",
+                                    "type": "Equal",
+                                    "utc_time": "2020-01-10T03:06:58.630121+00:00",
+                                    "second": "This is a short thing",
+                                    "passed": false,
+                                    "type_actual": "str",
+                                    "type_expected": "str",
+                                    "first": "This is a long thing with some extra at the end",
+                                    "machine_time": "2020-01-10T11:06:58.630129+00:00",
+                                    "line_no": 25
+                                },
+                                {
+                                    "category": "DEFAULT",
                                     "description": "Description for failing equality",
                                     "meta_type": "assertion",
                                     "label": "==",

--- a/testplan/web_ui/testing/src/Report/BatchReportBeta/state/reportActions/fetchReport.js
+++ b/testplan/web_ui/testing/src/Report/BatchReportBeta/state/reportActions/fetchReport.js
@@ -131,7 +131,12 @@ const fetchReport = createAsyncThunk(
     const { dispatch, rejectWithValue, requestId } = thunkAPI;
     try {
       if(!_.isPlainObject(arg))
-        throw new class extends Error { name = 'FetchReportArgError'; }(
+        throw new class extends Error {
+          constructor(message) {
+            super(message);
+            this.name = 'FetchReportArgError';
+          }
+        }(
           __DEV__ ? '`fetchReport` takes a single plain object argument'
                   : 'Contact support'
         );

--- a/testplan/web_ui/testing/src/Toolbar/FilterBox.js
+++ b/testplan/web_ui/testing/src/Toolbar/FilterBox.js
@@ -26,6 +26,29 @@ class FilterBox extends Component {
       parserError: null,
       showHelp: false,
     };
+    this.toggleHelp = this.toggleHelp.bind(this);
+    this.helpText = (
+      <>
+        <p>
+          Just start typing in the search bar. The test items are filtered
+          automatically. The current selection if available in the serach are
+          maintained. All the search are <b>case insensitive</b>.
+        </p>
+        <p>
+          You can search by <b>free text</b>, then each word will be matched
+          against multitest, testsuite or testcase name as well as tags and tag
+          names. For tag or tag names the match must be exact, for the rest it
+          is enough that the name contains the word. If anything match it will
+          be included.
+        </p>
+        <p>
+          There are also <b>operators</b> that can be used for more advanced
+          search terms. The test items matching all the specified operators will
+          be filtered. The table below summarize them with examples:
+        </p>
+        {this.operatorsTable()}
+      </>
+    );
   }
 
   componentDidMount() {
@@ -34,7 +57,7 @@ class FilterBox extends Component {
     }
   }
 
-  toggleHelp = () => {
+  toggleHelp() {
     this.setState({ showHelp: !this.state.showHelp });
   };
 
@@ -108,29 +131,6 @@ class FilterBox extends Component {
       this.props.handleNavFilter({text: e.target.values, filters: []});
     }
   }
-
-  helpText = (
-    <>
-      <p>
-        Just start typing in the search bar. The test items are filtered
-        automatically. The current selection if available in the serach are
-        maintained. All the search are <b>case insensitive</b>.
-      </p>
-      <p>
-        You can search by <b>free text</b>, then each word will be matched
-        against multitest, testsuite or testcase name as well as tags and tag
-        names. For tag or tag names the match must be exact, for the rest it is
-        enough that the name contains the word. If anything match it will be
-        included.
-      </p>
-      <p>
-        There are also <b>operators</b> that can be used for more advanced
-        search terms. The test items matching all the specified operators will
-        be filtered. The table below summarize them with examples:
-      </p>
-      {this.operatorsTable()}
-    </>
-  );
 
   operatorsTable() {
     const descriptions = [


### PR DESCRIPTION
## Bug / Requirement Description
Add highlight for EqualAssertion.
Also fix some eslint errors.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
