### PR TITLE
Pin flask version to < 2.0

### DIFF
--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -15,7 +15,7 @@ terminaltables
 pyparsing
 cycler
 requests>=2.4.3
-flask
+flask<2.0.0
 flask_restplus
 cheroot
 validators==0.14.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ REQUIRED = [
     "numpy",
     "scipy",
     "requests>=2.4.3",
-    "flask",
+    "flask<2.0.0",
     "flask_restplus",
     "cheroot",
     "validators==0.14.0",


### PR DESCRIPTION
Current flask (2.0) requires Werkzeug >= 2.0, but Werkzeug
is pinned to < 1.0 due to a flask-restplus issue (see
https://github.com/morganstanley/testplan/pull/364).