### PR TITLE
Small improvement on  example runner

### DIFF
--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -4,8 +4,6 @@ This module encodes the argument and option names, types and behaviours.
 """
 import argparse
 import copy
-import os
-import random
 import sys
 
 from testplan.common.utils import logger

--- a/tests/helpers/example_runner.py
+++ b/tests/helpers/example_runner.py
@@ -1,8 +1,9 @@
+import sys
 import os
 import re
 import runpy
-import sys
-from traceback import format_exc
+import copy
+import traceback
 
 import pytest
 
@@ -16,47 +17,52 @@ SUCCES_EXIT_CODES = (
 )  # these considered as 0 return value and means success
 
 
-def run_example_in_process(filename, root, known_exceptions, cmdline_args=[]):
-    file_path = os.path.join(root, filename)
-    try:
+def run_example_in_process(
+    filename, root, known_exceptions, cmdline_args=None
+):
+    sys_path = copy.copy(sys.path)
+    sys_argv = copy.copy(sys.argv)
 
+    cmdline_args = cmdline_args or []
+    file_path = os.path.join(root, filename)
+    second_line = ""
+
+    try:
         # set up like an external invocation.
-        # add current dir to fron of sys path
+        # add current dir to front of sys.path
         # no arguments pass in command line
 
         sys.path.insert(0, root)
-        argv = sys.argv
-        sys.argv = [sys.argv[0], *cmdline_args]
+        sys.argv = [""] + cmdline_args
 
         with change_directory(root), open(filename) as file_obj:
             file_obj.readline()
-            second_line = file_obj.readline()
-
+            second_line = file_obj.readline().strip()
             runpy.run_path(os.path.join(root, filename), run_name="__main__")
 
     except SystemExit as e:
         if e.code not in SUCCES_EXIT_CODES:
             assert (
                 "# This plan contains tests that demonstrate failures as well."
-            ) == second_line.strip(), (
-                "Expected '{}' example to pass, it failed".format(file_path)
+            ) == second_line, (
+                'Expected "{}" example to pass, it failed'.format(file_path)
             )
     except Exception as e:
         for exception in known_exceptions:
             if re.search(exception, "{}: {}".format(type(e).__name__, str(e))):
                 pytest.xfail()
-        pytest.fail(format_exc())
+        pytest.fail(traceback.format_exc())
     finally:
         # clean up after execution
         # remove the modules imported from the directory of testplan_path
-        # remove the added toot from sys.path
+        # remove the added root from sys.path
         # reset the args as it was before execution
 
-        for m in get_local_modules(root):
-            del sys.modules[m]
+        for mod_name in get_local_modules(root):
+            del sys.modules[mod_name]
 
-        sys.path = sys.path[1:]
-        sys.argv = argv
+        sys.path = sys_path
+        sys.argv = sys_argv
 
 
 def get_local_modules(path_prefix):
@@ -67,9 +73,8 @@ def get_local_modules(path_prefix):
     :return:
     """
     return set(
-        n
-        for n, m in sys.modules.items()
-        if hasattr(m, "__file__")
-        and m.__file__
-        and m.__file__.startswith(path_prefix)
+        mod_name
+        for mod_name, module in sys.modules.items()
+        if getattr(module, "__file__", None)
+        and module.__file__.startswith(path_prefix)
     )


### PR DESCRIPTION
* Improve the code of example runner for running testplan examples
  which is also a part of CI: 1> Make sure that original command line
  argument and system path will not be changed during running script;
  2> Default argument should not be of mutable type; 3> Remove code
  that is unecessary; 4> fix typo.
