### PR TITLE
Add weight param to Task, to control scheduling.

### DIFF
--- a/examples/ExecutionPools/Process/tasks.py
+++ b/examples/ExecutionPools/Process/tasks.py
@@ -68,7 +68,6 @@ def make_multitest(index=0):
     Creates a new MultiTest that runs TCP connection tests.
     This will be created inside a process worker.
     """
-    print("Creating a MultiTest on process id {}.".format(os.getpid()))
     test = MultiTest(
         name="TCPMultiTest_{}".format(index),
         suites=[TCPTestsuite()],

--- a/examples/ExecutionPools/Remote/tasks.py
+++ b/examples/ExecutionPools/Remote/tasks.py
@@ -76,7 +76,6 @@ def make_multitest(index=0, files=None):
     Creates a new MultiTest that runs TCP connection tests.
     This will be created inside a remote worker.
     """
-    print("Creating a MultiTest on process id {}.".format(os.getpid()))
     test = MultiTest(
         name="TCPMultiTest_{}".format(index),
         suites=[TCPTestsuite(files)],

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -282,7 +282,8 @@ class TestRunner(Runnable):
 
     def __init__(self, **options):
         super(TestRunner, self).__init__(**options)
-        self._tests = OrderedDict()  # uid to resource
+        self._tests = OrderedDict()  # uid to resource, in definition order
+
         self._part_instance_names = set()  # name of Multitest part
         self._result.test_report = TestReport(
             name=self.cfg.name,

--- a/testplan/runners/base.py
+++ b/testplan/runners/base.py
@@ -78,6 +78,9 @@ class Executor(Resource):
         raise NotImplementedError()
 
     def _prepopulate_runnables(self):
+        # If we are to apply test_sorter, it would be here
+        # but it's not easy to implement a reasonable behavior
+        # as _input could be a mixture of runnable/task/callable
         self.ongoing = list(self._input.keys())
 
     def starting(self):

--- a/testplan/runners/pools/tasks/base.py
+++ b/testplan/runners/pools/tasks/base.py
@@ -62,10 +62,14 @@ class Task(object):
     :type kwargs: ``kwargs``
     :param uid: Task uid.
     :type uid: ``str``
-    :param rerun: Rerun the task up to user specified times unless it passes,
-        by default 0 (no rerun). To enable task rerun feature, this value can
-        be at most 3.
+    :param rerun: Rerun the task up to user specified times until it passes,
+        by default 0 (no rerun). To enable task rerun feature, set to positive
+        value no greater than 3.
     :type rerun: ``int``
+    :param weight: Affects task scheduling - the larger the weight, the sooner
+        task will be assigned to a worker. Default weight is 0, tasks with the
+        same weight will be scheduled in the order they are added.
+    :type weight: ``int``
     """
 
     MAX_RERUN_LIMIT = 3
@@ -79,6 +83,7 @@ class Task(object):
         kwargs=None,
         uid=None,
         rerun=0,
+        weight=0,
     ):
         self._target = target
         self._module = module
@@ -94,6 +99,7 @@ class Task(object):
         )
         self._assign_for_rerun = 0
         self._executors = OrderedDict()
+        self.priority = -weight
 
         if self._max_rerun_limit < 0:
             raise ValueError("Value of `rerun` cannot be negative.")

--- a/tests/functional/testplan/runners/pools/test_pool_base.py
+++ b/tests/functional/testplan/runners/pools/test_pool_base.py
@@ -30,42 +30,58 @@ def schedule_tests_to_pool(plan, pool, **pool_cfg):
     pool_name = pool.__name__
     pool = pool(name=pool_name, **pool_cfg)
     plan.add_resource(pool)
+    uids = []
 
     dirname = os.path.dirname(os.path.abspath(__file__))
 
     mtest1 = MultiTest(name="MTest1", suites=[MySuite()])
     mtest2 = MultiTest(name="MTest2", suites=[MySuite()])
-    uid1 = plan.schedule(target=mtest1, resource=pool_name)
-    uid2 = plan.schedule(Task(target=mtest2), resource=pool_name)
+    uids.append(plan.schedule(target=mtest1, weight=1, resource=pool_name))
 
-    task3 = Task(target=get_mtest, path=dirname, kwargs=dict(name=3))
-    uid3 = plan.schedule(task=task3, resource=pool_name)
+    uids.append(
+        plan.schedule(Task(target=mtest2, weight=2), resource=pool_name)
+    )
+
+    task3 = Task(target=get_mtest, path=dirname, kwargs=dict(name=3), weight=3)
+    uids.append(plan.schedule(task=task3, resource=pool_name))
 
     # Task schedule shortcut
-    uid4 = plan.schedule(
-        target="get_mtest",
-        module="func_pool_base_tasks",
-        path=dirname,
-        kwargs=dict(name=4),
-        resource=pool_name,
-    )
-    uid5 = plan.schedule(
-        Task(
+    uids.append(
+        plan.schedule(
             target="get_mtest",
             module="func_pool_base_tasks",
             path=dirname,
-            kwargs=dict(name=5),
-        ),
-        resource=pool_name,
+            kwargs=dict(name=4),
+            weight=4,
+            resource=pool_name,
+        )
+    )
+    uids.append(
+        plan.schedule(
+            Task(
+                target="get_mtest",
+                module="func_pool_base_tasks",
+                path=dirname,
+                kwargs=dict(name=5),
+                weight=5,
+            ),
+            resource=pool_name,
+        )
     )
 
     from .func_pool_base_tasks import get_mtest_imported
 
-    uid6 = plan.schedule(
-        Task(target=get_mtest_imported, kwargs=dict(name=6)),
-        resource=pool_name,
+    uids.append(
+        plan.schedule(
+            Task(target=get_mtest_imported, kwargs=dict(name=6), weight=6),
+            resource=pool_name,
+        )
     )
-    uid7 = plan.schedule(Task(target=get_mtest(name=7)), resource=pool_name)
+    uids.append(
+        plan.schedule(
+            Task(target=get_mtest(name=7), weight=7), resource=pool_name
+        )
+    )
 
     # with log_propagation_disabled(TESTPLAN_LOGGER):
     assert plan.run().run is True
@@ -73,17 +89,12 @@ def schedule_tests_to_pool(plan, pool, **pool_cfg):
     assert plan.report.passed is True
     assert plan.report.counter == {"passed": 7, "total": 7, "failed": 0}
 
-    names = sorted(["MTest{}".format(x) for x in range(1, 8)])
-    assert sorted([entry.name for entry in plan.report.entries]) == names
+    names = ["MTest{}".format(x) for x in range(1, 8)]
+    assert [entry.name for entry in plan.report.entries] == names
 
     assert isinstance(plan.report.serialize(), dict)
-    assert plan.result.test_results[uid1].report.name == "MTest1"
-    assert plan.result.test_results[uid2].report.name == "MTest2"
-    assert plan.result.test_results[uid3].report.name == "MTest3"
-    assert plan.result.test_results[uid4].report.name == "MTest4"
-    assert plan.result.test_results[uid5].report.name == "MTest5"
-    assert plan.result.test_results[uid6].report.name == "MTest6"
-    assert plan.result.test_results[uid7].report.name == "MTest7"
+    assert [plan.result.test_results[uid].report.name for uid in uids] == names
+    assert list(pool._executed_tests) == uids[::-1]
 
 
 def test_pool_basic(mockplan):

--- a/tests/functional/testplan/runners/pools/test_pool_process.py
+++ b/tests/functional/testplan/runners/pools/test_pool_process.py
@@ -178,16 +178,10 @@ def test_reassign_times_limit(mockplan):
     assert mockplan.report.counter["error"] == 1
 
 
-def test_custom_rerun_condition(mockplan):
-    """Force reschedule task X times to test logic."""
+def test_disable_rerun_in_pool(mockplan):
     pool_name = ProcessPool.__name__
     uid = "custom_task_uid"
     rerun_limit = 2
-
-    def custom_rerun(pool, task_result):
-        if task_result.task.reassign_cnt > task_result.task.rerun:
-            return False
-        return True
 
     pool_size = 4
     pool = ProcessPool(
@@ -197,8 +191,8 @@ def test_custom_rerun_condition(mockplan):
         heartbeats_miss_limit=2,
         max_active_loop_sleep=1,
         restart_count=0,
+        allow_task_rerun=False,
     )
-    pool.set_rerun_check(custom_rerun)
     pool_uid = mockplan.add_resource(pool)
 
     dirname = os.path.dirname(os.path.abspath(__file__))
@@ -229,7 +223,7 @@ def test_custom_rerun_condition(mockplan):
 
     assert res.success is True
     assert mockplan.report.status == Status.PASSED
-    assert pool.added_item(uid).reassign_cnt == rerun_limit
+    assert pool.added_item(uid).reassign_cnt == 0
 
 
 @pytest.mark.skip("Target is materialized before scheduling")


### PR DESCRIPTION
## Bug / Requirement Description
User would like to schedule the task in order different than definition order.

## Solution description
Task with higher weight will have higher priority to be scheduled to a worker by pool.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
