### PR TITLE
Sort testcases without break down parametrization groups.

### DIFF
--- a/testplan/common/utils/testing.py
+++ b/testplan/common/utils/testing.py
@@ -280,12 +280,17 @@ def check_report_context(report, ctx):
 
         for suite_report, (suite_name, testcases) in zip(mt_report, suite_ctx):
             assert suite_report.name == suite_name
-            assert len(suite_report) == len(testcases), "{}, {}".format(
-                suite_report.entries, testcases
-            )
+            assert len(suite_report) == len(testcases)
 
-            for testcase_report, testcase_name in zip(suite_report, testcases):
-                assert testcase_report.name == testcase_name
+            for testcase_report, testcase_info in zip(suite_report, testcases):
+                if isinstance(testcase_info, tuple):
+                    param_group_name, param_testcases = testcase_info
+                    assert testcase_report.name == param_group_name
+                    assert [
+                        entry.name for entry in testcase_report.entries
+                    ] == param_testcases
+                else:
+                    assert testcase_report.name == testcase_info
 
 
 class XMLComparison(object):

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -292,7 +292,7 @@ class MultiTest(testing_base.Test):
             sorted_testcases = (
                 testcases
                 if getattr(suite, "strict_order", False)
-                else self.cfg.test_sorter.sorted_testcases(testcases)
+                else self.cfg.test_sorter.sorted_testcases(suite, testcases)
             )
 
             testcases_to_run = [

--- a/testplan/testing/multitest/suite.py
+++ b/testplan/testing/multitest/suite.py
@@ -452,6 +452,9 @@ def testsuite(*args, **kwargs):
         tags, or named tags, or multi-named tags.
     :type tags: ``str`` or ``tuple(str)`` or ``dict( str: str)`` or
         ``dict( str: tuple(str))`` or ``NoneType``
+    :param strict_order: Force testcases to run sequentially as they were
+        defined in test suite.
+    :type strict_order: ``bool``
     """
     return _selective_call(
         decorator_func=_testsuite,

--- a/testplan/testing/ordering.py
+++ b/testplan/testing/ordering.py
@@ -68,7 +68,7 @@ class BaseSorter(object):
     def sort_testsuites(self, testsuites):
         raise NotImplementedError
 
-    def sort_testcases(self, testcases):
+    def sort_testcases(self, testcases, param_groups=None):
         raise NotImplementedError
 
     def sorted_instances(self, instances):
@@ -81,9 +81,35 @@ class BaseSorter(object):
             return self.sort_testsuites(testsuites)
         return testsuites
 
-    def sorted_testcases(self, testcases):
+    def sorted_testcases(self, testsuite, testcases):
         if self.should_sort_testcases():
-            return self.sort_testcases(testcases)
+            test_methods, param_groups = [], {}
+            for testcase in testcases:
+                param_template = getattr(
+                    testcase, "_parametrization_template", None
+                )
+                if param_template:
+                    if param_template not in param_groups:
+                        test_methods.append(getattr(testsuite, param_template))
+                    param_groups.setdefault(param_template, []).append(
+                        testcase
+                    )
+                else:
+                    test_methods.append(testcase)
+
+            result = self.sort_testcases(test_methods, param_groups)
+            if isinstance(result, (tuple, list)):
+                sorted_test_methods, soted_param_groups = result
+            else:
+                sorted_test_methods, soted_param_groups = result, {}
+
+            testcases = []
+            for test_method in sorted_test_methods:
+                if getattr(test_method, "__parametrization_template__", False):
+                    testcases.extend(soted_param_groups[test_method.__name__])
+                else:
+                    testcases.append(test_method)
+
         return testcases
 
 
@@ -149,8 +175,12 @@ class ShuffleSorter(TypedSorter):
     def sort_testsuites(self, testsuites):
         return self.shuffle(testsuites)
 
-    def sort_testcases(self, testcases):
-        return self.shuffle(testcases)
+    def sort_testcases(self, testcases, param_groups=None):
+        param_groups = param_groups or {}
+        return self.shuffle(testcases), {
+            param_template: self.shuffle(testcases)
+            for param_template, testcases in param_groups.items()
+        }
 
 
 class AlphanumericSorter(TypedSorter):
@@ -162,5 +192,9 @@ class AlphanumericSorter(TypedSorter):
     def sort_testsuites(self, testsuites):
         return sorted(testsuites, key=operator.attrgetter("name"))
 
-    def sort_testcases(self, testcases):
-        return sorted(testcases, key=operator.attrgetter("name"))
+    def sort_testcases(self, testcases, param_groups=None):
+        param_groups = param_groups or {}
+        return sorted(testcases, key=operator.attrgetter("name")), {
+            param_template: sorted(testcases, key=operator.attrgetter("name"))
+            for param_template, testcases in param_groups.items()
+        }

--- a/tests/functional/testplan/testing/test_ordering.py
+++ b/tests/functional/testplan/testing/test_ordering.py
@@ -37,8 +37,16 @@ class Beta(object):
     def test_xxx(self, env, result):
         pass
 
+    @testcase(parameters=[0, 1])
+    def test_bbb(self, env, result, val):
+        pass
+
     @testcase
     def test_aaa(self, env, result):
+        pass
+
+    @testcase(parameters=[3, 2, 1])
+    def test_yyy(self, env, result, val):
         pass
 
 
@@ -52,7 +60,26 @@ class Beta(object):
                 (
                     "Multitest",
                     [
-                        ("Beta", ["test_ccc", "test_xxx", "test_aaa"]),
+                        (
+                            "Beta",
+                            [
+                                "test_ccc",
+                                "test_xxx",
+                                (
+                                    "test_bbb",
+                                    ["test_bbb <val=0>", "test_bbb <val=1>"],
+                                ),
+                                "test_aaa",
+                                (
+                                    "test_yyy",
+                                    [
+                                        "test_yyy <val=3>",
+                                        "test_yyy <val=2>",
+                                        "test_yyy <val=1>",
+                                    ],
+                                ),
+                            ],
+                        ),
                         ("Alpha", ["test_ccc", "test_bbb", "test_aaa"]),
                     ],
                 )
@@ -66,7 +93,31 @@ class Beta(object):
                     "Multitest",
                     [
                         ("Alpha", ["test_aaa", "test_bbb", "test_ccc"]),
-                        ("Beta", ["test_aaa", "test_ccc", "test_xxx"]),
+                        (
+                            "Beta",
+                            [
+                                "test_aaa",
+                                (
+                                    (
+                                        "test_bbb",
+                                        [
+                                            "test_bbb <val=0>",
+                                            "test_bbb <val=1>",
+                                        ],
+                                    )
+                                ),
+                                "test_ccc",
+                                "test_xxx",
+                                (
+                                    "test_yyy",
+                                    [
+                                        "test_yyy <val=1>",
+                                        "test_yyy <val=2>",
+                                        "test_yyy <val=3>",
+                                    ],
+                                ),
+                            ],
+                        ),
                     ],
                 )
             ],
@@ -78,7 +129,26 @@ class Beta(object):
                 (
                     "Multitest",
                     [
-                        ("Beta", ["test_aaa", "test_ccc", "test_xxx"]),
+                        (
+                            "Beta",
+                            [
+                                (
+                                    "test_yyy",
+                                    [
+                                        "test_yyy <val=1>",
+                                        "test_yyy <val=3>",
+                                        "test_yyy <val=2>",
+                                    ],
+                                ),
+                                "test_ccc",
+                                "test_aaa",
+                                "test_xxx",
+                                (
+                                    "test_bbb",
+                                    ["test_bbb <val=0>", "test_bbb <val=1>"],
+                                ),
+                            ],
+                        ),
                         ("Alpha", ["test_aaa", "test_ccc", "test_bbb"]),
                     ],
                 )
@@ -91,7 +161,26 @@ class Beta(object):
                 (
                     "Multitest",
                     [
-                        ("Beta", ["test_ccc", "test_xxx", "test_aaa"]),
+                        (
+                            "Beta",
+                            [
+                                "test_ccc",
+                                "test_xxx",
+                                (
+                                    "test_bbb",
+                                    ["test_bbb <val=0>", "test_bbb <val=1>"],
+                                ),
+                                "test_aaa",
+                                (
+                                    "test_yyy",
+                                    [
+                                        "test_yyy <val=3>",
+                                        "test_yyy <val=2>",
+                                        "test_yyy <val=1>",
+                                    ],
+                                ),
+                            ],
+                        ),
                         ("Alpha", ["test_ccc", "test_bbb", "test_aaa"]),
                     ],
                 )
@@ -104,7 +193,26 @@ class Beta(object):
                 (
                     "Multitest",
                     [
-                        ("Beta", ["test_aaa", "test_ccc", "test_xxx"]),
+                        (
+                            "Beta",
+                            [
+                                (
+                                    "test_yyy",
+                                    [
+                                        "test_yyy <val=1>",
+                                        "test_yyy <val=3>",
+                                        "test_yyy <val=2>",
+                                    ],
+                                ),
+                                "test_ccc",
+                                "test_aaa",
+                                "test_xxx",
+                                (
+                                    "test_bbb",
+                                    ["test_bbb <val=0>", "test_bbb <val=1>"],
+                                ),
+                            ],
+                        ),
                         ("Alpha", ["test_aaa", "test_ccc", "test_bbb"]),
                     ],
                 )
@@ -113,9 +221,9 @@ class Beta(object):
     ),
 )
 def test_programmatic_ordering(sorter, report_ctx):
-    multitest_x = MultiTest(name="Multitest", suites=[Beta(), Alpha()])
+    multitest = MultiTest(name="Multitest", suites=[Beta(), Alpha()])
     plan = TestplanMock(name="plan", test_sorter=sorter)
-    plan.add(multitest_x)
+    plan.add(multitest)
 
     with log_propagation_disabled(TESTPLAN_LOGGER):
         plan.run()
@@ -134,7 +242,26 @@ def test_programmatic_ordering(sorter, report_ctx):
                 (
                     "Multitest",
                     [
-                        ("Beta", ["test_ccc", "test_xxx", "test_aaa"]),
+                        (
+                            "Beta",
+                            [
+                                "test_ccc",
+                                "test_xxx",
+                                (
+                                    "test_bbb",
+                                    ["test_bbb <val=0>", "test_bbb <val=1>"],
+                                ),
+                                "test_aaa",
+                                (
+                                    "test_yyy",
+                                    [
+                                        "test_yyy <val=3>",
+                                        "test_yyy <val=2>",
+                                        "test_yyy <val=1>",
+                                    ],
+                                ),
+                            ],
+                        ),
                         ("Alpha", ["test_ccc", "test_bbb", "test_aaa"]),
                     ],
                 )
@@ -147,7 +274,26 @@ def test_programmatic_ordering(sorter, report_ctx):
                 (
                     "Multitest",
                     [
-                        ("Beta", ["test_aaa", "test_ccc", "test_xxx"]),
+                        (
+                            "Beta",
+                            [
+                                (
+                                    "test_yyy",
+                                    [
+                                        "test_yyy <val=1>",
+                                        "test_yyy <val=3>",
+                                        "test_yyy <val=2>",
+                                    ],
+                                ),
+                                "test_ccc",
+                                "test_aaa",
+                                "test_xxx",
+                                (
+                                    "test_bbb",
+                                    ["test_bbb <val=0>", "test_bbb <val=1>"],
+                                ),
+                            ],
+                        ),
                         ("Alpha", ["test_aaa", "test_ccc", "test_bbb"]),
                     ],
                 )
@@ -160,7 +306,26 @@ def test_programmatic_ordering(sorter, report_ctx):
                 (
                     "Multitest",
                     [
-                        ("Beta", ["test_aaa", "test_ccc", "test_xxx"]),
+                        (
+                            "Beta",
+                            [
+                                (
+                                    "test_yyy",
+                                    [
+                                        "test_yyy <val=1>",
+                                        "test_yyy <val=3>",
+                                        "test_yyy <val=2>",
+                                    ],
+                                ),
+                                "test_ccc",
+                                "test_aaa",
+                                "test_xxx",
+                                (
+                                    "test_bbb",
+                                    ["test_bbb <val=0>", "test_bbb <val=1>"],
+                                ),
+                            ],
+                        ),
                         ("Alpha", ["test_aaa", "test_ccc", "test_bbb"]),
                     ],
                 )
@@ -173,7 +338,26 @@ def test_programmatic_ordering(sorter, report_ctx):
                 (
                     "Multitest",
                     [
-                        ("Beta", ["test_ccc", "test_xxx", "test_aaa"]),
+                        (
+                            "Beta",
+                            [
+                                "test_ccc",
+                                "test_xxx",
+                                (
+                                    "test_bbb",
+                                    ["test_bbb <val=0>", "test_bbb <val=1>"],
+                                ),
+                                "test_aaa",
+                                (
+                                    "test_yyy",
+                                    [
+                                        "test_yyy <val=3>",
+                                        "test_yyy <val=2>",
+                                        "test_yyy <val=1>",
+                                    ],
+                                ),
+                            ],
+                        ),
                         ("Alpha", ["test_ccc", "test_bbb", "test_aaa"]),
                     ],
                 )
@@ -186,7 +370,26 @@ def test_programmatic_ordering(sorter, report_ctx):
                 (
                     "Multitest",
                     [
-                        ("Beta", ["test_aaa", "test_ccc", "test_xxx"]),
+                        (
+                            "Beta",
+                            [
+                                (
+                                    "test_yyy",
+                                    [
+                                        "test_yyy <val=1>",
+                                        "test_yyy <val=3>",
+                                        "test_yyy <val=2>",
+                                    ],
+                                ),
+                                "test_ccc",
+                                "test_aaa",
+                                "test_xxx",
+                                (
+                                    "test_bbb",
+                                    ["test_bbb <val=0>", "test_bbb <val=1>"],
+                                ),
+                            ],
+                        ),
                         ("Alpha", ["test_aaa", "test_ccc", "test_bbb"]),
                     ],
                 )
@@ -196,11 +399,11 @@ def test_programmatic_ordering(sorter, report_ctx):
 )
 def test_command_line_ordering(cmdline_args, report_ctx):
 
-    multitest_x = MultiTest(name="Multitest", suites=[Beta(), Alpha()])
+    multitest = MultiTest(name="Multitest", suites=[Beta(), Alpha()])
 
     with argv_overridden(*cmdline_args):
         plan = TestplanMock(name="plan", parse_cmdline=True)
-        plan.add(multitest_x)
+        plan.add(multitest)
 
         with log_propagation_disabled(TESTPLAN_LOGGER):
             plan.run()

--- a/tests/unit/testplan/testing/test_ordering.py
+++ b/tests/unit/testplan/testing/test_ordering.py
@@ -9,7 +9,7 @@ def test_noop_sorter():
     arr = [1, 2, 3, 4]
     assert arr == sorter.sorted_instances(arr)
     assert arr == sorter.sorted_testsuites(arr)
-    assert arr == sorter.sorted_testcases(arr)
+    assert arr == sorter.sorted_testcases(None, arr)
 
 
 @pytest.mark.parametrize(
@@ -61,7 +61,7 @@ class TestShuffleSorter(object):
         assert shuffled != arr
         assert sorter.sorted_instances(arr) == shuffled
         assert sorter.sorted_testsuites(arr) == shuffled
-        assert sorter.sorted_testcases(arr) == shuffled
+        assert sorter.sorted_testcases(None, arr) == shuffled
 
     @pytest.mark.parametrize(
         "shuffle_types, expected",
@@ -106,4 +106,4 @@ class TestShuffleSorter(object):
     def test_sorted_testcases(self, shuffle_types, expected):
         sorter = ordering.ShuffleSorter(seed=5, shuffle_type=shuffle_types)
         arr = [1, 2, 3, 4, 5]
-        assert expected == sorter.sorted_testcases(arr)
+        assert expected == sorter.sorted_testcases(None, arr)


### PR DESCRIPTION
* For example, a test suite have child [case1, param1, param2, case2],
  after shuffled this can be [case2, param2, case1, param1]. however
  the desired result should be [case2, param2, param1, case1], the
  testcases in the same param group should still be next to each other.
* this rule should also appplies to other kind or sorting, for example:
  alphanumeric sorting.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
