### PR TITLE
Fix an issue that --tags cannot work well in interactive mode

### DIFF
--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -473,12 +473,6 @@ class ProcessRunnerTest(Test):
     def report_path(self):
         return os.path.join(self._runpath, "report.xml")
 
-    @property
-    def test_context(self):
-        if self._test_context is None:
-            self._test_context = self.get_test_context()
-        return self._test_context
-
     def test_command(self):
         """
         Override this to add extra options to the test command.


### PR DESCRIPTION
* In interactive mode, the server receives request from client and
  creates a pattern filter based on testsuite & testcases names, but
  this filter should be applied after the filters of test runner is
  applied, otherwise some unwanted testcases will be executed.
* Use `test_context` property instead of calling `get_test_contest`
  method as much as possible for performance.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
