### PR TITLE
Fix a bug of Task rerun feature in Pool execution

### DIFF
--- a/tests/functional/testplan/runners/pools/test_task_rerun.py
+++ b/tests/functional/testplan/runners/pools/test_task_rerun.py
@@ -175,7 +175,7 @@ def test_task_rerun_in_thread_pool(mockplan):
         tempfile.gettempdir(), getpass.getuser(), "{}.tmp".format(uuid.uuid4())
     )
     task = Task(
-        target=make_multitest_1, path=directory, args=(tmp_file,), rerun=2
+        target=make_multitest_1, path=directory, args=(tmp_file,), rerun=3
     )
     uid = mockplan.schedule(task=task, resource=pool_name)
 


### PR DESCRIPTION
## Bug / Requirement Description
Bug: passed task will also rerun.

## Solution description
Check task result in task result handling

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
