### PR TITLE
Fix naming conflict.

### DIFF
--- a/testplan/common/utils/sockets/fix/server.py
+++ b/testplan/common/utils/sockets/fix/server.py
@@ -578,15 +578,15 @@ class Server(object):
         if self.log_callback:
             self.log_callback("Flushed received message queues")
 
-    def _flush_queue(self, queue):
+    def _flush_queue(self, msg_queue):
         """
         Flush the given receive queue.
 
-        :param queue: Queue to flush.
-        :type queue: ``queue``
+        :param msg_queue: Queue to flush.
+        :type msg_queue: ``queue``
         """
         try:
             while True:
-                queue.get(False)
+                msg_queue.get(False)
         except queue.Empty:
             return


### PR DESCRIPTION
## Bug / Requirement Description
naming conflict of queue

## Solution description
Rename queue to msg_queue

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
