### PR TITLE
Add proper remote path to remote sys.path

### DIFF
--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -90,9 +90,14 @@ class ProcessWorker(Worker):
     def _write_syspath(self):
         """Write out our current sys.path to a file and return the filename."""
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
-            f.write("\n".join(sys.path))
+            sys_path = self._get_syspath()
+            f.write("\n".join(sys_path))
             self.logger.debug("Written sys.path to file: %s", f.name)
             return f.name
+
+    def _get_syspath(self):
+        """provide a way for subclasses to generate modified sys path which is valid on target"""
+        return sys.path
 
     def starting(self):
         """Start a child process worker."""


### PR DESCRIPTION
## Bug / Requirement Description
if someone use module="package1.module1" in plan.schedule with a remote pool. On remote the package1 is not found

## Solution description
The problem that on remote the sys.path is not set up with the copied workspace in it.
To make this apparent replace the current script dir with the remote workspace dir in sys.path before writing to file.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
