### PR TITLE
Only one way of defining pre_testcase & post_testcase

### DIFF
--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -48,44 +48,57 @@ A MultiTest instance can be constructed from the following parameters:
       def a_testcase_method(self, env, result):
         ...
 
-   In addition suites can have setup() and teardown() methods. The setup method
-   will be executed on suite entry, prior to any testcase if present. The
-   teardown method will be executed on suite exit, after setup and all
-   ``@testcase``-decorated testcases have executed.
+  In addition suites can have ``setup`` and ``teardown`` methods. The ``setup``
+  method will be executed on suite entry, prior to any testcase if present.
+  The ``teardown`` method will be executed on suite exit, after setup and all
+  ``@testcase``-decorated testcases have executed.
 
-   Again, the signature of those methods is checked at import time, and must be
-   as follows:
+  Again, the signature of those methods is checked at import time, and must be
+  as follows:
 
-   .. code-block:: python
+  .. code-block:: python
 
-     def setup(self, env):
-         ...
+    def setup(self, env):
+        ...
 
-     def teardown(self, env):
-         ...
+    def teardown(self, env):
+        ...
 
-   The result object can be optionally used to perform logging and basic
-   assertions:
+  The result object can be optionally used to perform logging and basic
+  assertions:
 
-   .. code-block:: python
+  .. code-block:: python
 
-     def setup(self, env, result):
-         ...
+    def setup(self, env, result):
+        ...
 
-     def teardown(self, env, result):
-         ...
+    def teardown(self, env, result):
+        ...
 
-   To signal that either setup or teardown hasn't completed correctly, you must
-   raise an exception. Raising an exception in ``setup()`` will abort the
-   execution of the testsuite, raising one in ``teardown()`` will be logged in
-   the report but will not prevent the execution of the next testsuite.
+  To signal that either ``setup`` or ``teardown`` hasn't completed correctly,
+  you must raise an exception. Raising an exception in ``setup`` will abort
+  the execution of the testsuite, raising one in ``teardown`` will be logged
+  in the report but will not prevent the execution of the next testsuite.
 
-   The :py:func:`@testcase <testplan.testing.multitest.suite.testcase>` decorated
-   methods will execute in the order in which they are defined. If more than
-   one suite is passed, the suites will be executed in the order in which they
-   are placed in the list that is used to pass them to the constructor. To
-   change testsuite and testcase execution order, click
-   :ref:`here <ordering_tests>` .
+  Similarly suites can have ``pre_testcase`` and ``post_testcase`` methods.
+  The ``pre_testcase`` method is executed before each testcase runs, and the
+  ``post_testcase`` method is executed after each testcase finishes. Exceptions
+  raised in these methods will be logged in the report. Note that argument
+  ``name`` is populated with name of testcase.
+
+  .. code-block:: python
+
+    def pre_testcase(self, name, env, result):
+        pass
+
+    def post_testcase(self, name, env, result):
+        pass
+
+  The :py:func:`@testcase <testplan.testing.multitest.suite.testcase>` decorated
+  methods will execute in the order in which they are defined. If more than
+  one suite is passed, the suites will be executed in the order in which they
+  are placed in the list that is used to pass them to the constructor. To
+  change testsuite and testcase execution order, click :ref:`here <ordering_tests>`.
 
 * **Environment**: The environment is a list of
   :py:class:`drivers <testplan.testing.multitest.driver.base.Driver>`. Drivers are
@@ -997,15 +1010,23 @@ This is equivalent to declaring each method call explicitly:
 See the :ref:`addition_associativity <example_multitest_parametrization>` test
 in the downloadable example.
 
-If a :py:func:`pre_testcase <testplan.testing.multitest.suite.pre_testcase>`/
-:py:func:`post_testcase <testplan.testing.multitest.suite.post_testcase>` function is
-used along with parameterized testcases, then its arguments should contain
-``kwargs`` to access the parameters of the associated testcase.
+If a ``pre_testcase`` or ``post_testcase`` method is defined in test suite and
+used along with parameterized testcases, then it can have an extra argument
+named ``kwargs`` to access the parameters of the associated testcase, for non
+parameterized testcases an empty dictionary is passed for ``kwargs``.
 
 .. code-block:: python
 
-    # To be used in pre_testcase/post_testcase
-    def function(name, self, env, result, **kwargs):
+    @testcase(parameters=(("foo", "bar"), ("baz", "quz")))
+    def sample_test(self, env, result, x, y):
+        pass
+
+    def pre_testcase(name, self, env, result, kwargs):
+        result.log("Param 1 is {}".format(kwargs.get("x")))
+        result.log("Param 2 is {}".format(kwargs.get("y")))
+        ...
+
+    def post_testcase(name, self, env, result, kwargs):
         ...
 
 .. _parametrization_default_values:

--- a/examples/Multitest/Basic/Name Customization/test_plan.py
+++ b/examples/Multitest/Basic/Name Customization/test_plan.py
@@ -26,6 +26,13 @@ def case_name_func(func_name, kwargs):
 
 @testsuite(name="A Simple Suite")
 class SimpleSuite(object):
+    def pre_testcase(self, name, env, result, kwargs):
+        result.log('Before testcase "{}" run'.format(name))
+        result.log("Extra arguments: {}".format(kwargs))
+
+    def post_testcase(self, name, env, result, kwargs):
+        result.log('After testcase "{}" run'.format(name))
+
     @testcase(name="A simple testcase")
     def test_example(self, env, result):
         result.equal(
@@ -59,6 +66,12 @@ class SimpleSuite(object):
 class ComplicatedSuite(object):
     def __init__(self, val):
         self.val = val
+
+    def pre_testcase(self, name, env, result):
+        pass
+
+    def post_testcase(self, name, env, result):
+        pass
 
     @testcase(name="A testcase with one assertion")
     def test_less_than(self, env, result):

--- a/examples/Transports/ZMQ/zmq_publish_subscribe_connection.py
+++ b/examples/Transports/ZMQ/zmq_publish_subscribe_connection.py
@@ -10,7 +10,6 @@ from testplan.testing.multitest import MultiTest, testsuite, testcase
 from testplan.testing.multitest.driver.zmq import ZMQServer, ZMQClient
 
 from testplan.common.utils.context import context
-from testplan.testing.multitest.suite import post_testcase
 
 
 def after_start(env):
@@ -25,21 +24,19 @@ def after_start(env):
     time.sleep(1)
 
 
-def flush_clients(name, self, env, result):
-    env.client1.flush()
-    env.client2.flush()
-    # As above the sleep is to verify the clients have reconnected.
-    time.sleep(1)
-
-
-# The clients must be flushed after each test to remove any extra messages.
-# This would occur when running many_publish_one_subscribe before
-# one_publish_many_subscribe on client 2.
-@post_testcase(flush_clients)
 @testsuite
 class ZMQTestsuite(object):
     def setup(self, env):
         self.timeout = 5
+
+    # The clients must be flushed after each test to remove any extra messages.
+    # This would occur when running many_publish_one_subscribe before
+    # one_publish_many_subscribe on client 2.
+    def post_testcase(self, name, env, result):
+        env.client1.flush()
+        env.client2.flush()
+        # As above the sleep is to verify the clients have reconnected.
+        time.sleep(1)
 
     @testcase
     def many_publish_one_subscribe(self, env, result):

--- a/testplan/common/utils/interface.py
+++ b/testplan/common/utils/interface.py
@@ -60,7 +60,7 @@ class MethodSignature(object):
         :type rhs: :py:class:`MethodSignature`
 
         :return: True if self and rhs are equivalent, False otherwise
-        :rtype: C{bool}
+        :rtype: ``bool``
         """
         return (
             (self.name == rhs.name)

--- a/testplan/exporters/testing/http/__init__.py
+++ b/testplan/exporters/testing/http/__init__.py
@@ -66,7 +66,7 @@ class HTTPExporter(Exporter):
         response = None
         errmsg = ""
 
-        if data and (data.get("entries") or data.get("attachments")):
+        if data:
             headers = {"Content-Type": "application/json"}
             try:
                 response = requests.post(
@@ -80,8 +80,8 @@ class HTTPExporter(Exporter):
                 errmsg = "Failed to export to {}: {}".format(url, str(exp))
         else:
             errmsg = (
-                "Skipping exporting test report via http "
-                "for empty report: {}".format(data["name"])
+                "Skipping exporting test report via http for"
+                " empty report: {}".format(data.get("name") or "[UNKNOWN]")
             )
 
         return response, errmsg

--- a/tests/unit/testplan/testing/multitest/test_suite.py
+++ b/tests/unit/testplan/testing/multitest/test_suite.py
@@ -11,14 +11,14 @@ from testplan.testing.multitest import suite
 from testplan.testing import tagging
 
 
-def ptestcase(name, self, env, result, **kwargs):
-    pass
-
-
-@suite.pre_testcase(ptestcase)
-@suite.post_testcase(ptestcase)
 @suite.testsuite
 class MySuite1(object):
+    def pre_testcase(self, name, env, result):
+        pass
+
+    def post_testcase(self, name, env, result):
+        pass
+
     @suite.testcase
     def case1(self, env, result):
         pass
@@ -85,6 +85,8 @@ def test_basic_suites():
     cases = ("case1", "case2", "case3")
     assert tuple(mysuite.__testcases__) == cases
     assert tuple(mysuite.__skip__) == ("case2",)
+    assert "pre_testcase" not in mysuite.__testcases__
+    assert "post_testcase" not in mysuite.__testcases__
 
     for method in suite.get_testcase_methods(MySuite1):
         assert method.__name__ in cases


### PR DESCRIPTION
* remove the ``pre_testcase`` & ``post_testcase`` decorater since it
  brings extra complication. They should be defined as instance method
  like ``setup`` and ``teardown``.
* ``post_testcase`` must run even ``pre_testcase`` had raised.
* ``teardown`` must run even ``setup`` had failed.
* Update document and testcases.

## Checklist:
- [x] Test
- [x] Example (both test_plan.py and .rst)
- [x] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
