### PR TITLE
Skip test for GTest and Cppunit on Windows

### DIFF
--- a/tests/functional/testplan/testing/cpp/test_cppunit.py
+++ b/tests/functional/testplan/testing/cpp/test_cppunit.py
@@ -64,6 +64,7 @@ def test_cppunit(mockplan, binary_dir, expected_report, report_status):
     assert mockplan.report.status == report_status
 
 
+@skip_on_windows(reason="Cppunit is skipped on Windows.")
 def test_cppunit_no_report(mockplan):
 
     binary_path = os.path.join(fixture_root, "error", "runTests.sh")

--- a/tests/functional/testplan/testing/cpp/test_gtest.py
+++ b/tests/functional/testplan/testing/cpp/test_gtest.py
@@ -66,6 +66,7 @@ def test_gtest(mockplan, binary_dir, expected_report, report_status):
     assert mockplan.report.status == report_status
 
 
+@skip_on_windows(reason="GTest is skipped on Windows.")
 def test_gtest_no_report(mockplan):
 
     binary_path = os.path.join(fixture_root, "error", "runTests.sh")


### PR DESCRIPTION
* forget that `skip_on_windows` decorator, add it.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
