### PR TITLE
Remove _BYTES_KEY and fix ag-grid cannot display bytes issue.

### DIFF
--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/dictAssertionUtils.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/dictAssertionUtils.js
@@ -217,6 +217,29 @@ export function prepareDictColumnDefs(cellStyle, cellRenderer, hasExpected) {
   return columnDefs;
 }
 
+
+/**
+ * Convert _BYTES_KEY type object to string
+ * We will remove this backward-compat code in future.
+ *
+ * @param {object} value - Result of the object as a built-in type or _BYTES_KEY
+ * @returns {String}
+ * @private
+ */
+function formatBytesKeyValue(value) {
+  if (typeof value === 'object') {
+    if (value['_BYTES_KEY']) {
+      return String(value['_BYTES_KEY']);
+    } else {
+      console.log("Cannot format unknown type!");
+      console.log(value);
+      return String(value);
+    }
+  }
+  return value;
+}
+
+
 /**
  * Prepare the rows for Dict/FixMatch assertions.
  *
@@ -262,11 +285,14 @@ export function prepareDictRowData(data, lineNo) {
     } else {
       lineObject.key = { value: key, type: 'key' };
       if (hasAcutalValue) {
-        lineObject.value = { value: actualValue[1], type: actualValue[0] };
+        lineObject.value = {
+          value: formatBytesKeyValue(actualValue[1]),
+          type: actualValue[0]
+        };
       }
       if (hasExpectedValue) {
         lineObject.expected = {
-          value: expectedValue[1],
+          value: formatBytesKeyValue(expectedValue[1]),
           type: expectedValue[0]
         };
       }

--- a/tests/unit/testplan/report/test_testing.py
+++ b/tests/unit/testplan/report/test_testing.py
@@ -415,18 +415,17 @@ def test_report_json_binary_serialization(
     ).data
 
     j = json.loads(data)
-    bkey = EntriesField._BYTES_KEY
 
     # passing assertion
-    hx_1_1 = get_path(j, "entries.1.entries.0.entries.1.first")[bkey]
-    hx_1_2 = get_path(j, "entries.1.entries.0.entries.1.second")[bkey]
-    assert ["0xF2"] == hx_1_1 == hx_1_2
+    hx_1_1 = get_path(j, "entries.1.entries.0.entries.1.first")
+    hx_1_2 = get_path(j, "entries.1.entries.0.entries.1.second")
+    assert str(b"\xF2") == hx_1_1 == hx_1_2
 
     # failing assertion
-    hx_2_1 = get_path(j, "entries.1.entries.0.entries.2.first")[bkey]
-    hx_2_2 = get_path(j, "entries.1.entries.0.entries.2.second")[bkey]
-    assert ["0x00", "0xB1", "0xC1"] == hx_2_1
-    assert ["0x00", "0xB2", "0xC2"] == hx_2_2
+    hx_2_1 = get_path(j, "entries.1.entries.0.entries.2.first")
+    hx_2_2 = get_path(j, "entries.1.entries.0.entries.2.second")
+    assert str(b"\x00\xb1\xC1") == hx_2_1
+    assert str(b"\x00\xB2\xC2") == hx_2_2
 
     # dict.match the schema for that producing list of tuples
 
@@ -435,33 +434,13 @@ def test_report_json_binary_serialization(
     SECOND_INDEX = 4
 
     comps = get_path(j, "entries.1.entries.0.entries.3.comparison")
-    assert comps[0][KEY_INDEX][bkey] == EntriesField._binary_to_hex_list(
-        b"binarykey\xB1"
-    )
-    assert comps[1][FIRST_INDEX][1][bkey] == EntriesField._binary_to_hex_list(
-        b"binary value\xB1"
-    )
-    assert comps[1][SECOND_INDEX][1][bkey] == EntriesField._binary_to_hex_list(
-        b"binary value\xB1"
-    )
-    assert comps[3][FIRST_INDEX][1][bkey] == EntriesField._binary_to_hex_list(
-        b"binary\xB1"
-    )
-    assert comps[3][SECOND_INDEX][1][bkey] == EntriesField._binary_to_hex_list(
-        b"binary\xB1"
-    )
-    assert comps[7][FIRST_INDEX][1][bkey] == EntriesField._binary_to_hex_list(
-        b"binary\xB1"
-    )
-    assert comps[7][SECOND_INDEX][1][bkey] == EntriesField._binary_to_hex_list(
-        b"binary\xB1"
-    )
-
-    deserialized_report = test_plan_schema.loads(data).data
-    check_report(
-        actual=deserialized_report,
-        expected=dummy_test_plan_report_with_binary_asserts,
-    )
+    assert comps[0][KEY_INDEX] == str(b"binarykey\xB1")
+    assert comps[1][FIRST_INDEX][1] == str(b"binary value\xB1")
+    assert comps[1][SECOND_INDEX][1] == str(b"binary value\xB1")
+    assert comps[3][FIRST_INDEX][1] == str(b"binary\xB1")
+    assert comps[3][SECOND_INDEX][1] == str(b"binary\xB1")
+    assert comps[7][FIRST_INDEX][1] == str(b"binary\xB1")
+    assert comps[7][SECOND_INDEX][1] == str(b"binary\xB1")
 
 
 class TestReportTags(object):


### PR DESCRIPTION
## Bug / Requirement Description
ag-grid cannot display _BYTES_KEY object.

## Solution description
Remove _BYTES_KEY serialize in schema. Use string & bytes directly.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
