### PR TITLE
Fail fast on app shutdown will fail only if no values were extracted

### DIFF
--- a/examples/App/Basic/echo.sh
+++ b/examples/App/Basic/echo.sh
@@ -1,2 +1,0 @@
-echo testplan
-read UNUSED

--- a/examples/App/Basic/test_plan.py
+++ b/examples/App/Basic/test_plan.py
@@ -23,7 +23,6 @@ class MyTestsuite(object):
         matcher = LogMatcher(log_path=env.echo.outpath)
         matched = matcher.match(re.compile(r"testplan"))
         result.true(matched, description="testplan in stdout")
-        env.echo.proc.stdin.write(b"finish\n")
 
 
 def after_stop_fn(env, result):
@@ -43,8 +42,8 @@ def main(plan):
             environment=[
                 App(
                     "echo",
-                    binary="echo.sh",
-                    shell=True,
+                    binary="/bin/echo",
+                    args=["testplan"],
                     stdout_regexps=[
                         re.compile(r"testplan")
                     ],  # argument inherited from Driver class

--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -291,11 +291,12 @@ class App(Driver):
     def started_check(self, timeout=None):
         def ensure_app_running_while_extracting_values():
             proc_result = self.proc.poll()
-            if proc_result is not None:
+            extract_values_result = self.extract_values()
+            if proc_result is not None and not extract_values_result:
                 raise RuntimeError(
                     f"App {self.name} has unexpectedly stopped with: {proc_result}"
                 )
-            return self.extract_values()
+            return extract_values_result
 
         wait(
             ensure_app_running_while_extracting_values,


### PR DESCRIPTION
## Bug / Requirement Description
When matching logs the test would fail when the app shutdown properly but quicker than the LogMatcher could match the logs.

## Solution description
Tests will fail if the app shutdown only if no logs were matched as well.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
