### PR TITLE
Use JSON5 to parse json which contains NaN value.

### DIFF
--- a/testplan/web_ui/testing/package.json
+++ b/testplan/web_ui/testing/package.json
@@ -24,6 +24,7 @@
     "date-fns": "^2.14.0",
     "eslint-plugin-react": "^7.14.3",
     "history": "~4.10.1",
+    "json5": "^2.2.0",
     "lodash": "~4.17.15",
     "pegjs": "^0.11.0-master.b7b87ea",
     "react": "16.13.1",

--- a/testplan/web_ui/testing/src/Common/utils.js
+++ b/testplan/web_ui/testing/src/Common/utils.js
@@ -2,6 +2,7 @@
  * Common utility functions.
  */
 import {NAV_ENTRY_DISPLAY_DATA} from "./defaults";
+import JSON5 from "json5";
 import _ from 'lodash';
 
 /**
@@ -173,4 +174,18 @@ export const toPlainObjectIn = (obj, enumerableOnly = false) => {
 
 export const joinURLComponent = (base, component) => {
   return `${base.replace(/\/+$/, '').trim()}/${component}`;
+};
+
+/**
+ * Parse JSON string to object by JSON5 https://json5.org/
+ * @param {string} data - The json string
+ * @returns {object}
+ */
+export const parseToJson = (data) => {
+  let result = data;
+  if (typeof data === 'string' && data.length) {
+    result = JSON5.parse(result);
+  }
+
+  return result;
 };

--- a/testplan/web_ui/testing/src/Report/BatchReport.js
+++ b/testplan/web_ui/testing/src/Report/BatchReport.js
@@ -3,6 +3,7 @@ import {StyleSheet, css} from 'aphrodite';
 import axios from 'axios';
 import PropTypes from 'prop-types';
 
+import { parseToJson } from "../Common/utils";
 import Toolbar from '../Toolbar/Toolbar';
 import {TimeButton} from '../Toolbar/Buttons';
 import Nav from '../Nav/Nav';
@@ -107,10 +108,12 @@ class BatchReport extends React.Component {
           const rawReport = response.data;
           if (rawReport.version === 2) {
             const assertionsReq = axios.get(
-              `/api/v1/reports/${uid}/attachments/${rawReport.assertions_file}`
+              `/api/v1/reports/${uid}/attachments/${rawReport.assertions_file}`,
+              {transformResponse: parseToJson}
             );
             const structureReq = axios.get(
-              `/api/v1/reports/${uid}/attachments/${rawReport.structure_file}`
+              `/api/v1/reports/${uid}/attachments/${rawReport.structure_file}`,
+              {transformResponse: parseToJson}
             );
             axios.all([assertionsReq, structureReq]).then(
               axios.spread((assertionsRes, structureRes) => {

--- a/testplan/web_ui/testing/src/Report/InteractiveReport.js
+++ b/testplan/web_ui/testing/src/Report/InteractiveReport.js
@@ -26,7 +26,10 @@ import {
   GetSelectedEntries,
   getSelectedUIDsFromPath,
 } from './reportUtils.js';
-import {encodeURIComponent2} from '../Common/utils';
+import {
+  encodeURIComponent2,
+  parseToJson
+} from '../Common/utils';
 
 import {POLL_MS} from '../Common/defaults.js';
 
@@ -96,8 +99,9 @@ class InteractiveReport extends React.Component {
         1500,
       );
     } else {
-      axios.get('/api/v1/interactive/report')
-        .then(response => {
+      axios.get('/api/v1/interactive/report',
+      {transformResponse: parseToJson}
+      ).then(response => {
           if (!this.state.report ||
             this.state.report.hash !== response.data.hash) {
             this.getTests().then(tests => {
@@ -118,7 +122,8 @@ class InteractiveReport extends React.Component {
    */
   getTests() {
     return axios.get(
-      "/api/v1/interactive/report/tests"
+      "/api/v1/interactive/report/tests",
+      {transformResponse: parseToJson}
     ).then(response => {
       return Promise.all(response.data.map(
         newTest => {
@@ -147,7 +152,8 @@ class InteractiveReport extends React.Component {
   getSuites(newTest, existingTest) {
     const encoded_test_uid = encodeURIComponent2(newTest.uid);
     return axios.get(
-      `/api/v1/interactive/report/tests/${encoded_test_uid}/suites`
+      `/api/v1/interactive/report/tests/${encoded_test_uid}/suites`,
+      {transformResponse: parseToJson}
     ).then(response => {
       return Promise.all(response.data.map(
         newSuite => {
@@ -176,7 +182,8 @@ class InteractiveReport extends React.Component {
     const encoded_suite_uid = encodeURIComponent2(newSuite.uid);
     return axios.get(
       `/api/v1/interactive/report/tests/${encoded_test_uid}/suites/` +
-      `${encoded_suite_uid}/testcases`
+      `${encoded_suite_uid}/testcases`,
+      {transformResponse: parseToJson}
     ).then(response => {
       return Promise.all(response.data.map((newTestCase) => {
         switch (newTestCase.category) {
@@ -221,7 +228,8 @@ class InteractiveReport extends React.Component {
     const encoded_testcase_uid = encodeURIComponent2(testcase.uid);
     return axios.get(
       `/api/v1/interactive/report/tests/${encoded_test_uid}/suites/` +
-      `${encoded_suite_uid}/testcases/${encoded_testcase_uid}/parametrizations`
+      `${encoded_suite_uid}/testcases/${encoded_testcase_uid}/parametrizations`,
+      {transformResponse: parseToJson}
     ).then(response => response.data);
   }
 


### PR DESCRIPTION
## Bug / Requirement Description
The JSON string  which generated by json.dumps in python will contain NaN. But chrome cannot parse it by JSON.parse.

## Solution description
Use JSON5 https://json5.org/

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
