### PR TITLE
Remove unused libraries from requirement

### DIFF
--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -1,8 +1,6 @@
 pytest
 py
 psutil
-six
-future
 setuptools
 schema
 pytz
@@ -10,15 +8,12 @@ lxml
 python-dateutil
 reportlab
 marshmallow==3.0.0b2
-mock
 termcolor
 colorama
-enum34; python_version < '3.4'
 pyzmq
 terminaltables
 pyparsing
 cycler
-functools32; python_version <= '2.7'
 requests>=2.4.3
 flask
 flask_restplus

--- a/tests/functional/testplan/runnable/interactive/test_api.py
+++ b/tests/functional/testplan/runnable/interactive/test_api.py
@@ -1,8 +1,8 @@
 """Functional tests for interactive HTTP API."""
 
-from mock import patch
 
 import functools
+from unittest import mock
 
 import pytest
 import requests
@@ -56,7 +56,7 @@ class ExampleSuite(object):
 def plan(tmpdir):
     """Yield an interactive testplan."""
 
-    with patch(
+    with mock.patch(
         "testplan.runnable.interactive.reloader.ModuleReloader"
     ) as MockReloader:
         MockReloader.return_value = None
@@ -132,7 +132,7 @@ def plan2(tmpdir):
     one test suite whose `strict_order` attribute is enabled.
     """
 
-    with patch(
+    with mock.patch(
         "testplan.runnable.interactive.reloader.ModuleReloader"
     ) as MockReloader:
         MockReloader.return_value = None


### PR DESCRIPTION
* The libraries for PY2/PY3 compatibility could be removed since
  we only support Python 3 now.
