### PR TITLE
Add label for grouping test reports.

### DIFF
--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -313,6 +313,12 @@ that match ALL of the given tags.
             help="Specify log level for file logs. Set to None to disable "
             "file logging.",
         )
+        report_group.add_argument(
+            "--label",
+            default=None,
+            help="Label the test report with the given name, "
+            'useful to categorize or classify similar reports (aka "run-id").',
+        )
 
         self.add_arguments(parser)
         return parser

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -450,10 +450,12 @@ class TestReport(BaseReportGroup):
         attachments=None,
         information=None,
         timeout=None,
+        label=None,
         **kwargs
     ):
         self._tags_index = None
         self.meta = meta or {}
+        self.label = label
         self.information = information or []
         try:
             user = getpass.getuser()
@@ -468,6 +470,8 @@ class TestReport(BaseReportGroup):
                 ("python_version", platform.python_version()),
             ]
         )
+        if self.label:
+            self.information.append(("label", label))
 
         # Report attachments: Dict[dst: str, src: str].
         # Maps from destination path (relative from attachments root dir)

--- a/testplan/report/testing/schemas.py
+++ b/testplan/report/testing/schemas.py
@@ -188,6 +188,7 @@ class TestReportSchema(Schema):
     category = fields.String(dump_only=True)
     timer = TimerField(required=True)
     meta = fields.Dict()
+    label = fields.String(allow_none=True)
 
     status = fields.String(dump_only=True)
     runtime_status = fields.String(dump_only=True)

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -154,6 +154,7 @@ class TestRunnerConfig(RunnableConfig):
                 "interactive_handler", default=TestRunnerIHandler
             ): object,
             ConfigOption("extra_deps", default=[]): list,
+            ConfigOption("label", default=None): Or(None, str),
         }
 
 
@@ -288,6 +289,7 @@ class TestRunner(Runnable):
             description=self.cfg.description,
             uid=self.cfg.name,
             timeout=self.cfg.timeout,
+            label=self.cfg.label,
         )
         self._exporters = None
         self._web_server_thread = None

--- a/tests/functional/testplan/testing/test_label.py
+++ b/tests/functional/testplan/testing/test_label.py
@@ -1,0 +1,28 @@
+from testplan.common.utils.testing import (
+    log_propagation_disabled,
+)
+from testplan import TestplanMock
+from testplan.testing.multitest import MultiTest, testsuite, testcase
+from testplan.common.utils.logger import TESTPLAN_LOGGER
+
+
+@testsuite
+class AlphaSuite(object):
+    @testcase
+    def test_pass(self, env, result):
+        result.true(True)
+
+
+def test_label():
+    mockplan = TestplanMock(name="test_label", label="my_label")
+
+    multitest = MultiTest(
+        name="MyMultitest",
+        suites=[AlphaSuite()],
+    )
+    mockplan.add(multitest)
+
+    with log_propagation_disabled(TESTPLAN_LOGGER):
+        mockplan.run()
+
+    assert mockplan.report.label == "my_label"


### PR DESCRIPTION
## Bug / Requirement Description
Add an attribute in report, useful to categorize or classify similar report

## Solution description
* Add --label command line option
* Save label in JSON report


## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
