### PR TITLE
Fix several bugs in interactive mode

### DIFF
--- a/testplan/runnable/interactive/http.py
+++ b/testplan/runnable/interactive/http.py
@@ -111,7 +111,8 @@ def generate_interactive_api(ihandler):
     def execution_out_of_order(err):
         """Return a custom message and 200 status code."""
         return {
-            "errmsg": "{} Reset test report if necessary.".format(err)
+            "errmsg": "{} Restart runtime environment"
+            " to reset test report if necessary.".format(err)
         }, 200
 
     @api.route("/report")

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -166,7 +166,7 @@ class Test(Runnable):
         However subclasses may build larger tag indices
         by collecting tags from their children for example.
         """
-        return self.cfg.tags
+        return self.cfg.tags or {}
 
     def get_filter_levels(self):
         if not self.filter_levels:

--- a/testplan/web_ui/testing/src/Nav/InteractiveNavList.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNavList.js
@@ -23,7 +23,7 @@ const InteractiveNavList = (props) => {
         envStatus={entry.env_status}
         type={entry.category}
         caseCountPassed={entry.counter.passed}
-        caseCountFailed={entry.counter.failed}
+        caseCountFailed={entry.counter.failed + (entry.counter.error || 0)}
         handlePlayClick={(e) => props.handlePlayClick(e, entry)}
         envCtrlCallback={
           (e, action) => props.envCtrlCallback(e, entry, action)

--- a/testplan/web_ui/testing/src/Nav/NavBreadcrumbs.js
+++ b/testplan/web_ui/testing/src/Nav/NavBreadcrumbs.js
@@ -51,7 +51,7 @@ const createNavButtons = (props) => {
           status={entry.status}
           type={entry.category}
           caseCountPassed={entry.counter.passed}
-          caseCountFailed={entry.counter.failed}
+          caseCountFailed={entry.counter.failed + (entry.counter.error || 0)}
           executionTime={null}
           displayTime={false}
         />

--- a/testplan/web_ui/testing/src/Nav/NavList.js
+++ b/testplan/web_ui/testing/src/Nav/NavList.js
@@ -23,7 +23,7 @@ const NavList = (props) => {
           status={entry.status}
           type={entry.category}
           caseCountPassed={entry.counter.passed}
-          caseCountFailed={entry.counter.failed}
+          caseCountFailed={entry.counter.failed + (entry.counter.error || 0)}
           executionTime={executionTime}
           displayTime={props.displayTime}
         />

--- a/tests/functional/testplan/runnable/interactive/test_api.py
+++ b/tests/functional/testplan/runnable/interactive/test_api.py
@@ -913,7 +913,7 @@ def test_run_testcases_sequentially(plan2):
     testcase_json = rsp.json()
     assert (
         "errmsg" in testcase_json
-        and "Reset test report if necessary" in testcase_json["errmsg"]
+        and "reset test report if necessary" in testcase_json["errmsg"]
     )
 
     # Run the 3rd and 4th testcases sequentially again and this time it is OK
@@ -974,7 +974,7 @@ def test_run_testcases_sequentially(plan2):
     testcase_json = rsp.json()
     assert (
         "errmsg" in testcase_json
-        and "Reset test report if necessary" in testcase_json["errmsg"]
+        and "reset test report if necessary" in testcase_json["errmsg"]
     )
 
     # Run the 2nd and 3rd testcases sequentially in param group again
@@ -1011,7 +1011,7 @@ def test_run_testcases_sequentially(plan2):
     suite_json = rsp.json()
     assert (
         "errmsg" in suite_json
-        and "Reset test report if necessary" in suite_json["errmsg"]
+        and "reset test report if necessary" in suite_json["errmsg"]
     )
 
 


### PR DESCRIPTION
* Fix an issue that for general test other than Multitest, tags cannot
  be set in interactive mode.
* Fix an issue on interactive UI that only failed result is taken into
  counter but error result should also be taken.
* An improvement on warning message.
