### PR TITLE
Increase yarn install timeout.

### DIFF
--- a/install-testplan-ui
+++ b/install-testplan-ui
@@ -94,7 +94,7 @@ def install_and_build_ui(path=TESTPLAN_UI_DIR, dev=False, verbose=False):
         logging.info("Installing Testplan UI dependencies...")
         logging.info("Installing to path: {}".format(os.path.abspath(path)))
         subprocess.check_call(
-            "yarn install {}".format(production_cmd),
+            "yarn install {} --network-timeout 600000".format(production_cmd),
             shell=True,
             cwd=path,
             stdout=output,


### PR DESCRIPTION
Increase yarn network timeout to avoid " There appears to be trouble with your network connection. Retrying..." issue.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
