### PR TITLE
Quick fix for test_app for windows

### DIFF
--- a/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
+++ b/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
@@ -99,6 +99,8 @@ def test_app_fail_fast_with_log_regex(runpath):
         app.start()
         app.wait(app.STATUS.STARTED)
 
+    app.stop()
+
 
 def test_app_cwd(runpath):
     """Test working_dir usage."""


### PR DESCRIPTION
if exception is thrown from start, the app object still
holds the stderr and stdout files. Depends on timing of gc
runtest fixture cleanup may try to delete the file before it
is closed, which result an error on windows. Make sure we
stop the app which will close the files in the testcase.

## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
