### PR TITLE
Fix testcases on windows

### DIFF
--- a/tests/functional/examples/test_examples.py
+++ b/tests/functional/examples/test_examples.py
@@ -51,6 +51,7 @@ SKIP_ON_WINDOWS = [
     os.path.join("Cpp", "HobbesTest", "test_plan.py"),
     os.path.join("Transports", "FIX", "test_plan.py"),
     os.path.join("App", "Basic", "test_plan.py"),
+    os.path.join("App", "Autostart", "test_plan.py"),
     os.path.join("JUnit", "test_plan.py"),
 ]
 

--- a/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
+++ b/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
@@ -88,6 +88,7 @@ def test_app_fail_fast_with_log_regex(runpath):
         name="myapp",
         binary="echo",
         args=["yes"],
+        shell=True,
         stderr_regexps=[re.compile(r".*no*")],
         status_wait_timeout=2,
         runpath=runpath,


### PR DESCRIPTION
## Bug / Requirement Description
echo is a shell builtin and cat not available so skip that testcase.

## Solution description
Fixed one of the tests and marked the other one to be skipped on Windows for now.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
