### PR TITLE
Interactive UI: Show runtime status in real time and bug fix

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -9,7 +9,6 @@ import signal
 import time
 import threading
 import psutil
-import functools
 from collections import deque, OrderedDict
 import traceback
 
@@ -1183,7 +1182,8 @@ class RunnableManager(Entity):
                 signal.signal(sig, self._handle_abort)
         except ValueError:
             self.logger.warning(
-                "Not able to install signal handler - signal only works in main thread"
+                "Not able to install signal handler -"
+                " signal only works in main thread"
             )
 
         execute_as_thread(

--- a/testplan/common/report/base.py
+++ b/testplan/common/report/base.py
@@ -256,6 +256,18 @@ class ReportGroup(Report):
                 if isinstance(child, ReportGroup):
                     child.build_index(recursive=recursive)
 
+    def get_by_uids(self, uids):
+        """
+        Get child report via a series of `uid` lookup.
+
+        :param uids: A `uid` for the child report.
+        :type uids: ``list`` of ``hashable``
+        """
+        report = self
+        for uid in uids:
+            report = report.get_by_uid(uid)
+        return report
+
     def get_by_uid(self, uid):
         """
         Get child report via `uid` lookup.

--- a/testplan/testing/multitest/suite.py
+++ b/testplan/testing/multitest/suite.py
@@ -144,6 +144,9 @@ def get_testsuite_name(suite):
             "Test suite object contains colon in name: {}".format(suite.name)
         )
 
+    import types
+
+    suite.uid = types.MethodType(lambda self: self.name, suite)
     return suite.name
 
 
@@ -372,7 +375,6 @@ def _testsuite(klass):
         getattr(klass, func_name).strict_order = klass.strict_order
 
     klass.get_testcases = get_testcase_methods
-    testcase_methods = get_testcase_methods(klass)
 
     # propagate suite's native tags onto itself, which
     # will propagate them further to the suite's testcases
@@ -382,7 +384,7 @@ def _testsuite(klass):
     update_tag_index(
         obj=klass,
         tag_dict=tagging.merge_tag_dicts(
-            *[tc.__tags_index__ for tc in testcase_methods]
+            *[tc.__tags_index__ for tc in get_testcase_methods(klass)]
         ),
     )
 
@@ -454,7 +456,14 @@ def testsuite(*args, **kwargs):
 
 def _validate_function_name(func):
     """Validate the function name is valid for a testcase."""
-    reserved_words = ("name", "get_testcases", "pre_testcase", "post_testcase")
+    reserved_words = (
+        "name",
+        "get_testcases",
+        "setup",
+        "teardown",
+        "pre_testcase",
+        "post_testcase",
+    )
     errmsg = None
 
     if (

--- a/testplan/web_ui/testing/src/Common/defaults.js
+++ b/testplan/web_ui/testing/src/Common/defaults.js
@@ -125,8 +125,11 @@ const STATUS_CATEGORY = {
 
 const RUNTIME_STATUS = [
   'ready',
+  'waiting',
   'running',
+  'resetting',
   'finished',
+  'not_run',
 ];
 
 const NAV_ENTRY_ACTIONS = [

--- a/testplan/web_ui/testing/src/Nav/InteractiveNav.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNav.js
@@ -46,6 +46,7 @@ const InteractiveNav = (props) => {
         displayTime={false}
         selectedUid={GetSelectedUid(props.selected)}
         handlePlayClick={props.handlePlayClick}
+        handleResetClick={props.handleResetClick}
         envCtrlCallback={props.envCtrlCallback}
         url={props.url}
       />

--- a/testplan/web_ui/testing/src/Nav/InteractiveNavList.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNavList.js
@@ -26,6 +26,7 @@ const InteractiveNavList = (props) => {
         caseCountPassed={entry.counter.passed}
         caseCountFailed={entry.counter.failed + (entry.counter.error || 0)}
         handlePlayClick={(e) => props.handlePlayClick(e, entry)}
+        handleResetClick={(e) => props.handleResetClick(e, entry)}
         envCtrlCallback={
           (e, action) => props.envCtrlCallback(e, entry, action)
         }

--- a/testplan/web_ui/testing/src/Nav/NavEntry.js
+++ b/testplan/web_ui/testing/src/Nav/NavEntry.js
@@ -39,6 +39,13 @@ const NavEntry = (props) => {
       className='d-flex justify-content-between align-items-center'
       style={{ height: "1.5em" }}
     >
+      <Badge
+        className={css(styles.entryIcon, styles[badgeStyle], styles.badge)}
+        title={props.type}
+        pill
+      >
+        {CATEGORY_ICONS[props.type]}
+      </Badge>
       <div
         className={css(styles.entryName, styles[STATUS_CATEGORY[props.status]])}
         title={props.description || props.name}
@@ -52,12 +59,6 @@ const NavEntry = (props) => {
           /
           <span className={css(styles.failed)}>{props.caseCountFailed}</span>
         </i>
-        <Badge
-          className={css(styles.entryIcon, styles[badgeStyle], styles.badge)}
-          title={props.type}
-          pill>
-          {CATEGORY_ICONS[props.type]}
-        </Badge>
       </div>
     </div>
   );

--- a/testplan/web_ui/testing/src/Nav/__tests__/InteractiveNavEntry.test.js
+++ b/testplan/web_ui/testing/src/Nav/__tests__/InteractiveNavEntry.test.js
@@ -54,6 +54,42 @@ describe('InteractiveNavEntry', () => {
     expect(renderedEntry).toMatchSnapshot();
   });
 
+  it('renders a testcase in "resetting" state', () => {
+    const renderedEntry = shallow(
+      <InteractiveNavEntry
+        name={'FakeTestcase'}
+        description={'TestCaseDesc'}
+        status={'unknown'}
+        runtime_status={'resetting'}
+        envStatus={null}
+        type={'testcase'}
+        caseCountPassed={0}
+        caseCountFailed={0}
+        handlePlayClick={() => undefined}
+        envCtrlCallback={null}
+      />
+    );
+    expect(renderedEntry).toMatchSnapshot();
+  });
+
+  it('renders a testcase in "waiting" state', () => {
+    const renderedEntry = shallow(
+      <InteractiveNavEntry
+        name={'FakeTestcase'}
+        description={'TestCaseDesc'}
+        status={'unknown'}
+        runtime_status={'waiting'}
+        envStatus={null}
+        type={'testcase'}
+        caseCountPassed={0}
+        caseCountFailed={0}
+        handlePlayClick={() => undefined}
+        envCtrlCallback={null}
+      />
+    );
+    expect(renderedEntry).toMatchSnapshot();
+  });
+
   it('renders a testcase in "passed" state', () => {
     const renderedEntry = shallow(
       <InteractiveNavEntry
@@ -83,6 +119,24 @@ describe('InteractiveNavEntry', () => {
         type={'testcase'}
         caseCountPassed={8}
         caseCountFailed={1}
+        handlePlayClick={() => undefined}
+        envCtrlCallback={null}
+      />
+    );
+    expect(renderedEntry).toMatchSnapshot();
+  });
+
+  it('renders a testcase in "not_run" state', () => {
+    const renderedEntry = shallow(
+      <InteractiveNavEntry
+        name={'FakeTestcase'}
+        description={'TestCaseDesc'}
+        status={'unknown'}
+        runtime_status={'not_run'}
+        envStatus={null}
+        type={'testcase'}
+        caseCountPassed={0}
+        caseCountFailed={0}
         handlePlayClick={() => undefined}
         envCtrlCallback={null}
       />
@@ -225,7 +279,7 @@ describe('InteractiveNavEntry', () => {
     // we need to additionally filter for the one which is the environment
     // controller - we do this by matching on the title text.
     const faIcons = renderedEntry.find(FontAwesomeIcon);
-    expect(faIcons).toHaveLength(2);
+    expect(faIcons).toHaveLength(3);
     faIcons.find({title: 'Start environment'}).simulate('click');
 
     // The callback should have been called once when the component was
@@ -257,7 +311,7 @@ describe('InteractiveNavEntry', () => {
     // we need to additionally filter for the one which is the environment
     // controller - we do this by matching on the title text.
     const faIcons = renderedEntry.find(FontAwesomeIcon);
-    expect(faIcons).toHaveLength(2);
+    expect(faIcons).toHaveLength(3);
     faIcons.find({title: 'Stop environment'}).simulate('click');
 
     // The callback should have been called once when the component was

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
@@ -9,8 +9,17 @@ exports[`InteractiveNavEntry renders a testcase in "failed" state 1`] = `
     }
   }
 >
+  <Badge
+    className="entryIcon_9gb3m5-o_O-failedBadge_1i8mqax"
+    color="secondary"
+    pill={true}
+    tag="span"
+    title="testcase"
+  >
+    C
+  </Badge>
   <div
-    className="entryName_1dd7qci-o_O-failed_11es5k7"
+    className="entryName_1wxvk90-o_O-failed_11es5k7"
     title="TestCaseDesc"
   >
     FakeTestcase
@@ -34,15 +43,84 @@ exports[`InteractiveNavEntry renders a testcase in "failed" state 1`] = `
         1
       </span>
     </i>
-    <Badge
-      className="entryIcon_9gb3m5-o_O-failedBadge_1i8mqax"
-      color="secondary"
-      pill={true}
-      tag="span"
-      title="testcase"
+    <FontAwesomeIcon
+      border={false}
+      className="entryButton_yr2g96"
+      fixedWidth={false}
+      flip={null}
+      icon={
+        Object {
+          "icon": Array [
+            512,
+            512,
+            Array [],
+            "f01e",
+            "M500.333 0h-47.411c-6.853 0-12.314 5.729-11.986 12.574l3.966 82.759C399.416 41.899 331.672 8 256.001 8 119.34 8 7.899 119.526 8 256.187 8.101 393.068 119.096 504 256 504c63.926 0 122.202-24.187 166.178-63.908 5.113-4.618 5.354-12.561.482-17.433l-33.971-33.971c-4.466-4.466-11.64-4.717-16.38-.543C341.308 415.448 300.606 432 256 432c-97.267 0-176-78.716-176-176 0-97.267 78.716-176 176-176 60.892 0 114.506 30.858 146.099 77.8l-101.525-4.865c-6.845-.328-12.574 5.133-12.574 11.986v47.411c0 6.627 5.373 12 12 12h200.333c6.627 0 12-5.373 12-12V12c0-6.627-5.373-12-12-12z",
+          ],
+          "iconName": "redo",
+          "prefix": "fas",
+        }
+      }
+      inverse={false}
+      listItem={false}
+      mask={null}
+      onClick={[Function]}
+      pull={null}
+      pulse={false}
+      rotation={null}
+      size={null}
+      spin={false}
+      symbol={false}
+      title="Run tests"
+      transform={null}
+    />
+  </div>
+</div>
+`;
+
+exports[`InteractiveNavEntry renders a testcase in "not_run" state 1`] = `
+<div
+  className="d-flex justify-content-between align-items-center"
+  style={
+    Object {
+      "height": "1.5em",
+    }
+  }
+>
+  <Badge
+    className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
+    color="secondary"
+    pill={true}
+    tag="span"
+    title="testcase"
+  >
+    C
+  </Badge>
+  <div
+    className="entryName_1wxvk90-o_O-unknown_1qg7pkz"
+    title="TestCaseDesc"
+  >
+    FakeTestcase
+  </div>
+  <div
+    className="entryIcons_195essn"
+  >
+    <i
+      className="entryIcon_9gb3m5"
+      title="passed/failed testcases"
     >
-      C
-    </Badge>
+      <span
+        className="passed_1kh4m98"
+      >
+        0
+      </span>
+      /
+      <span
+        className="failed_11es5k7"
+      >
+        0
+      </span>
+    </i>
     <FontAwesomeIcon
       border={false}
       className="entryButton_yr2g96"
@@ -87,8 +165,17 @@ exports[`InteractiveNavEntry renders a testcase in "passed" state 1`] = `
     }
   }
 >
+  <Badge
+    className="entryIcon_9gb3m5-o_O-passedBadge_1isorc2"
+    color="secondary"
+    pill={true}
+    tag="span"
+    title="testcase"
+  >
+    C
+  </Badge>
   <div
-    className="entryName_1dd7qci-o_O-passed_1kh4m98"
+    className="entryName_1wxvk90-o_O-passed_1kh4m98"
     title="TestCaseDesc"
   >
     FakeTestcase
@@ -112,15 +199,6 @@ exports[`InteractiveNavEntry renders a testcase in "passed" state 1`] = `
         0
       </span>
     </i>
-    <Badge
-      className="entryIcon_9gb3m5-o_O-passedBadge_1isorc2"
-      color="secondary"
-      pill={true}
-      tag="span"
-      title="testcase"
-    >
-      C
-    </Badge>
     <FontAwesomeIcon
       border={false}
       className="entryButton_yr2g96"
@@ -165,8 +243,17 @@ exports[`InteractiveNavEntry renders a testcase in "ready" state 1`] = `
     }
   }
 >
+  <Badge
+    className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
+    color="secondary"
+    pill={true}
+    tag="span"
+    title="testcase"
+  >
+    C
+  </Badge>
   <div
-    className="entryName_1dd7qci-o_O-unknown_1qg7pkz"
+    className="entryName_1wxvk90-o_O-unknown_1qg7pkz"
     title="TestCaseDesc"
   >
     FakeTestcase
@@ -190,15 +277,6 @@ exports[`InteractiveNavEntry renders a testcase in "ready" state 1`] = `
         0
       </span>
     </i>
-    <Badge
-      className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
-      color="secondary"
-      pill={true}
-      tag="span"
-      title="testcase"
-    >
-      C
-    </Badge>
     <FontAwesomeIcon
       border={false}
       className="entryButton_yr2g96"
@@ -234,7 +312,7 @@ exports[`InteractiveNavEntry renders a testcase in "ready" state 1`] = `
 </div>
 `;
 
-exports[`InteractiveNavEntry renders a testcase in "running" state 1`] = `
+exports[`InteractiveNavEntry renders a testcase in "resetting" state 1`] = `
 <div
   className="d-flex justify-content-between align-items-center"
   style={
@@ -243,8 +321,17 @@ exports[`InteractiveNavEntry renders a testcase in "running" state 1`] = `
     }
   }
 >
+  <Badge
+    className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
+    color="secondary"
+    pill={true}
+    tag="span"
+    title="testcase"
+  >
+    C
+  </Badge>
   <div
-    className="entryName_1dd7qci-o_O-unknown_1qg7pkz"
+    className="entryName_1wxvk90-o_O-unknown_1qg7pkz"
     title="TestCaseDesc"
   >
     FakeTestcase
@@ -268,15 +355,84 @@ exports[`InteractiveNavEntry renders a testcase in "running" state 1`] = `
         0
       </span>
     </i>
-    <Badge
-      className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
-      color="secondary"
-      pill={true}
-      tag="span"
-      title="testcase"
+    <FontAwesomeIcon
+      border={false}
+      className="inactiveEntryButton_klwly8"
+      fixedWidth={false}
+      flip={null}
+      icon={
+        Object {
+          "icon": Array [
+            512,
+            512,
+            Array [],
+            "f01e",
+            "M500.333 0h-47.411c-6.853 0-12.314 5.729-11.986 12.574l3.966 82.759C399.416 41.899 331.672 8 256.001 8 119.34 8 7.899 119.526 8 256.187 8.101 393.068 119.096 504 256 504c63.926 0 122.202-24.187 166.178-63.908 5.113-4.618 5.354-12.561.482-17.433l-33.971-33.971c-4.466-4.466-11.64-4.717-16.38-.543C341.308 415.448 300.606 432 256 432c-97.267 0-176-78.716-176-176 0-97.267 78.716-176 176-176 60.892 0 114.506 30.858 146.099 77.8l-101.525-4.865c-6.845-.328-12.574 5.133-12.574 11.986v47.411c0 6.627 5.373 12 12 12h200.333c6.627 0 12-5.373 12-12V12c0-6.627-5.373-12-12-12z",
+          ],
+          "iconName": "redo",
+          "prefix": "fas",
+        }
+      }
+      inverse={false}
+      listItem={false}
+      mask={null}
+      onClick={[Function]}
+      pull={null}
+      pulse={false}
+      rotation={null}
+      size={null}
+      spin={true}
+      symbol={false}
+      title="Resetting..."
+      transform={null}
+    />
+  </div>
+</div>
+`;
+
+exports[`InteractiveNavEntry renders a testcase in "running" state 1`] = `
+<div
+  className="d-flex justify-content-between align-items-center"
+  style={
+    Object {
+      "height": "1.5em",
+    }
+  }
+>
+  <Badge
+    className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
+    color="secondary"
+    pill={true}
+    tag="span"
+    title="testcase"
+  >
+    C
+  </Badge>
+  <div
+    className="entryName_1wxvk90-o_O-unknown_1qg7pkz"
+    title="TestCaseDesc"
+  >
+    FakeTestcase
+  </div>
+  <div
+    className="entryIcons_195essn"
+  >
+    <i
+      className="entryIcon_9gb3m5"
+      title="passed/failed testcases"
     >
-      C
-    </Badge>
+      <span
+        className="passed_1kh4m98"
+      >
+        0
+      </span>
+      /
+      <span
+        className="failed_11es5k7"
+      >
+        0
+      </span>
+    </i>
     <FontAwesomeIcon
       border={false}
       className="inactiveEntryButton_klwly8"
@@ -312,7 +468,7 @@ exports[`InteractiveNavEntry renders a testcase in "running" state 1`] = `
 </div>
 `;
 
-exports[`InteractiveNavEntry renders an entry with environment status STARTED 1`] = `
+exports[`InteractiveNavEntry renders a testcase in "waiting" state 1`] = `
 <div
   className="d-flex justify-content-between align-items-center"
   style={
@@ -321,8 +477,17 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTED 1`
     }
   }
 >
+  <Badge
+    className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
+    color="secondary"
+    pill={true}
+    tag="span"
+    title="testcase"
+  >
+    C
+  </Badge>
   <div
-    className="entryName_1dd7qci-o_O-unknown_1qg7pkz"
+    className="entryName_1wxvk90-o_O-unknown_1qg7pkz"
     title="TestCaseDesc"
   >
     FakeTestcase
@@ -346,15 +511,114 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTED 1`
         0
       </span>
     </i>
-    <Badge
-      className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
-      color="secondary"
-      pill={true}
-      tag="span"
-      title="multitest"
+    <FontAwesomeIcon
+      border={false}
+      className="inactiveEntryButton_klwly8"
+      fixedWidth={false}
+      flip={null}
+      icon={
+        Object {
+          "icon": Array [
+            384,
+            512,
+            Array [],
+            "f254",
+            "M360 64c13.255 0 24-10.745 24-24V24c0-13.255-10.745-24-24-24H24C10.745 0 0 10.745 0 24v16c0 13.255 10.745 24 24 24 0 90.965 51.016 167.734 120.842 192C75.016 280.266 24 357.035 24 448c-13.255 0-24 10.745-24 24v16c0 13.255 10.745 24 24 24h336c13.255 0 24-10.745 24-24v-16c0-13.255-10.745-24-24-24 0-90.965-51.016-167.734-120.842-192C308.984 231.734 360 154.965 360 64z",
+          ],
+          "iconName": "hourglass",
+          "prefix": "fas",
+        }
+      }
+      inverse={false}
+      listItem={false}
+      mask={null}
+      onClick={[Function]}
+      pull={null}
+      pulse={false}
+      rotation={null}
+      size={null}
+      spin={true}
+      symbol={false}
+      title="Waiting..."
+      transform={null}
+    />
+  </div>
+</div>
+`;
+
+exports[`InteractiveNavEntry renders an entry with environment status STARTED 1`] = `
+<div
+  className="d-flex justify-content-between align-items-center"
+  style={
+    Object {
+      "height": "1.5em",
+    }
+  }
+>
+  <Badge
+    className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
+    color="secondary"
+    pill={true}
+    tag="span"
+    title="multitest"
+  >
+    MT
+  </Badge>
+  <div
+    className="entryName_1wxvk90-o_O-unknown_1qg7pkz"
+    title="TestCaseDesc"
+  >
+    FakeTestcase
+  </div>
+  <div
+    className="entryIcons_195essn"
+  >
+    <i
+      className="entryIcon_9gb3m5"
+      title="passed/failed testcases"
     >
-      MT
-    </Badge>
+      <span
+        className="passed_1kh4m98"
+      >
+        0
+      </span>
+      /
+      <span
+        className="failed_11es5k7"
+      >
+        0
+      </span>
+    </i>
+    <FontAwesomeIcon
+      border={false}
+      className="entryButton_yr2g96"
+      fixedWidth={false}
+      flip={null}
+      icon={
+        Object {
+          "icon": Array [
+            512,
+            512,
+            Array [],
+            "f049",
+            "M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z",
+          ],
+          "iconName": "fast-backward",
+          "prefix": "fas",
+        }
+      }
+      inverse={false}
+      listItem={false}
+      mask={null}
+      pull={null}
+      pulse={false}
+      rotation={null}
+      size={null}
+      spin={false}
+      symbol={false}
+      title="Reset report"
+      transform={null}
+    />
     <FontAwesomeIcon
       border={false}
       className="entryButton_yr2g96"
@@ -430,8 +694,17 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTING 1
     }
   }
 >
+  <Badge
+    className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
+    color="secondary"
+    pill={true}
+    tag="span"
+    title="multitest"
+  >
+    MT
+  </Badge>
   <div
-    className="entryName_1dd7qci-o_O-unknown_1qg7pkz"
+    className="entryName_1wxvk90-o_O-unknown_1qg7pkz"
     title="TestCaseDesc"
   >
     FakeTestcase
@@ -455,15 +728,37 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTING 1
         0
       </span>
     </i>
-    <Badge
-      className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
-      color="secondary"
-      pill={true}
-      tag="span"
-      title="multitest"
-    >
-      MT
-    </Badge>
+    <FontAwesomeIcon
+      border={false}
+      className="inactiveEntryButton_klwly8"
+      fixedWidth={false}
+      flip={null}
+      icon={
+        Object {
+          "icon": Array [
+            512,
+            512,
+            Array [],
+            "f049",
+            "M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z",
+          ],
+          "iconName": "fast-backward",
+          "prefix": "fas",
+        }
+      }
+      inverse={false}
+      listItem={false}
+      mask={null}
+      onClick={[Function]}
+      pull={null}
+      pulse={false}
+      rotation={null}
+      size={null}
+      spin={false}
+      symbol={false}
+      title="Reset report"
+      transform={null}
+    />
     <FontAwesomeIcon
       border={false}
       className="inactiveEntryButton_klwly8"
@@ -497,7 +792,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTING 1
     />
     <FontAwesomeIcon
       border={false}
-      className="entryButton_yr2g96"
+      className="inactiveEntryButton_klwly8"
       fixedWidth={false}
       flip={null}
       icon={
@@ -539,8 +834,17 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPED 1`
     }
   }
 >
+  <Badge
+    className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
+    color="secondary"
+    pill={true}
+    tag="span"
+    title="multitest"
+  >
+    MT
+  </Badge>
   <div
-    className="entryName_1dd7qci-o_O-unknown_1qg7pkz"
+    className="entryName_1wxvk90-o_O-unknown_1qg7pkz"
     title="TestCaseDesc"
   >
     FakeTestcase
@@ -564,15 +868,36 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPED 1`
         0
       </span>
     </i>
-    <Badge
-      className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
-      color="secondary"
-      pill={true}
-      tag="span"
-      title="multitest"
-    >
-      MT
-    </Badge>
+    <FontAwesomeIcon
+      border={false}
+      className="entryButton_yr2g96"
+      fixedWidth={false}
+      flip={null}
+      icon={
+        Object {
+          "icon": Array [
+            512,
+            512,
+            Array [],
+            "f049",
+            "M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z",
+          ],
+          "iconName": "fast-backward",
+          "prefix": "fas",
+        }
+      }
+      inverse={false}
+      listItem={false}
+      mask={null}
+      pull={null}
+      pulse={false}
+      rotation={null}
+      size={null}
+      spin={false}
+      symbol={false}
+      title="Reset report"
+      transform={null}
+    />
     <FontAwesomeIcon
       border={false}
       className="entryButton_yr2g96"
@@ -648,8 +973,17 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPING 1
     }
   }
 >
+  <Badge
+    className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
+    color="secondary"
+    pill={true}
+    tag="span"
+    title="multitest"
+  >
+    MT
+  </Badge>
   <div
-    className="entryName_1dd7qci-o_O-unknown_1qg7pkz"
+    className="entryName_1wxvk90-o_O-unknown_1qg7pkz"
     title="TestCaseDesc"
   >
     FakeTestcase
@@ -673,15 +1007,37 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPING 1
         0
       </span>
     </i>
-    <Badge
-      className="entryIcon_9gb3m5-o_O-unknownBadge_y8uc99"
-      color="secondary"
-      pill={true}
-      tag="span"
-      title="multitest"
-    >
-      MT
-    </Badge>
+    <FontAwesomeIcon
+      border={false}
+      className="inactiveEntryButton_klwly8"
+      fixedWidth={false}
+      flip={null}
+      icon={
+        Object {
+          "icon": Array [
+            512,
+            512,
+            Array [],
+            "f049",
+            "M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z",
+          ],
+          "iconName": "fast-backward",
+          "prefix": "fas",
+        }
+      }
+      inverse={false}
+      listItem={false}
+      mask={null}
+      onClick={[Function]}
+      pull={null}
+      pulse={false}
+      rotation={null}
+      size={null}
+      spin={false}
+      symbol={false}
+      title="Reset report"
+      transform={null}
+    />
     <FontAwesomeIcon
       border={false}
       className="inactiveEntryButton_klwly8"
@@ -715,7 +1071,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPING 1
     />
     <FontAwesomeIcon
       border={false}
-      className="entryButton_yr2g96"
+      className="inactiveEntryButton_klwly8"
       fixedWidth={false}
       flip={null}
       icon={

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavList.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavList.test.js.snap
@@ -46,6 +46,7 @@ exports[`InteractiveNavList shallow renders and matches snapshot 1`] = `
         description="Interactive MTest Desc"
         envCtrlCallback={[Function]}
         handlePlayClick={[Function]}
+        handleResetClick={[Function]}
         key="bbb"
         name="Interactive MTest"
         runtime_status="ready"

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavEntry.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavEntry.test.js.snap
@@ -9,6 +9,15 @@ exports[`NavEntry shallow renders the correct HTML structure 1`] = `
     }
   }
 >
+  <Badge
+    className="entryIcon_9gb3m5-o_O-passedBadge_1isorc2-o_O-badge_1nusemj"
+    color="secondary"
+    pill={true}
+    tag="span"
+    title="testplan"
+  >
+    TP
+  </Badge>
   <div
     className="entryName_1dd7qci-o_O-passed_1kh4m98"
     title="entry description"
@@ -34,15 +43,6 @@ exports[`NavEntry shallow renders the correct HTML structure 1`] = `
         0
       </span>
     </i>
-    <Badge
-      className="entryIcon_9gb3m5-o_O-passedBadge_1isorc2-o_O-badge_1nusemj"
-      color="secondary"
-      pill={true}
-      tag="span"
-      title="testplan"
-    >
-      TP
-    </Badge>
   </div>
 </div>
 `;
@@ -56,6 +56,15 @@ exports[`NavEntry when prop status="failed" name div and Badge have correct styl
     }
   }
 >
+  <Badge
+    className="entryIcon_9gb3m5-o_O-failedBadge_1i8mqax-o_O-badge_1nusemj"
+    color="secondary"
+    pill={true}
+    tag="span"
+    title="testplan"
+  >
+    TP
+  </Badge>
   <div
     className="entryName_1dd7qci-o_O-failed_11es5k7"
     title="entry description"
@@ -81,15 +90,6 @@ exports[`NavEntry when prop status="failed" name div and Badge have correct styl
         0
       </span>
     </i>
-    <Badge
-      className="entryIcon_9gb3m5-o_O-failedBadge_1i8mqax-o_O-badge_1nusemj"
-      color="secondary"
-      pill={true}
-      tag="span"
-      title="testplan"
-    >
-      TP
-    </Badge>
   </div>
 </div>
 `;
@@ -103,6 +103,15 @@ exports[`NavEntry when prop status="xfail" name div and Badge have correct style
     }
   }
 >
+  <Badge
+    className="entryIcon_9gb3m5-o_O-unstableBadge_15sg10d-o_O-badge_1nusemj"
+    color="secondary"
+    pill={true}
+    tag="span"
+    title="testplan"
+  >
+    TP
+  </Badge>
   <div
     className="entryName_1dd7qci-o_O-unstable_eujaab"
     title="entry description"
@@ -128,15 +137,6 @@ exports[`NavEntry when prop status="xfail" name div and Badge have correct style
         0
       </span>
     </i>
-    <Badge
-      className="entryIcon_9gb3m5-o_O-unstableBadge_15sg10d-o_O-badge_1nusemj"
-      color="secondary"
-      pill={true}
-      tag="span"
-      title="testplan"
-    >
-      TP
-    </Badge>
   </div>
 </div>
 `;

--- a/testplan/web_ui/testing/src/Nav/navUtils.js
+++ b/testplan/web_ui/testing/src/Nav/navUtils.js
@@ -235,7 +235,10 @@ const GetInteractiveNavEntries = (selected) => {
     if (idx < testcaseEntries.length) {
       // at least one testcase is ready to run
       testcaseEntries[idx].action = (
-        testcaseEntries[idx].runtime_status === 'running' ? 'prohibit': 'play'
+        testcaseEntries[idx].runtime_status === 'running' ||
+        testcaseEntries[idx].runtime_status === 'resetting' ||
+        testcaseEntries[idx].runtime_status === 'waiting'
+          ? 'prohibit': 'play'
       );
       testcaseEntries.slice(idx + 1).forEach((entry) => {
         entry.action = 'prohibit';

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/InteractiveReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/InteractiveReport.test.js.snap
@@ -33,6 +33,7 @@ exports[`InteractiveReport Handles environment being started 1`] = `
     filter={null}
     handleColumnResizing={[Function]}
     handlePlayClick={[Function]}
+    handleResetClick={[Function]}
     navListWidth="28em"
     report={
       Object {
@@ -496,6 +497,7 @@ exports[`InteractiveReport Parially refreshes the report on update. 1`] = `
     filter={null}
     handleColumnResizing={[Function]}
     handlePlayClick={[Function]}
+    handleResetClick={[Function]}
     navListWidth="28em"
     report={
       Object {
@@ -795,6 +797,7 @@ exports[`InteractiveReport Updates testcase state 1`] = `
     filter={null}
     handleColumnResizing={[Function]}
     handlePlayClick={[Function]}
+    handleResetClick={[Function]}
     navListWidth="28em"
     report={
       Object {
@@ -1104,6 +1107,7 @@ exports[`InteractiveReport handles individual parametrizations being run 1`] = `
     filter={null}
     handleColumnResizing={[Function]}
     handlePlayClick={[Function]}
+    handleResetClick={[Function]}
     navListWidth="28em"
     report={
       Object {
@@ -1162,6 +1166,7 @@ exports[`InteractiveReport handles individual parametrizations being run 1`] = `
                         "counter": undefined,
                         "description": null,
                         "entries": Array [],
+                        "hash": undefined,
                         "logs": Array [],
                         "name": "ParametrizationName__val_1",
                         "name_type_index": Array [
@@ -1372,6 +1377,7 @@ exports[`InteractiveReport handles individual parametrizations being run 1`] = `
                           "counter": undefined,
                           "description": null,
                           "entries": Array [],
+                          "hash": undefined,
                           "logs": Array [],
                           "name": "ParametrizationName__val_1",
                           "name_type_index": Array [
@@ -1567,6 +1573,7 @@ exports[`InteractiveReport handles individual test suites being run 1`] = `
     filter={null}
     handleColumnResizing={[Function]}
     handlePlayClick={[Function]}
+    handleResetClick={[Function]}
     navListWidth="28em"
     report={
       Object {
@@ -2028,6 +2035,7 @@ exports[`InteractiveReport handles individual testcases being run 1`] = `
     filter={null}
     handleColumnResizing={[Function]}
     handlePlayClick={[Function]}
+    handleResetClick={[Function]}
     navListWidth="28em"
     report={
       Object {
@@ -2489,6 +2497,7 @@ exports[`InteractiveReport handles tests being run 1`] = `
     filter={null}
     handleColumnResizing={[Function]}
     handlePlayClick={[Function]}
+    handleResetClick={[Function]}
     navListWidth="28em"
     report={
       Object {

--- a/tests/functional/testplan/runnable/interactive/test_api.py
+++ b/tests/functional/testplan/runnable/interactive/test_api.py
@@ -6,10 +6,11 @@ import pytest
 import requests
 
 import testplan
-from testplan import report
 from testplan.testing import multitest
-from testplan.common.utils import timing
+from testplan.testing.multitest import driver
+from testplan.report import Status, RuntimeStatus
 from testplan.common import entity
+from testplan.common.utils import timing
 from testplan.exporters.testing import XMLExporter
 
 from tests.unit.testplan.runnable.interactive import test_api
@@ -88,8 +89,58 @@ def plan(tmpdir):
         plan.abort()
 
 
+class BadDriver(driver.Driver):
+    """Driver that cannot start de to exception raised."""
+
+    def __init__(self, name, **options):
+        super(BadDriver, self).__init__(name=name, **options)
+
+    def starting(self):
+        super(BadDriver, self).starting()
+        raise Exception("Failed to start with no reason")
+
+
+@pytest.fixture
+def plan2(tmpdir):
+    """Yield an interactive testplan."""
+
+    with mock.patch(
+        "testplan.runnable.interactive.reloader.ModuleReloader"
+    ) as MockReloader:
+        MockReloader.return_value = None
+
+        plan = testplan.TestplanMock(
+            name="InteractiveAPITest",
+            interactive_port=0,
+            interactive_block=False,
+            exporters=[XMLExporter(xml_dir=str(tmpdir / "xml_exporter"))],
+        )
+
+        logfile = tmpdir / "attached_log.txt"
+        logfile.write_text(
+            "This text will be written into the attached file.",
+            encoding="utf-8",
+        )
+
+        plan.add(
+            multitest.MultiTest(
+                name="BrokenMTest",
+                suites=[ExampleSuite(str(logfile))],
+                environment=[BadDriver(name="BadDriver")],
+            )
+        )
+        plan.run()
+        timing.wait(
+            lambda: plan.interactive.http_handler_info is not None,
+            300,
+            raise_on_timeout=True,
+        )
+        yield plan
+        plan.abort()
+
+
 @multitest.testsuite(strict_order=True)
-class ExampleSuite2(object):
+class StrictOrderSuite(object):
     """Example test suite."""
 
     def __init__(self, tmpfile):
@@ -124,7 +175,7 @@ class ExampleSuite2(object):
 
 
 @pytest.fixture
-def plan2(tmpdir):
+def plan3(tmpdir):
     """
     Yield an interactive testplan. It only has one multitest instance with
     one test suite whose `strict_order` attribute is enabled.
@@ -151,7 +202,7 @@ def plan2(tmpdir):
         plan.add(
             multitest.MultiTest(
                 name="ExampleMTest2",
-                suites=[ExampleSuite2(str(logfile))],
+                suites=[StrictOrderSuite(str(logfile))],
             )
         )
         plan.run()
@@ -561,18 +612,18 @@ EXPECTED_INITIAL_GET = [
 
 # Expected results of testcases.
 EXPECTED_TESTCASE_RESULTS = [
-    ("test_passes", "passed"),
-    ("test_fails", "failed"),
-    ("test_logs", "passed"),
-    ("test_attach", "passed"),
-    ("test_parametrized", "passed"),
+    ("test_passes", Status.PASSED, RuntimeStatus.FINISHED),
+    ("test_fails", Status.FAILED, RuntimeStatus.FINISHED),
+    ("test_logs", Status.PASSED, RuntimeStatus.FINISHED),
+    ("test_attach", Status.PASSED, RuntimeStatus.FINISHED),
+    ("test_parametrized", Status.PASSED, RuntimeStatus.FINISHED),
 ]
 
 # Expected results of parametrized testcases.
 EXPECTED_PARAM_TESTCASE_RESULTS = [
-    ("test_parametrized__val_1", "passed"),
-    ("test_parametrized__val_2", "passed"),
-    ("test_parametrized__val_3", "passed"),
+    ("test_parametrized__val_1", Status.PASSED, RuntimeStatus.FINISHED),
+    ("test_parametrized__val_2", Status.PASSED, RuntimeStatus.FINISHED),
+    ("test_parametrized__val_3", Status.PASSED, RuntimeStatus.FINISHED),
 ]
 
 
@@ -592,74 +643,6 @@ def test_initial_get(plan):
         )
         assert rsp.status_code == 200
         test_api.compare_json(rsp.json(), expected_json)
-
-
-def test_run_all_tests(plan):
-    """
-    Test running all tests.
-    """
-    host, port = plan.interactive.http_handler_info
-    assert host == "0.0.0.0"
-
-    report_url = "http://localhost:{}/api/v1/interactive/report".format(port)
-    rsp = requests.get(report_url)
-    assert rsp.status_code == 200
-    report_json = rsp.json()
-    last_hash = report_json["hash"]
-
-    # Trigger all tests to run by updating the report status to RUNNING
-    # and PUTting back the data.
-    report_json["runtime_status"] = report.RuntimeStatus.RUNNING
-    rsp = requests.put(report_url, json=report_json)
-    assert rsp.status_code == 200
-
-    updated_json = rsp.json()
-    test_api.compare_json(updated_json, report_json)
-    assert updated_json["hash"] != last_hash
-
-    timing.wait(
-        functools.partial(
-            _check_test_status, report_url, "failed", updated_json["hash"]
-        ),
-        interval=0.2,
-        timeout=60,
-        raise_on_timeout=True,
-    )
-
-    # After running all tests, check that we can retrieve the attached file.
-    _test_attachments(port)
-
-
-def test_run_mtest(plan):
-    """Test running a single MultiTest."""
-    host, port = plan.interactive.http_handler_info
-    assert host == "0.0.0.0"
-
-    mtest_url = (
-        "http://localhost:{}/api/v1/interactive/report/tests/"
-        "ExampleMTest".format(port)
-    )
-    rsp = requests.get(mtest_url)
-    assert rsp.status_code == 200
-    mtest_json = rsp.json()
-
-    # Trigger all tests to run by updating the report status to RUNNING
-    # and PUTting back the data.
-    mtest_json["runtime_status"] = report.RuntimeStatus.RUNNING
-    rsp = requests.put(mtest_url, json=mtest_json)
-    assert rsp.status_code == 200
-    updated_json = rsp.json()
-    test_api.compare_json(updated_json, mtest_json)
-    assert updated_json["hash"] != mtest_json["hash"]
-
-    timing.wait(
-        functools.partial(
-            _check_test_status, mtest_url, "failed", updated_json["hash"]
-        ),
-        interval=0.2,
-        timeout=60,
-        raise_on_timeout=True,
-    )
 
 
 def test_environment_control(plan):
@@ -721,6 +704,124 @@ def test_environment_control(plan):
     )
 
 
+def test_run_all_tests(plan):
+    """
+    Test running all tests.
+    """
+    host, port = plan.interactive.http_handler_info
+    assert host == "0.0.0.0"
+
+    report_url = "http://localhost:{}/api/v1/interactive/report".format(port)
+    rsp = requests.get(report_url)
+    assert rsp.status_code == 200
+    report_json = rsp.json()
+    last_hash = report_json["hash"]
+
+    # Trigger all tests to run by updating the report status to RUNNING
+    # and PUTting back the data.
+    report_json["runtime_status"] = RuntimeStatus.RUNNING
+    rsp = requests.put(report_url, json=report_json)
+    assert rsp.status_code == 200
+
+    updated_json = rsp.json()
+    assert updated_json["hash"] != last_hash
+    assert updated_json["runtime_status"] == RuntimeStatus.WAITING
+    test_api.compare_json(
+        updated_json, report_json, ignored_keys=["runtime_status"]
+    )
+
+    timing.wait(
+        functools.partial(
+            _check_test_status,
+            report_url,
+            Status.FAILED,
+            RuntimeStatus.FINISHED,
+            updated_json["hash"],
+        ),
+        interval=0.2,
+        timeout=60,
+        raise_on_timeout=True,
+    )
+
+    # After running all tests, check that we can retrieve the attached file.
+    _test_attachments(port)
+
+
+def test_run_and_reset_mtest(plan):
+    """Test running a single MultiTest and then reset the test report."""
+    host, port = plan.interactive.http_handler_info
+    assert host == "0.0.0.0"
+
+    mtest_url = (
+        "http://localhost:{}/api/v1/interactive/report/tests/"
+        "ExampleMTest".format(port)
+    )
+    rsp = requests.get(mtest_url)
+    assert rsp.status_code == 200
+    mtest_json = rsp.json()
+
+    # Trigger multitest to run by updating the report status to RUNNING
+    # and PUTting back the data.
+    mtest_json["runtime_status"] = RuntimeStatus.RUNNING
+    rsp = requests.put(mtest_url, json=mtest_json)
+    assert rsp.status_code == 200
+    updated_json = rsp.json()
+    assert updated_json["hash"] != mtest_json["hash"]
+    assert updated_json["runtime_status"] == RuntimeStatus.WAITING
+    test_api.compare_json(
+        updated_json, mtest_json, ignored_keys=["runtime_status"]
+    )
+
+    timing.wait(
+        functools.partial(
+            _check_test_status,
+            mtest_url,
+            Status.FAILED,
+            RuntimeStatus.FINISHED,
+            updated_json["hash"],
+        ),
+        interval=0.2,
+        timeout=60,
+        raise_on_timeout=True,
+    )
+
+    # Get the updated report
+    rsp = requests.get(mtest_url)
+    assert rsp.status_code == 200
+    mtest_json = rsp.json()
+
+    # Trigger multitest to run by updating the report status to RESETTING
+    # and PUTting back the data.
+    mtest_json["runtime_status"] = RuntimeStatus.RESETTING
+    rsp = requests.put(mtest_url, json=mtest_json)
+    assert rsp.status_code == 200
+    updated_json = rsp.json()
+    assert updated_json["hash"] != mtest_json["hash"]
+    assert updated_json["runtime_status"] == RuntimeStatus.WAITING
+    test_api.compare_json(
+        updated_json, mtest_json, ignored_keys=["runtime_status", "env_status"]
+    )
+
+    timing.wait(
+        functools.partial(
+            _check_test_status,
+            mtest_url,
+            Status.UNKNOWN,
+            RuntimeStatus.READY,
+            updated_json["hash"],
+        ),
+        interval=0.2,
+        timeout=60,
+        raise_on_timeout=True,
+    )
+
+    rsp = requests.get(mtest_url)
+    assert rsp.status_code == 200
+    mtest_json = rsp.json()
+    assert mtest_json["runtime_status"] == RuntimeStatus.READY
+    assert mtest_json["env_status"] == entity.ResourceStatus.STOPPED
+
+
 def test_run_suite(plan):
     """Test running a single test suite."""
     host, port = plan.interactive.http_handler_info
@@ -734,18 +835,25 @@ def test_run_suite(plan):
     assert rsp.status_code == 200
     suite_json = rsp.json()
 
-    # Trigger all tests to run by updating the report status to RUNNING
+    # Trigger test suite to run by updating the report status to RUNNING
     # and PUTting back the data.
-    suite_json["runtime_status"] = report.RuntimeStatus.RUNNING
+    suite_json["runtime_status"] = RuntimeStatus.RUNNING
     rsp = requests.put(suite_url, json=suite_json)
     assert rsp.status_code == 200
     updated_json = rsp.json()
-    test_api.compare_json(updated_json, suite_json)
     assert updated_json["hash"] != suite_json["hash"]
+    assert updated_json["runtime_status"] == RuntimeStatus.WAITING
+    test_api.compare_json(
+        updated_json, suite_json, ignored_keys=["runtime_status"]
+    )
 
     timing.wait(
         functools.partial(
-            _check_test_status, suite_url, "failed", updated_json["hash"]
+            _check_test_status,
+            suite_url,
+            Status.FAILED,
+            RuntimeStatus.FINISHED,
+            updated_json["hash"],
         ),
         interval=0.2,
         timeout=60,
@@ -758,7 +866,11 @@ def test_run_testcase(plan):
     host, port = plan.interactive.http_handler_info
     assert host == "0.0.0.0"
 
-    for testcase_name, expected_result in EXPECTED_TESTCASE_RESULTS:
+    for (
+        testcase_name,
+        expected_status,
+        expected_runtime_status,
+    ) in EXPECTED_TESTCASE_RESULTS:
         testcase_url = (
             "http://localhost:{port}/api/v1/interactive/report/tests/"
             "ExampleMTest/suites/ExampleSuite/testcases/{testcase}".format(
@@ -770,20 +882,70 @@ def test_run_testcase(plan):
         assert rsp.status_code == 200
         testcase_json = rsp.json()
 
-        # Trigger all tests to run by updating the report status to RUNNING
+        # Trigger testcase to run by updating the report status to RUNNING
         # and PUTting back the data.
-        testcase_json["runtime_status"] = report.RuntimeStatus.RUNNING
+        testcase_json["runtime_status"] = RuntimeStatus.RUNNING
         rsp = requests.put(testcase_url, json=testcase_json)
         assert rsp.status_code == 200
         updated_json = rsp.json()
-        test_api.compare_json(updated_json, testcase_json)
         assert updated_json["hash"] != testcase_json["hash"]
+        assert updated_json["runtime_status"] == RuntimeStatus.WAITING
+        test_api.compare_json(
+            updated_json, testcase_json, ignored_keys=["runtime_status"]
+        )
 
         timing.wait(
             functools.partial(
                 _check_test_status,
                 testcase_url,
-                expected_result,
+                expected_status,
+                expected_runtime_status,
+                updated_json["hash"],
+            ),
+            interval=0.2,
+            timeout=60,
+            raise_on_timeout=True,
+        )
+
+
+def test_run_param_testcase(plan):
+    """Test running a single parametrized testcase."""
+    host, port = plan.interactive.http_handler_info
+    assert host == "0.0.0.0"
+
+    for (
+        param_name,
+        expected_status,
+        expected_runtime_status,
+    ) in EXPECTED_PARAM_TESTCASE_RESULTS:
+        testcase_url = (
+            "http://localhost:{port}/api/v1/interactive/report/tests/"
+            "ExampleMTest/suites/ExampleSuite/testcases/test_parametrized/"
+            "parametrizations/{param}".format(port=port, param=param_name)
+        )
+
+        rsp = requests.get(testcase_url)
+        assert rsp.status_code == 200
+        testcase_json = rsp.json()
+
+        # Trigger testcase to run by updating the report status to RUNNING
+        # and PUTting back the data.
+        testcase_json["runtime_status"] = RuntimeStatus.RUNNING
+        rsp = requests.put(testcase_url, json=testcase_json)
+        assert rsp.status_code == 200
+        updated_json = rsp.json()
+        assert updated_json["hash"] != testcase_json["hash"]
+        assert updated_json["runtime_status"] == RuntimeStatus.WAITING
+        test_api.compare_json(
+            updated_json, testcase_json, ignored_keys=["runtime_status"]
+        )
+
+        timing.wait(
+            functools.partial(
+                _check_test_status,
+                testcase_url,
+                expected_status,
+                expected_runtime_status,
                 updated_json["hash"],
             ),
             interval=0.2,
@@ -793,6 +955,7 @@ def test_run_testcase(plan):
 
 
 def test_export_report(plan):
+    """Test exporting report."""
     host, port = plan.interactive.http_handler_info
     assert host == "0.0.0.0"
     export_url = (
@@ -812,70 +975,125 @@ def test_export_report(plan):
     assert len(result["history"]) == 1
 
 
-def test_run_param_testcase(plan):
-    """Test running a single parametrized testcase."""
-    host, port = plan.interactive.http_handler_info
+def test_cannot_start_environment(plan2):
+    """Test starting the environment but fails."""
+    host, port = plan2.interactive.http_handler_info
     assert host == "0.0.0.0"
 
-    for param_name, expected_result in EXPECTED_PARAM_TESTCASE_RESULTS:
-        testcase_url = (
-            "http://localhost:{port}/api/v1/interactive/report/tests/"
-            "ExampleMTest/suites/ExampleSuite/testcases/test_parametrized/"
-            "parametrizations/{param}".format(port=port, param=param_name)
-        )
+    mtest_url = (
+        "http://localhost:{}/api/v1/interactive/report/tests/"
+        "BrokenMTest".format(port)
+    )
+    rsp = requests.get(mtest_url)
+    assert rsp.status_code == 200
+    mtest_json = rsp.json()
 
-        rsp = requests.get(testcase_url)
-        assert rsp.status_code == 200
-        testcase_json = rsp.json()
+    # Trigger the environment to start by setting the env_status to STARTING
+    # and PUTting back the data.
+    mtest_json["env_status"] = entity.ResourceStatus.STARTING
+    rsp = requests.put(mtest_url, json=mtest_json)
+    assert rsp.status_code == 200
+    updated_json = rsp.json()
+    test_api.compare_json(updated_json, mtest_json)
+    assert updated_json["hash"] != mtest_json["hash"]
 
-        # Trigger all tests to run by updating the report status to RUNNING
-        # and PUTting back the data.
-        testcase_json["runtime_status"] = report.RuntimeStatus.RUNNING
-        rsp = requests.put(testcase_url, json=testcase_json)
-        assert rsp.status_code == 200
-        updated_json = rsp.json()
-        test_api.compare_json(updated_json, testcase_json)
-        assert updated_json["hash"] != testcase_json["hash"]
+    # Wait for the environment to become STOPPED.
+    timing.wait(
+        functools.partial(
+            _check_env_status,
+            mtest_url,
+            entity.ResourceStatus.STOPPED,
+            updated_json["hash"],
+        ),
+        interval=0.2,
+        timeout=60,
+        raise_on_timeout=True,
+    )
 
-        timing.wait(
-            functools.partial(
-                _check_test_status,
-                testcase_url,
-                expected_result,
-                updated_json["hash"],
-            ),
-            interval=0.2,
-            timeout=60,
-            raise_on_timeout=True,
-        )
+    # Check the error message
+    rsp = requests.get(mtest_url)
+    assert rsp.status_code == 200
+    mtest_json = rsp.json()
+    assert len(mtest_json["logs"]) == 1
+    assert "Failed to start with no reason" in mtest_json["logs"][0]["message"]
 
 
-def test_run_testcases_sequentially(plan2):
-    """Test running a single testcase."""
+def test_cannot_run_mtest(plan2):
+    """Test running a single MultiTest and then reset the test report."""
     host, port = plan2.interactive.http_handler_info
+    assert host == "0.0.0.0"
+
+    mtest_url = (
+        "http://localhost:{}/api/v1/interactive/report/tests/"
+        "BrokenMTest".format(port)
+    )
+    rsp = requests.get(mtest_url)
+    assert rsp.status_code == 200
+    mtest_json = rsp.json()
+
+    # Trigger multitest to run by updating the report status to RUNNING
+    # and PUTting back the data.
+    mtest_json["runtime_status"] = RuntimeStatus.RUNNING
+    rsp = requests.put(mtest_url, json=mtest_json)
+    assert rsp.status_code == 200
+    updated_json = rsp.json()
+    assert updated_json["hash"] != mtest_json["hash"]
+    assert updated_json["runtime_status"] == RuntimeStatus.WAITING
+    test_api.compare_json(
+        updated_json, mtest_json, ignored_keys=["runtime_status"]
+    )
+
+    timing.wait(
+        functools.partial(
+            _check_test_status,
+            mtest_url,
+            Status.ERROR,
+            RuntimeStatus.NOT_RUN,
+            updated_json["hash"],
+        ),
+        interval=0.2,
+        timeout=60,
+        raise_on_timeout=True,
+    )
+
+    # Check the error message
+    rsp = requests.get(mtest_url)
+    assert rsp.status_code == 200
+    mtest_json = rsp.json()
+    assert len(mtest_json["logs"]) == 1
+    assert "Failed to start with no reason" in mtest_json["logs"][0]["message"]
+
+
+def test_run_testcases_sequentially(plan3):
+    """Test running a single testcase."""
+    host, port = plan3.interactive.http_handler_info
     assert host == "0.0.0.0"
 
     suite_url = (
         "http://localhost:{}/api/v1/interactive/report/tests/"
-        "ExampleMTest2/suites/ExampleSuite2".format(port)
+        "ExampleMTest2/suites/StrictOrderSuite".format(port)
     )
     case_url = (
         "http://localhost:{port}/api/v1/interactive/report/tests/"
-        "ExampleMTest2/suites/ExampleSuite2/testcases/{testcase}"
+        "ExampleMTest2/suites/StrictOrderSuite/testcases/{testcase}"
     )
     param_case_url = (
         "http://localhost:{port}/api/v1/interactive/report/tests/"
-        "ExampleMTest2/suites/ExampleSuite2/testcases/test_parametrized/"
+        "ExampleMTest2/suites/StrictOrderSuite/testcases/test_parametrized/"
         "parametrizations/{param}"
     )
 
     # Run the 1st and 2nd testcases
-    for testcase_name, expected_result in EXPECTED_TESTCASE_RESULTS[:2]:
+    for (
+        testcase_name,
+        expected_status,
+        expected_runtime_status,
+    ) in EXPECTED_TESTCASE_RESULTS[:2]:
         testcase_url = case_url.format(port=port, testcase=testcase_name)
         rsp = requests.get(testcase_url)
         assert rsp.status_code == 200
         testcase_json = rsp.json()
-        testcase_json["runtime_status"] = report.RuntimeStatus.RUNNING
+        testcase_json["runtime_status"] = RuntimeStatus.RUNNING
         rsp = requests.put(testcase_url, json=testcase_json)
         assert rsp.status_code == 200
         updated_json = rsp.json()
@@ -884,7 +1102,8 @@ def test_run_testcases_sequentially(plan2):
             functools.partial(
                 _check_test_status,
                 testcase_url,
-                expected_result,
+                expected_status,
+                expected_runtime_status,
                 updated_json["hash"],
             ),
             interval=0.2,
@@ -893,12 +1112,12 @@ def test_run_testcases_sequentially(plan2):
         )
 
     # Skip the 3rd testcase and run the 4th, it is not allowed
-    testcase_name, expected_result = EXPECTED_TESTCASE_RESULTS[3]
+    testcase_name, _, _ = EXPECTED_TESTCASE_RESULTS[3]
     testcase_url = case_url.format(port=port, testcase=testcase_name)
     rsp = requests.get(testcase_url)
     assert rsp.status_code == 200
     testcase_json = rsp.json()
-    testcase_json["runtime_status"] = report.RuntimeStatus.RUNNING
+    testcase_json["runtime_status"] = RuntimeStatus.RUNNING
     rsp = requests.put(testcase_url, json=testcase_json)
     assert rsp.status_code == 200
     testcase_json = rsp.json()
@@ -908,12 +1127,16 @@ def test_run_testcases_sequentially(plan2):
     )
 
     # Run the 3rd and 4th testcases sequentially again and this time it is OK
-    for testcase_name, expected_result in EXPECTED_TESTCASE_RESULTS[2:4]:
+    for (
+        testcase_name,
+        expected_status,
+        expected_runtime_status,
+    ) in EXPECTED_TESTCASE_RESULTS[2:4]:
         testcase_url = case_url.format(port=port, testcase=testcase_name)
         rsp = requests.get(testcase_url)
         assert rsp.status_code == 200
         testcase_json = rsp.json()
-        testcase_json["runtime_status"] = report.RuntimeStatus.RUNNING
+        testcase_json["runtime_status"] = RuntimeStatus.RUNNING
         rsp = requests.put(testcase_url, json=testcase_json)
         assert rsp.status_code == 200
         updated_json = rsp.json()
@@ -922,7 +1145,8 @@ def test_run_testcases_sequentially(plan2):
             functools.partial(
                 _check_test_status,
                 testcase_url,
-                expected_result,
+                expected_status,
+                expected_runtime_status,
                 updated_json["hash"],
             ),
             interval=0.2,
@@ -931,12 +1155,16 @@ def test_run_testcases_sequentially(plan2):
         )
 
     # Run the 1st testcase in param group
-    for param_name, expected_result in EXPECTED_PARAM_TESTCASE_RESULTS[:1]:
+    for (
+        param_name,
+        expected_status,
+        expected_runtime_status,
+    ) in EXPECTED_PARAM_TESTCASE_RESULTS[:1]:
         testcase_url = param_case_url.format(port=port, param=param_name)
         rsp = requests.get(testcase_url)
         assert rsp.status_code == 200
         testcase_json = rsp.json()
-        testcase_json["runtime_status"] = report.RuntimeStatus.RUNNING
+        testcase_json["runtime_status"] = RuntimeStatus.RUNNING
         rsp = requests.put(testcase_url, json=testcase_json)
         assert rsp.status_code == 200
         updated_json = rsp.json()
@@ -945,7 +1173,8 @@ def test_run_testcases_sequentially(plan2):
             functools.partial(
                 _check_test_status,
                 testcase_url,
-                expected_result,
+                expected_status,
+                expected_runtime_status,
                 updated_json["hash"],
             ),
             interval=0.2,
@@ -954,12 +1183,16 @@ def test_run_testcases_sequentially(plan2):
         )
 
     # Skip the 2nd testcase in param group and run the 3rd, it is not allowed
-    param_name, expected_result = EXPECTED_PARAM_TESTCASE_RESULTS[2]
+    (
+        param_name,
+        expected_status,
+        expected_runtime_status,
+    ) = EXPECTED_PARAM_TESTCASE_RESULTS[2]
     testcase_url = param_case_url.format(port=port, param=param_name)
     rsp = requests.get(testcase_url)
     assert rsp.status_code == 200
     testcase_json = rsp.json()
-    testcase_json["runtime_status"] = report.RuntimeStatus.RUNNING
+    testcase_json["runtime_status"] = RuntimeStatus.RUNNING
     rsp = requests.put(testcase_url, json=testcase_json)
     assert rsp.status_code == 200
     testcase_json = rsp.json()
@@ -969,12 +1202,16 @@ def test_run_testcases_sequentially(plan2):
     )
 
     # Run the 2nd and 3rd testcases sequentially in param group again
-    for param_name, expected_result in EXPECTED_PARAM_TESTCASE_RESULTS[1:]:
+    for (
+        param_name,
+        expected_status,
+        expected_runtime_status,
+    ) in EXPECTED_PARAM_TESTCASE_RESULTS[1:]:
         testcase_url = param_case_url.format(port=port, param=param_name)
         rsp = requests.get(testcase_url)
         assert rsp.status_code == 200
         testcase_json = rsp.json()
-        testcase_json["runtime_status"] = report.RuntimeStatus.RUNNING
+        testcase_json["runtime_status"] = RuntimeStatus.RUNNING
         rsp = requests.put(testcase_url, json=testcase_json)
         assert rsp.status_code == 200
         updated_json = rsp.json()
@@ -983,7 +1220,8 @@ def test_run_testcases_sequentially(plan2):
             functools.partial(
                 _check_test_status,
                 testcase_url,
-                expected_result,
+                expected_status,
+                expected_runtime_status,
                 updated_json["hash"],
             ),
             interval=0.2,
@@ -996,7 +1234,7 @@ def test_run_testcases_sequentially(plan2):
     rsp = requests.get(suite_url.format(port))
     assert rsp.status_code == 200
     suite_json = rsp.json()
-    suite_json["runtime_status"] = report.RuntimeStatus.RUNNING
+    suite_json["runtime_status"] = RuntimeStatus.RUNNING
     rsp = requests.put(suite_url, json=suite_json)
     assert rsp.status_code == 200
     suite_json = rsp.json()
@@ -1031,7 +1269,9 @@ def _test_attachments(port):
     assert rsp.text == "This text will be written into the attached file."
 
 
-def _check_test_status(test_url, expected_status, last_hash):
+def _check_test_status(
+    test_url, expected_status, expected_runtime_status, last_hash
+):
     """
     Check the test status by polling the report resource. If the test is
     still running, return False. Otherwise assert that the status matches
@@ -1041,16 +1281,17 @@ def _check_test_status(test_url, expected_status, last_hash):
     assert rsp.status_code == 200
     report_json = rsp.json()
 
-    if (
-        report_json["runtime_status"] == report.RuntimeStatus.RUNNING
-        or report_json["runtime_status"] == report.RuntimeStatus.READY
+    if report_json["runtime_status"] in (
+        RuntimeStatus.RUNNING,
+        RuntimeStatus.RESETTING,
+        RuntimeStatus.WAITING,
     ):
         # when running a test entity, the whole test report can be reset by
         # `dry_run` and `runtime_status` is changed to "ready".
         return False
     else:
-        assert report_json["runtime_status"] == report.RuntimeStatus.FINISHED
         assert report_json["status"] == expected_status
+        assert report_json["runtime_status"] == expected_runtime_status
         assert report_json["hash"] != last_hash
         return True
 

--- a/tests/unit/testplan/runnable/interactive/test_irunner.py
+++ b/tests/unit/testplan/runnable/interactive/test_irunner.py
@@ -219,7 +219,7 @@ def test_environment_control(irunner, sync):
     start_results = irunner.start_test_resources("test_1", await_results=sync)
 
     # If the environment was started asynchronously, wait for all of the
-    # operations to copmlete before continuing.
+    # operations to complete before continuing.
     if not sync:
         start_results.result()
 

--- a/tests/unit/testplan/testing/multitest/test_multitest.py
+++ b/tests/unit/testplan/testing/multitest/test_multitest.py
@@ -285,17 +285,31 @@ def test_run_testcases_iter():
         thread_pool_size=3,
         **MTEST_DEFAULT_PARAMS
     )
+    mtest.dry_run()
 
     results = list(mtest.run_testcases_iter())
-    assert len(results) == 4
+    assert len(results) == 8
 
     testcase_report, parent_uids = results[0]
     assert parent_uids == ["MTest", "Suite"]
+    assert testcase_report.unknown
+    assert testcase_report.runtime_status == report.RuntimeStatus.RUNNING
+    assert len(testcase_report.entries) == 0
+
+    testcase_report, parent_uids = results[1]
+    assert parent_uids == ["MTest", "Suite"]
     _check_testcase_report(testcase_report)
 
-    for i, (testcase_report, parent_uids) in enumerate(results[1:]):
+    for i, (testcase_report, parent_uids) in enumerate(results[2:]):
         assert parent_uids == ["MTest", "Suite", "parametrized"]
-        _check_param_testcase_report(testcase_report, i)
+        if i % 2 == 0:
+            assert testcase_report.unknown
+            assert (
+                testcase_report.runtime_status == report.RuntimeStatus.RUNNING
+            )
+            assert len(testcase_report.entries) == 0
+        else:
+            _check_param_testcase_report(testcase_report, int(i / 2))
 
 
 def _check_parallel_testcase(testcase_report, i):


### PR DESCRIPTION
* In interactive mode, while executing a multitest or a test suite,
  all of the testcases on UI seems to be running, however there is
  only one testcase running. Add a new status "waiting" so that user
  can intuitively see the progress.
* A new reset button is added to clear the report (reset it to the
  initial state) for each test, since we have this new button, then
  restart environment will not clear the report.
* Fix a bug that no error handling for environment start/stop that
  test execution will not stop even withuot drivers.
* Add logs in shallow deserialized report that if any exception
  raised (e.g. during environment start/stop) error will be logged
  in test report which is marked as "error".
* If environment fails to start they all testcases pending there
  should have runtime status changed to "finished", however, without
  any assertion the testcase's status is "passed" by default, so a
  new status "not_run" is added, when runtime status changed from
  "waiting" to "not_run" the report status is still "unknown".
* While executing testcases on server side the mutex is occupied
  and the client side periodically sends request but pending there,
  all of the pending requests will be processed, that is a waste of
  time. Till the last GET request be processed then sends the next
  one after an interval.
* Put the Badge icon at the beginning of navigation entry just as
  that displayed in Breadcrumbs navigation.
* If testcase is running or waiting, or environment is starting or
  stopping, the navigation entry should not accept any click event
  any more, although the server side can handle it and return 400.
* Code refactor of interactive UI.
* Update testcases.


## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
