### PR TITLE
remote path manipulation operate on sys.path copy

### DIFF
--- a/testplan/runners/pools/remote.py
+++ b/testplan/runners/pools/remote.py
@@ -644,7 +644,7 @@ class RemoteWorker(ProcessWorker):
         :return: list of remote valid sys paths
         """
 
-        sys_path = sys.path
+        sys_path = list(sys.path)
         main = sys.modules["__main__"]
 
         if main:


### PR DESCRIPTION
## Bug / Requirement Description
The previous chnage to remote sys.path transfer introduced a bug. 
During the sys.path preparations the sys.path is altered as well as the change is happening on a ref and not on copy

## Solution description
make a copy of  sys.path before altering it.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
