### PR TITLE
DictMatch should support empty string or None as dict key

### DIFF
--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/dictAssertionUtils.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/dictAssertionUtils.js
@@ -238,7 +238,9 @@ export function prepareDictRowData(data, lineNo) {
       [level, key, status, actualValue, expectedValue] = line;
     }
     actualValue = actualValue || [];
-    const isEmptyLine = key.length === 0 && actualValue.length === 0;
+    const isEmptyLine = (
+        key !== null && key.length === 0 && actualValue.length === 0
+    );
     const hasAcutalValue = Array.isArray(actualValue);
     const hasExpectedValue = Array.isArray(expectedValue);
 
@@ -418,7 +420,7 @@ export function flattenedDictToDOM(flattenedDict) {
       // If key and value are string and length is 0, the current row is empty.
       // Empty row will be ignored.
       actualValue = actualValue || "";
-      if (key.length === 0 && actualValue.length === 0) {
+      if (key !== null && key.length === 0 && actualValue.length === 0) {
         return;
       }
       let tr = document.createElement('tr');


### PR DESCRIPTION
* If empty string or `None` is used as dictionary key and try matching
  dictionary, then the assertion data in generated report is incorrect,
  should use a special ABSENT to indicate that key does not exist.
* If `None` is used as dictionary key, UI should be aware of this or
  error occurs.
