### PR TITLE
Add @pre & @post decorators

### DIFF
--- a/examples/Multitest/Hooks/test_plan.py
+++ b/examples/Multitest/Hooks/test_plan.py
@@ -1,0 +1,63 @@
+import sys
+from testplan.testing.multitest import MultiTest, testsuite, testcase
+from testplan.common.utils.callable import pre, post
+
+from testplan import test_plan
+from testplan.report.testing.styles import Style
+
+
+def pre_fn(self, env, result):
+    result.log("pre_fn")
+
+
+def post_fn(self, env, result):
+    result.log("post_fn")
+
+
+@testsuite
+class SimpleTest(object):
+    def setup(self, env, result):
+        result.log("setup")
+
+    def teardown(self, env, result):
+        result.log("tear down")
+
+    def pre_testcase(self, name, env, result, kwargs):
+        result.log(f"name = {name}", description="pre_testcase")
+        if kwargs:
+            result.dict.log(kwargs, description="kwargs")
+
+    def post_testcase(self, name, env, result, kwargs):
+        result.log(f"name = {name}", description="post_testcase")
+        if kwargs:
+            result.dict.log(kwargs, description="kwargs")
+
+    @pre(pre_fn)
+    @post(post_fn)
+    @testcase
+    def add_simple(self, env, result):
+        result.equal(10 + 5, 15)
+
+    @testcase(
+        parameters=((3, 3, 6), (7, 8, 15)),
+        custom_wrappers=[pre(pre_fn), post(post_fn)],
+    )
+    def add_param(self, env, result, a, b, expect):
+        result.equal(a + b, expect)
+
+
+@test_plan(
+    name="Hooks",
+    stdout_style=Style("assertion-detail", "assertion-detail"),
+)
+def main(plan):
+    plan.add(
+        MultiTest(
+            name="Hooks",
+            suites=[SimpleTest()],
+        )
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(not main())

--- a/testplan/common/utils/callable.py
+++ b/testplan/common/utils/callable.py
@@ -4,7 +4,6 @@ import inspect
 import functools
 from collections import namedtuple
 
-
 WRAPPER_ASSIGNMENTS = functools.WRAPPER_ASSIGNMENTS + (
     "__tags__",
     "__tags_index__",
@@ -140,3 +139,68 @@ def wraps(
         return wrapper
 
     return _inner
+
+
+def pre(*prefunctions):
+    """
+    Attaches function(s) to another function for systematic execution before
+    said function, with the same arguments
+
+    :param prefunction: function to execute before
+    :type prefunction: ``callable``
+
+    :return: function decorator
+    :rtype: ``callable``
+    """
+
+    def outer(function):
+        """
+        Function decorator adding the execution of a prefunction
+        """
+
+        @wraps(function)
+        def inner(*args, **kwargs):
+            """
+            Inner decorator body, executing the prefunctions and the
+            function itself
+            """
+            for prefunction in prefunctions:
+                prefunction(*args, **kwargs)
+            return function(*args, **kwargs)
+
+        return inner
+
+    return outer
+
+
+def post(*postfunctions):
+    """
+    Attaches function(s) to another function for systematic execution after
+    said function, with the same arguments
+
+    :param postfunction: function to execute after
+    :type postfunction: ``callable``
+
+    :return: function decorator
+    :rtype: ``callable``
+    """
+
+    def outer(function):
+        """
+        Function decorator adding the excution of a postfunction
+        """
+
+        @wraps(function)
+        def inner(*args, **kwargs):
+            """
+            Inner decorator body, executing the postfunctions and the
+            function itself
+            """
+            result = function(*args, **kwargs)
+            for postfunction in postfunctions:
+                postfunction(*args, **kwargs)
+            return result
+
+        return inner
+
+    return outer

--- a/testplan/testing/multitest/driver/fix/server.py
+++ b/testplan/testing/multitest/driver/fix/server.py
@@ -119,6 +119,16 @@ class FixServer(Driver):
         self._host = self.cfg.host
         self._port = self._server.port
 
+        # use parent.logger here so that this goes to stdout
+        # self.logger is writing to file_logger
+        self.parent.logger.debug(
+            "%s[%s] listening on %s:%s",
+            type(self).__name__,
+            self.name,
+            self._host,
+            self._port,
+        )
+
     def active_connections(self):
         """
         Docstring from Server.active_connections


### PR DESCRIPTION
Requested by user, generic @pre and @post decorators; also add example of using them on testcases.

## Checklist:
- [X] Test
- [X] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
