### PR TITLE
Force to execute testcases sequentially in a test suite

### DIFF
--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -180,6 +180,23 @@ Example can be found :ref:`here <example_basic_name_customization>`.
 To customize names for parametrized testcases another argument ``name_func`` can be
 used, refer to the document of :ref:`name_func <parametrization_custom_name_func>`.
 
+Strict order
+------------
+
+In a test suite all testcases can be forced to run sequentially, which means, they will
+be executed strictly in the order as they were defined, even some :ref:`paralell feature <testcase_parallelization>`
+like "shuffling" and "execution group" will not take effect. Specify such a test suite
+like this:
+
+    * @testsuite(strict_order=True)
+
+When executed in interactive mode, UI can help user to run testcases one by one,
+that is, in a "strict ordered" test suite, only the first testcase can run, after
+it finishes its execution then the next testcase is able to run, and there is no
+idea to re-run the finished testcases unless the whole test report is reset.
+Similarly, you cannot run a test suite if some testcases in it already finish
+execution or are running, an error message will be displayed.
+
 Listing
 -------
 

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -591,6 +591,7 @@ class TestGroupReport(BaseReportGroup):
         part=None,
         fix_spec_path=None,
         env_status=None,
+        strict_order=False,
         **kwargs
     ):
         super(TestGroupReport, self).__init__(name=name, **kwargs)
@@ -615,6 +616,9 @@ class TestGroupReport(BaseReportGroup):
 
         # Expected to be one of ResourceStatus, or None.
         self.env_status = env_status
+
+        # Can be True For group report in category "testsuite"
+        self.strict_order = strict_order
 
     def __str__(self):
         return (
@@ -954,6 +958,7 @@ class TestCaseReport(Report):
                 self.status,
                 self.runtime_status,
                 tuple(id(entry) for entry in self.entries),
+                tuple(entry["uid"] for entry in self.logs),
             )
         )
 

--- a/testplan/report/testing/schemas.py
+++ b/testplan/report/testing/schemas.py
@@ -120,13 +120,13 @@ class TestCaseReportSchema(ReportSchema):
 
     entries = fields.List(EntriesField())
 
+    category = fields.String(dump_only=True)
     status = fields.String(dump_only=True)
     runtime_status = fields.String(dump_only=True)
     counter = fields.Dict(dump_only=True)
     suite_related = fields.Bool()
     timer = TimerField(required=True)
     tags = TagField()
-    category = fields.String(dump_only=True)
 
     status_reason = fields.String(allow_none=True)
 
@@ -156,14 +156,10 @@ class TestGroupReportSchema(TestCaseReportSchema):
     """
 
     source_class = TestGroupReport
-    # category = fields.String()
     part = fields.List(fields.Integer, allow_none=True)
     fix_spec_path = fields.String(allow_none=True)
     env_status = fields.String(allow_none=True)
-
-    # status_reason = fields.String(allow_none=True)
-    # runtime_status = fields.String(dump_only=True)
-    # counter = fields.Dict(dump_only=True)
+    strict_order = fields.Bool()
 
     entries = custom_fields.GenericNested(
         schema_context={
@@ -186,10 +182,11 @@ class TestGroupReportSchema(TestCaseReportSchema):
 class TestReportSchema(Schema):
     """Schema for test report root, ``testing.TestReport``."""
 
-    timer = TimerField(required=True)
     name = fields.String(required=True)
     description = fields.String(allow_none=True)
     uid = fields.String(required=True)
+    category = fields.String(dump_only=True)
+    timer = TimerField(required=True)
     meta = fields.Dict()
 
     status = fields.String(dump_only=True)
@@ -206,7 +203,6 @@ class TestReportSchema(Schema):
     entries = custom_fields.GenericNested(
         schema_context={TestGroupReport: TestGroupReportSchema}, many=True
     )
-    category = fields.String(dump_only=True)
 
     @post_load
     def make_test_report(self, data):  # pylint: disable=no-self-use
@@ -238,9 +234,10 @@ class ShallowTestGroupReportSchema(Schema):
     """Schema for shallow serialization of ``TestGroupReport``."""
 
     name = fields.String(required=True)
-    uid = fields.String(required=True)
-    timer = TimerField(required=True)
     description = fields.String(allow_none=True)
+    uid = fields.String(required=True)
+    category = fields.String()
+    timer = TimerField(required=True)
     part = fields.List(fields.Integer, allow_none=True)
     fix_spec_path = fields.String(allow_none=True)
     status_override = fields.String(allow_none=True)
@@ -252,8 +249,8 @@ class ShallowTestGroupReportSchema(Schema):
     entry_uids = fields.List(fields.Str(), dump_only=True)
     parent_uids = fields.List(fields.Str())
     hash = fields.Integer(dump_only=True)
-    category = fields.String()
     env_status = fields.String(allow_none=True)
+    strict_order = fields.Bool()
 
     @post_load
     def make_testgroup_report(self, data):
@@ -272,7 +269,9 @@ class ShallowTestReportSchema(Schema):
     """Schema for shallow serialization of ``TestReport``."""
 
     name = fields.String(required=True)
+    description = fields.String(allow_none=True)
     uid = fields.String(required=True)
+    category = fields.String(dump_only=True)
     timer = TimerField(required=True)
     meta = fields.Dict()
     status = fields.String(dump_only=True)
@@ -284,7 +283,6 @@ class ShallowTestReportSchema(Schema):
     entry_uids = fields.List(fields.Str(), dump_only=True)
     parent_uids = fields.List(fields.Str())
     hash = fields.Integer(dump_only=True)
-    category = fields.String(dump_only=True)
 
     @post_load
     def make_test_report(self, data):

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -14,6 +14,7 @@ from testplan.testing import filtering, ordering, tagging
 
 from testplan.common.entity import (
     Resource,
+    ResourceStatus,
     Runnable,
     RunnableResult,
     RunnableConfig,
@@ -151,6 +152,7 @@ class Test(Runnable):
             uid=self.uid(),
             category=self.__class__.__name__.lower(),
             tags=self.cfg.tags,
+            env_status=ResourceStatus.STOPPED,
         )
 
     def _init_test_report(self):
@@ -353,7 +355,7 @@ class Test(Runnable):
 
     def dry_run(self):
         """
-        Return an empty report skeleton for this Test including all
+        Return an empty report skeleton for this test including all
         testsuites, testcases etc. hierarchy. Does not run any tests.
         """
         suites_to_run = self.test_context

--- a/testplan/testing/filtering.py
+++ b/testplan/testing/filtering.py
@@ -146,7 +146,9 @@ class MetaFilter(BaseFilter):
 
 
 class Or(MetaFilter):
-    """Meta filter that returns True if ANY of the child filters return True"""
+    """
+    Meta filter that returns True if ANY of the child filters return True.
+    """
 
     operator_str = "|"
 
@@ -161,7 +163,9 @@ class Or(MetaFilter):
 
 
 class And(MetaFilter):
-    """Meta filter that returns True if ALL of the child filters return True"""
+    """
+    Meta filter that returns True if ALL of the child filters return True.
+    """
 
     operator_str = "&"
 
@@ -290,12 +294,8 @@ class Pattern(Filter):
         return fnmatch.fnmatch(test.name, self.test_pattern)
 
     def filter_suite(self, suite):
-        return fnmatch.fnmatch(
-            # Now, Suite has the same name and uid, just like that of Multitest
-            # suite.__class__.__name__ if self.match_definition else suite.name,
-            suite.name,
-            self.suite_pattern,
-        )
+        # For test suite uid is the same as name, just like that of Multitest
+        return fnmatch.fnmatch(suite.name, self.suite_pattern)
 
     def filter_case(self, case):
         name_match = fnmatch.fnmatch(

--- a/testplan/testing/multitest/parametrization.py
+++ b/testplan/testing/multitest/parametrization.py
@@ -394,7 +394,7 @@ def generate_functions(
     :type key_combs_limit: ``int``
     :param execution_group: Name of execution group in which the testcases
                             can be executed in parallel.
-    :type execution_group: ``str``
+    :type execution_group: ``str`` or ``NoneType``
     :param timeout: Timeout in seconds to wait for testcase to be finished.
     :type timeout: ``int``
     :return: List of functions that is testcase compliant

--- a/testplan/testing/multitest/suite.py
+++ b/testplan/testing/multitest/suite.py
@@ -357,8 +357,8 @@ def _testsuite(klass):
 
     assert all(testcase for testcase in klass.__testcases__)
 
-    # Attributes `name` and `__tags__` are added only when class is
-    # decorated by @testsuite(...) which has the following parentheses.
+    # Attributes `name` and `__tags__` and `strict_order` are added only when
+    # class is decorated by @testsuite(...) with following parentheses.
     if not hasattr(klass, "name"):
         klass.name = None
 
@@ -375,6 +375,12 @@ def _testsuite(klass):
     if not hasattr(klass, "__tags__"):
         klass.__tags__ = {}  # used for UI
         klass.__tags_index__ = {}  # used for actual filtering
+
+    if not hasattr(klass, "strict_order"):
+        klass.strict_order = False
+
+    for func_name in __PARAMETRIZATION_TEMPLATE__:
+        getattr(klass, func_name).strict_order = klass.strict_order
 
     klass.get_testcases = get_testcase_methods
     testcase_methods = get_testcase_methods(klass)
@@ -397,7 +403,7 @@ def _testsuite(klass):
     return klass
 
 
-def _testsuite_meta(name=None, tags=None):
+def _testsuite_meta(name=None, tags=None, strict_order=False):
     """
     Wrapper function that allows us to call :py:func:`@testsuite <testsuite>`
     decorator with extra arguments.
@@ -414,6 +420,8 @@ def _testsuite_meta(name=None, tags=None):
         else:
             klass.__tags__ = {}
             klass.__tags_index__ = {}
+
+        klass.strict_order = strict_order
 
         return _testsuite(klass)
 

--- a/testplan/web_ui/testing/src/Common/defaults.js
+++ b/testplan/web_ui/testing/src/Common/defaults.js
@@ -129,6 +129,11 @@ const RUNTIME_STATUS = [
   'finished',
 ];
 
+const NAV_ENTRY_ACTIONS = [
+  'play',
+  'open',
+  'prohibit',
+];
 
 const NAV_ENTRY_DISPLAY_DATA = [
   'name',
@@ -211,6 +216,7 @@ export {
   STATUS,
   STATUS_CATEGORY,
   RUNTIME_STATUS,
+  NAV_ENTRY_ACTIONS,
   NAV_ENTRY_DISPLAY_DATA,
   BASIC_ASSERTION_TYPES,
   SORT_TYPES,

--- a/testplan/web_ui/testing/src/Nav/InteractiveNav.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNav.js
@@ -5,7 +5,11 @@ import base64url from 'base64url';
 
 import NavBreadcrumbs from "./NavBreadcrumbs";
 import InteractiveNavList from "./InteractiveNavList";
-import {GetSelectedUid, GetNavEntries, GetNavBreadcrumbs} from "./navUtils";
+import {
+  GetSelectedUid,
+  GetInteractiveNavEntries,
+  GetNavBreadcrumbs
+} from "./navUtils";
 
 /**
  * Interactive Nav component.
@@ -23,7 +27,7 @@ import {GetSelectedUid, GetNavEntries, GetNavBreadcrumbs} from "./navUtils";
  * with the main Nav component, which will need to be eliminated.
  */
 const InteractiveNav = (props) => {
-  const navEntries = GetNavEntries(props.selected);
+  const navEntries = GetInteractiveNavEntries(props.selected);
   const breadCrumbEntries = GetNavBreadcrumbs(props.selected);
 
   return (

--- a/testplan/web_ui/testing/src/Nav/InteractiveNavEntry.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNavEntry.js
@@ -22,6 +22,7 @@ import {
   STATUS,
   STATUS_CATEGORY,
   RUNTIME_STATUS,
+  NAV_ENTRY_ACTIONS,
 } from "../Common/defaults";
 
 /**
@@ -35,7 +36,10 @@ import {
 const InteractiveNavEntry = (props) => {
   const badgeStyle = `${STATUS_CATEGORY[props.status]}Badge`;
   const statusIcon = getStatusIcon(
-    props.runtime_status, props.handlePlayClick, props.suiteRelated,
+    props.runtime_status,
+    props.handlePlayClick,
+    props.suiteRelated,
+    props.action,
   );
   const envStatusIcon = getEnvStatusIcon(
     props.envStatus, props.envCtrlCallback
@@ -89,7 +93,7 @@ const InteractiveNavEntry = (props) => {
  *   reports, cannot be directly run and are instead run automatically as
  *   required. So we do not render buttons to control them.
  */
-const getStatusIcon = (entryStatus, handlePlayClick, suiteRelated) => {
+const getStatusIcon = (entryStatus, handlePlayClick, suiteRelated, action) => {
   if (suiteRelated) {
     return null;
   }
@@ -98,30 +102,45 @@ const getStatusIcon = (entryStatus, handlePlayClick, suiteRelated) => {
     case 'ready':
       return (
         <FontAwesomeIcon
-          className={css(styles.entryButton)}
+          className={
+            action === 'prohibit' ? css(styles.inactiveEntryButton)
+            : css(styles.entryButton)
+          }
           icon={faPlay}
           title='Run tests'
-          onClick={handlePlayClick}
+          onClick={
+            action === 'prohibit' ? (e) => {
+              e.preventDefault(); e.stopPropagation();
+            } : handlePlayClick
+          }
         />
       );
 
     case 'running':
       return (
         <FontAwesomeIcon
-          className={css(styles.entryButton)}
+          className={css(styles.inactiveEntryButton)}
           icon={faRedo}
           title='Running...'
           spin
+          onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}
         />
       );
 
     case 'finished':
       return (
         <FontAwesomeIcon
-          className={css(styles.entryButton)}
+          className={
+            action === 'prohibit' ? css(styles.inactiveEntryButton)
+            : css(styles.entryButton)
+          }
           icon={faRedo}
           title='Run tests'
-          onClick={handlePlayClick}
+          onClick={
+            action === 'prohibit' ? (e) => {
+              e.preventDefault(); e.stopPropagation();
+            } : handlePlayClick
+          }
         />
       );
 
@@ -152,6 +171,7 @@ const getEnvStatusIcon = (envStatus, envCtrlCallback) => {
             className={css(styles.inactiveEntryButton)}
             icon={faToggleOff}
             title='Environment starting...'
+            onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}
           />
         );
 
@@ -171,6 +191,7 @@ const getEnvStatusIcon = (envStatus, envCtrlCallback) => {
             className={css(styles.inactiveEntryButton)}
             icon={faToggleOn}
             title='Environment stopping...'
+            onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}
           />
         );
 
@@ -187,6 +208,8 @@ InteractiveNavEntry.propTypes = {
   /** Entry status */
   status: PropTypes.oneOf(STATUS),
   runtime_status: PropTypes.oneOf(RUNTIME_STATUS),
+  /** Entry action */
+  action: PropTypes.oneOf(NAV_ENTRY_ACTIONS),
   /** Entry type */
   type: PropTypes.oneOf(ENTRY_TYPES),
   /** Number of passing testcases entry has */

--- a/testplan/web_ui/testing/src/Nav/InteractiveNavList.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNavList.js
@@ -5,7 +5,7 @@ import base64url from 'base64url';
 
 import InteractiveNavEntry from './InteractiveNavEntry';
 import {CreateNavButtons, GetNavColumn} from './navUtils.js';
-import {STATUS, RUNTIME_STATUS} from "../Common/defaults";
+import {STATUS, RUNTIME_STATUS, NAV_ENTRY_ACTIONS} from "../Common/defaults";
 
 /**
  * Render a vertical list of all the currently selected entries children for
@@ -29,6 +29,7 @@ const InteractiveNavList = (props) => {
           (e, action) => props.envCtrlCallback(e, entry, action)
         }
         suiteRelated={entry.suite_related}
+        action={entry.action}
       />
     ),
     base64url
@@ -47,6 +48,7 @@ InteractiveNavList.propTypes = {
     description: PropTypes.string,
     status: PropTypes.oneOf(STATUS),
     runtime_status: PropTypes.oneOf(RUNTIME_STATUS),
+    action: PropTypes.oneOf(NAV_ENTRY_ACTIONS),
     counter: PropTypes.shape({
       passed: PropTypes.number,
       failed: PropTypes.number,

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
@@ -123,7 +123,7 @@ exports[`InteractiveNavEntry renders a testcase in "running" state 1`] = `
     </Badge>
     <FontAwesomeIcon
       border={false}
-      className="entryButton_yr2g96"
+      className="inactiveEntryButton_bb26hz"
       fixedWidth={false}
       flip={null}
       icon={
@@ -142,6 +142,7 @@ exports[`InteractiveNavEntry renders a testcase in "running" state 1`] = `
       inverse={false}
       listItem={false}
       mask={null}
+      onClick={[Function]}
       pull={null}
       pulse={false}
       rotation={null}
@@ -484,6 +485,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTING 1
       inverse={false}
       listItem={false}
       mask={null}
+      onClick={[Function]}
       pull={null}
       pulse={false}
       rotation={null}
@@ -701,6 +703,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPING 1
       inverse={false}
       listItem={false}
       mask={null}
+      onClick={[Function]}
       pull={null}
       pulse={false}
       rotation={null}

--- a/testplan/web_ui/testing/src/Report/BatchReport.js
+++ b/testplan/web_ui/testing/src/Report/BatchReport.js
@@ -27,10 +27,12 @@ import {fakeReportAssertions} from "../Common/fakeReport";
  *   * render toolbar, nav & assertion components.
  */
 class BatchReport extends React.Component {
+
   constructor(props) {
     super(props);
     this.setError = this.setError.bind(this);
     this.setReport = this.setReport.bind(this);
+    this.getReport = this.getReport.bind(this);
     this.handleNavFilter = this.handleNavFilter.bind(this);
     this.updateFilter = this.updateFilter.bind(this);
     this.updateTagsDisplay = this.updateTagsDisplay.bind(this);
@@ -53,10 +55,8 @@ class BatchReport extends React.Component {
   }
 
   setError(error) {
-    this.setState({
-      error: error,
-      loading: false,
-    });
+    console.log(error);
+    this.setState({error: error, loading: false});
   }
 
   setReport(report) {
@@ -71,7 +71,7 @@ class BatchReport extends React.Component {
           this.props.match.path, 
           this.autoSelect(filteredReport.report)
         );
-    
+
     this.setState({
       report: processedReport,
       filteredReport,
@@ -117,7 +117,7 @@ class BatchReport extends React.Component {
                 if (!assertionsRes.data) {
                   alert(
                     "Failed to parse assertion datails!\n"
-                    +"Please report this issue to the testplan team."
+                    + "Please report this issue to the Testplan team."
                   );
                   console.error(assertionsRes);
                 }
@@ -125,7 +125,8 @@ class BatchReport extends React.Component {
                   rawReport, assertionsRes.data, structureRes.data
                 );
                 this.setReport(this.updateReportUID(mergedReport, uid));
-            })).catch(this.setError);
+              })
+            ).catch(this.setError);
           } else {
             this.setReport(this.updateReportUID(rawReport, uid));
           }

--- a/testplan/web_ui/testing/src/Report/InteractiveReport.js
+++ b/testplan/web_ui/testing/src/Report/InteractiveReport.js
@@ -42,20 +42,23 @@ class InteractiveReport extends React.Component {
 
   constructor(props) {
     super(props);
+    this.setError = this.setError.bind(this);
+    this.setReport = this.setReport.bind(this);
+    this.getReport = this.getReport.bind(this);
+    this.resetReport = this.resetReport.bind(this);
+    this.handlePlayClick = this.handlePlayClick.bind(this);
+    this.envCtrlCallback = this.envCtrlCallback.bind(this);
+    this.reloadCode = this.reloadCode.bind(this);
+    this.handleColumnResizing = this.handleColumnResizing.bind(this);
+
     this.state = {
       navWidth: `${INTERACTIVE_COL_WIDTH}em`,
-      report: null,      
+      report: null,
       loading: false,
       error: null,
       resetting: false,
       reloading: false,
     };
-    this.handlePlayClick = this.handlePlayClick.bind(this);
-    this.envCtrlCallback = this.envCtrlCallback.bind(this);
-    this.getReport = this.getReport.bind(this);
-    this.resetReport = this.resetReport.bind(this);
-    this.reloadCode = this.reloadCode.bind(this);
-    this.handleColumnResizing = this.handleColumnResizing.bind(this);
   }
 
   /**
@@ -64,6 +67,11 @@ class InteractiveReport extends React.Component {
    */
   componentDidMount() {
     this.setState({ loading: true }, this.getReport);
+  }
+
+  setError(error) {
+    console.log(error);
+    this.setState({error: error, loading: false});
   }
 
   setReport(report) {
@@ -97,11 +105,7 @@ class InteractiveReport extends React.Component {
               this.setReport(rawReport);
             });
           }
-        })
-        .catch(error => {
-          console.log(error);
-          this.setState({ error: error, loading: false });
-        });
+        }).catch(this.setError);
 
       // We poll for updates to the report every second.
       setTimeout(this.getReport, this.props.poll_intervall || POLL_MS);      
@@ -234,7 +238,14 @@ class InteractiveReport extends React.Component {
   putUpdatedReportEntry(updatedReportEntry) {
     const apiUrl = this.getApiUrl(updatedReportEntry);
     return axios.put(apiUrl, updatedReportEntry).then(
-      response => this.setShallowReportEntry(response.data)
+      response => {
+        if (response.data.errmsg) {
+          alert(response.data.errmsg);
+          console.error(response.data);
+        } else {
+          this.setShallowReportEntry(response.data);
+        }
+      }
     ).catch(
       error => this.setState({ error: error })
     );


### PR DESCRIPTION
* An attribute "strict_order" is added into test suite and testcases
  in this suite must run sequentially one by one and parallel feature
  such as execution group is disabled in batch mode.
* A test suite with "strict_order" ignores `test_sorter` configured for
  Test runner, and `test_filter` config does not take effect unless all
  of the testcases in suite been filtered out.
* If "strict_order" is specified, on interactive UI a testcase entry is
  disabled unless previous ones in the same test suite have run, this
  also applies to testcases in a parametrization group. At server side
  disorded execution can be detected and an error message is returned.
* In interactive mode the report of a multitest will be reset after
  environment is restarted.
* Fix an issue that `ProcessRunnerTest` & `PyTest` & `PyUnit` have no
  "reset env" button on interactive UI.
* Fix an issue that when "reset env" button is inactive, click event
  should be ignored and no action taken.
* Fix an issue that description of Testplan is missing.
* Fix an potential bug in interactive testcase (test_api).


## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [x] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
