### PR TITLE
Check if App is already stopped

### DIFF
--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -307,7 +307,7 @@ class App(Driver):
     def stopping(self):
         """Stops the application binary process."""
         super(App, self).stopping()
-        # 
+        #
         if self.proc is None:
             return
         try:

--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -307,6 +307,7 @@ class App(Driver):
     def stopping(self):
         """Stops the application binary process."""
         super(App, self).stopping()
+        # 
         if self.proc is None:
             return
         try:

--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -307,6 +307,8 @@ class App(Driver):
     def stopping(self):
         """Stops the application binary process."""
         super(App, self).stopping()
+        if self.proc is None:
+            return
         try:
             self._retcode = kill_process(self.proc)
         except Exception as exc:

--- a/testplan/testing/multitest/driver/base.py
+++ b/testplan/testing/multitest/driver/base.py
@@ -171,6 +171,8 @@ class Driver(Resource):
 
     def stop(self):
         """Stop the driver."""
+        if self.status.tag is self.STATUS.STOPPED:
+            return
         self.status.change(self.STATUS.STOPPING)
         if self.active:
             self.pre_stop()

--- a/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
+++ b/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
@@ -9,7 +9,6 @@ import tempfile
 import pytest
 
 from testplan.common.utils.timing import wait
-from testplan.common.utils import path
 
 from testplan.testing.multitest.driver.app import App
 
@@ -326,3 +325,24 @@ def run_app(cwd, runpath):
     with app:
         app.proc.wait()
     return app
+
+
+def test_app_stop_after_shutdown(runpath):
+    """Test manually stopping an App after it has stopped."""
+    app = App(
+        name="App",
+        binary="echo",
+        args=["hello"],
+        shell=True,
+        runpath=runpath,
+    )
+    app.start()
+    app.wait(app.STATUS.STARTED)
+    assert app.status.tag == app.status.STARTED
+
+    app.stop()
+    app.wait(app.STATUS.STOPPED)
+    assert app.proc is None
+    assert app.status.tag == app.status.STOPPED
+
+    app.stop()

--- a/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
+++ b/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
@@ -325,24 +325,3 @@ def run_app(cwd, runpath):
     with app:
         app.proc.wait()
     return app
-
-
-def test_app_stop_after_shutdown(runpath):
-    """Test manually stopping an App after it has stopped."""
-    app = App(
-        name="App",
-        binary="echo",
-        args=["hello"],
-        shell=True,
-        runpath=runpath,
-    )
-    app.start()
-    app.wait(app.STATUS.STARTED)
-    assert app.status.tag == app.status.STARTED
-
-    app.stop()
-    app.wait(app.STATUS.STOPPED)
-    assert app.proc is None
-    assert app.status.tag == app.status.STOPPED
-
-    app.stop()

--- a/tests/unit/testplan/testing/multitest/driver/test_driver.py
+++ b/tests/unit/testplan/testing/multitest/driver/test_driver.py
@@ -121,3 +121,25 @@ class TestPrePostCallables(object):
 
         assert driver.pre_stop_fn_called
         assert driver.post_stop_fn_called
+
+    def test_driver_stop_after_shutdown(self, runpath):
+        """Test manually stopping a Driver after it has stopped."""
+
+        driver = self.MyDriver(
+            name="MyDriver",
+            runpath=runpath,
+            pre_start=pre_start_fn,
+            post_start=post_start_fn,
+            pre_stop=pre_stop_fn,
+            post_stop=post_stop_fn,
+        )
+
+        driver.start()
+        driver.wait(driver.STATUS.STARTED)
+        assert driver.status.tag == driver.status.STARTED
+
+        driver.stop()
+        driver.wait(driver.STATUS.STOPPED)
+        assert driver.status.tag == driver.status.STOPPED
+
+        driver.stop()


### PR DESCRIPTION
## Bug / Requirement Description
When a `App`/`Driver` was stopped manually inside a test, the testplan cleanup process threw a warning because it assumed the Resource was still running and tried to stop it.

## Solution description
When calling the `stop()` function on an `App` or `Driver` nothing will happen if it's already stopped.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
