### PR TITLE
Fix attach assertion issue that same name files overwrite

### DIFF
--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -9,8 +9,6 @@ after testcases have finished running.
 import inspect
 import os
 import re
-import uuid
-import shutil
 
 from testplan import defaults
 from testplan.defaults import STDOUT_STYLE
@@ -2174,15 +2172,9 @@ class Result(object):
                  fail.
         :rtype: ``bool``
         """
-        filename = os.path.basename(filepath)
-        try:
-            # will best effort make a copy of the file
-            copy_of_file = os.path.join(self._scratch, filename)
-            shutil.copyfile(filepath, copy_of_file)
-        except Exception:
-            copy_of_file = filepath
-
-        attachment = base.Attachment(copy_of_file, description)
+        attachment = base.Attachment(
+            filepath, description, scratch_path=self._scratch
+        )
         self.attachments.append(attachment)
         _bind_entry(attachment, self)
         return attachment

--- a/tests/unit/testplan/testing/multitest/test_result.py
+++ b/tests/unit/testplan/testing/multitest/test_result.py
@@ -379,7 +379,9 @@ class TestResultBaseNamespace(object):
         assert len(result.entries) == 1
         attachment_entry = result.entries[0]
 
-        assert attachment_entry.source_path == tmpfile
+        assert attachment_entry.source_path == os.path.join(
+            os.path.dirname(tmpfile), attachment_entry.dst_path
+        )
         assert attachment_entry.hash == path_utils.hash_file(tmpfile)
         assert attachment_entry.orig_filename == "attach_me.txt"
         assert attachment_entry.filesize == os.path.getsize(tmpfile)
@@ -423,7 +425,9 @@ class TestResultBaseNamespace(object):
         size = os.path.getsize(tmpfile)
 
         for idx, attachment in enumerate(result.attachments):
-            assert attachment.source_path == tmpfile
+            assert attachment.source_path == os.path.join(
+                os.path.dirname(tmpfile), attachment.dst_path
+            )
             assert attachment.hash == file_hash
             assert attachment.orig_filename == "attach_me.txt"
             assert attachment.filesize == size


### PR DESCRIPTION
## Bug / Requirement Description
If 2 drivers both have stdout file, the latter one that is attached to report overwrites the previous one.

## Solution description
Rename the file with hash value when copy the file to scratch

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
