### PR TITLE
Fix: ProcessRunnerTest raises in interactive mode during reloading

### DIFF
--- a/testplan/runnable/interactive/reloader.py
+++ b/testplan/runnable/interactive/reloader.py
@@ -10,9 +10,9 @@ import functools
 from imp import reload
 
 from testplan.common.utils import path as path_utils
-from testplan.testing.multitest import suite
 from testplan.common.utils import logger
 from testplan.common.utils import strings
+from testplan.testing.multitest import suite, MultiTest
 
 
 class ModuleReloader(logger.Loggable):
@@ -196,13 +196,11 @@ class ModuleReloader(logger.Loggable):
             functools.partial(collections.defaultdict, list)
         )
         for test in tests:
-            try:
+            if isinstance(test, MultiTest):
                 for suite in test.cfg.suites:
                     suite_dict[suite.__module__][
                         suite.__class__.__name__
                     ].append(suite)
-            except AttributeError:
-                self.logger.exception("Test %r has no suites", test)
         return suite_dict
 
     def _reload_modified_modules(self, modified_modules, suite_instances):

--- a/tests/unit/testplan/testing/test_filtering.py
+++ b/tests/unit/testplan/testing/test_filtering.py
@@ -1,7 +1,6 @@
 import pytest
 
 from testplan.testing.multitest import MultiTest, testsuite, testcase
-from testplan.testing.multitest import parametrization
 
 from testplan.testing import filtering
 


### PR DESCRIPTION
* ``ProcessRunnerTest`` and other tests based on it (such as ``GTest``)
  cannot work well with interactive reloading of plan because there is
  an exception message printed on console. Actually that is not a real
  error because Testplan can only reload Multitest instance but all
  ``ProcessRunnerTest`` uses a binary to execute tests, so if need to
  reload them just replace the binary.
