### PR TITLE
Add Plotly chart support

### DIFF
--- a/doc/en/assertions.rst
+++ b/doc/en/assertions.rst
@@ -672,6 +672,14 @@ matplot assertion and contain output sample images can be found
 :ref:`here <example_basic_models>`.
 
 
+:py:meth:`result.plotly <testplan.testing.multitest.result.Result.plotly>`
+----------------------------------------------------------------------------
+
+Displays a Plotly figure in the report. Downloadable examples that use
+plotly assertion can be found
+:ref:`here <example_assertions_plotly>`.
+
+
 Assertion Groups
 ================
 While writing assertions, it's possible to group them together for formatting purposes.

--- a/doc/en/download/Assertions.rst
+++ b/doc/en/download/Assertions.rst
@@ -27,3 +27,16 @@ Required files:
 test_plan.py
 ++++++++++++
 .. literalinclude:: ../../../examples/Assertions/Summary/test_plan.py
+
+
+Plotly
+------
+
+.. _example_assertions_plotly:
+
+Required files:
+  - :download:`test_plan.py <../../../examples/Assertions/Plotly/test_plan.py>`
+
+test_plan.py
+++++++++++++
+.. literalinclude:: ../../../examples/Assertions/Plotly/test_plan.py

--- a/examples/Assertions/Plotly/test_plan.py
+++ b/examples/Assertions/Plotly/test_plan.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python
+"""
+This example shows usage of chart assertions.
+"""
+import os
+import re
+import sys
+import random
+
+from testplan import test_plan
+from testplan.testing.multitest import MultiTest, testsuite, testcase
+
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+
+
+@testsuite
+class SampleSuite(object):
+    @testcase
+    def line_tests(self, env, result):
+        """
+        Example from https://plotly.com/python/line-charts/
+        """
+        df = px.data.gapminder().query("continent=='Oceania'")
+        fig = px.line(df, x="year", y="lifeExp", color="country")
+        result.plotly(fig, description="Gapminder of Oceania")
+
+    @testcase
+    def timeline_tests(self, env, result):
+        """
+        Example from https://plotly.com/python/gantt/
+        """
+        df = pd.DataFrame(
+            [
+                dict(
+                    Task="Job A",
+                    Start="2009-01-01",
+                    Finish="2009-02-28",
+                    Completion_pct=50,
+                ),
+                dict(
+                    Task="Job B",
+                    Start="2009-03-05",
+                    Finish="2009-04-15",
+                    Completion_pct=25,
+                ),
+                dict(
+                    Task="Job C",
+                    Start="2009-02-20",
+                    Finish="2009-05-30",
+                    Completion_pct=75,
+                ),
+            ]
+        )
+
+        fig = px.timeline(
+            df,
+            x_start="Start",
+            x_end="Finish",
+            y="Task",
+            color="Completion_pct",
+        )
+        fig.update_yaxes(autorange="reversed")
+
+        result.plotly(fig, description="Task")
+
+    @testcase
+    def bar_tests(self, env, result):
+        """
+        Example from https://plotly.com/python/bar-charts/
+        """
+        months = [
+            "Jan",
+            "Feb",
+            "Mar",
+            "Apr",
+            "May",
+            "Jun",
+            "Jul",
+            "Aug",
+            "Sep",
+            "Oct",
+            "Nov",
+            "Dec",
+        ]
+
+        fig = go.Figure()
+        fig.add_trace(
+            go.Bar(
+                x=months,
+                y=[20, 14, 25, 16, 18, 22, 19, 15, 12, 16, 14, 17],
+                name="Primary Product",
+                marker_color="indianred",
+            )
+        )
+        fig.add_trace(
+            go.Bar(
+                x=months,
+                y=[19, 14, 22, 14, 16, 19, 15, 14, 10, 12, 12, 16],
+                name="Secondary Product",
+                marker_color="lightsalmon",
+            )
+        )
+
+        fig.update_layout(barmode="group", xaxis_tickangle=-45)
+        result.plotly(fig, description="Rotated Bar Chart Labels")
+
+    @testcase
+    def pie_tests(self, env, result):
+        """
+        Example from https://plotly.com/python/pie-charts/
+        """
+        df = (
+            px.data.gapminder()
+            .query("year == 2007")
+            .query("continent == 'Europe'")
+        )
+        df.loc[df["pop"] < 2.0e6, "country"] = "Other countries"
+        fig = px.pie(
+            df,
+            values="pop",
+            names="country",
+            title="Population of European continent",
+        )
+        result.plotly(fig, description="Pie chart with plotly express")
+
+    @testcase
+    def scatter_tests(self, env, result):
+        """
+        Example from https://plotly.com/python/line-and-scatter/
+        """
+        df = px.data.iris()
+        fig = px.scatter(
+            df,
+            x="sepal_width",
+            y="sepal_length",
+            color="species",
+            size="petal_length",
+            hover_data=["petal_width"],
+        )
+        result.plotly(fig, description="Set size and color with column names")
+
+    @testcase
+    def line_3d_tests(self, env, result):
+        """
+        Example from https://plotly.com/python/3d-line-plots/
+        """
+        rs = np.random.RandomState()
+        rs.seed(0)
+
+        def brownian_motion(T=1, N=100, mu=0.1, sigma=0.01, S0=20):
+            dt = float(T) / N
+            t = np.linspace(0, T, N)
+            W = rs.standard_normal(size=N)
+            W = np.cumsum(W) * np.sqrt(dt)  # standard brownian motion
+            X = (mu - 0.5 * sigma ** 2) * t + sigma * W
+            S = S0 * np.exp(X)  # geometric brownian motion
+            return S
+
+        dates = pd.date_range("2012-01-01", "2013-02-22")
+        T = (dates.max() - dates.min()).days / 365
+        N = dates.size
+        start_price = 100
+        y = brownian_motion(T, N, sigma=0.1, S0=start_price)
+        z = brownian_motion(T, N, sigma=0.1, S0=start_price)
+
+        fig = go.Figure(
+            data=go.Scatter3d(
+                x=dates,
+                y=y,
+                z=z,
+                marker=dict(
+                    size=4,
+                    color=z,
+                    colorscale="Viridis",
+                ),
+                line=dict(color="darkblue", width=2),
+            )
+        )
+
+        fig.update_layout(
+            width=800,
+            height=700,
+            autosize=False,
+            scene=dict(
+                camera=dict(
+                    up=dict(x=0, y=0, z=1),
+                    eye=dict(
+                        x=0,
+                        y=1.0707,
+                        z=1,
+                    ),
+                ),
+                aspectratio=dict(x=1, y=1, z=0.7),
+                aspectmode="manual",
+            ),
+        )
+        result.plotly(fig, description="Brownian Motion")
+
+
+@test_plan(name="Charts Example")
+def main(plan):
+    plan.add(MultiTest(name="Chart Assertions Test", suites=[SampleSuite()]))
+
+
+if __name__ == "__main__":
+    sys.exit(not main())

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -20,6 +20,7 @@ flask_restplus
 cheroot
 validators==0.14.0
 Pillow
+plotly
 
 # Documentation
 # ---------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ scikit-learn < 0.21.0
 black==19.10b0; python_version >= '3.0'
 kazoo
 confluent-kafka
+plotly
+pandas
+numpy

--- a/testplan/exporters/testing/pdf/renderers/entries/base.py
+++ b/testplan/exporters/testing/pdf/renderers/entries/base.py
@@ -180,6 +180,45 @@ class MatPlotRenderer(SerializedEntryRenderer):
         )
 
 
+@registry.bind(base.Plotly)
+class PlotlyRenderer(SerializedEntryRenderer):
+    """Render a Plotly assertion from a serialized entry."""
+
+    def get_row_data(self, source, depth, row_idx):
+        # TODO Add PDF render
+        # https://plotly.com/python/static-image-export/
+        # require kaleido which not support rhel6
+        return super(PlotlyRenderer, self).get_row_data(source, depth, row_idx)
+
+        #
+        # header = self.get_header(source, depth, row_idx)
+        # styles = [
+        #     RowStyle(
+        #         font=(constants.FONT, constants.FONT_SIZE_SMALL),
+        #         left_padding=constants.INDENT * (depth + 1),
+        #         text_color=colors.black,
+        #     )
+        # ]
+        #
+        # fig = plotly.io.read_json(source["source_path"])
+        #
+        # img_file = str(pathlib.Path(source["source_path"]).with_suffix(".jpg"))
+        # plotly.io.write_image(fig, img_file)
+        # p_img = pil_image.open(img_file)
+        # dpi_w, dpi_h = p_img.info["dpi"]
+        #
+        # width = p_img.width / dpi_w * inch
+        # height = p_img.height / dpi_h * inch
+        #
+        # img = Image(img_file, width, height)
+        #
+        # return header + RowData(
+        #     content=[img, "", "", ""],
+        #     start=header.end,
+        #     style=styles,
+        # )
+
+
 @registry.bind(base.TableLog)
 class TableLogRenderer(SerializedEntryRenderer):
     """Render a Table from a serialized entry."""

--- a/testplan/testing/multitest/entries/base.py
+++ b/testplan/testing/multitest/entries/base.py
@@ -7,6 +7,8 @@ import pprint
 import re
 import os
 import shutil
+import pathlib
+import plotly.io
 
 from testplan.common.utils.convert import nested_groups
 from testplan.common.utils.timing import utcnow
@@ -377,6 +379,21 @@ class MatPlot(Attachment):
         super(MatPlot, self).__init__(
             filepath=image_file_path, description=description
         )
+
+
+class Plotly(Attachment):
+    def __init__(self, fig, data_file_path, style=None, description=None):
+        fig_json = plotly.io.to_json(fig)
+        pathlib.Path(data_file_path).resolve().parent.mkdir(
+            parents=True, exist_ok=True
+        )
+        with open(data_file_path, "w") as f:
+            f.write(fig_json)
+
+        super(Plotly, self).__init__(
+            filepath=data_file_path, description=description
+        )
+        self.style = style
 
 
 class CodeLog(BaseEntry):

--- a/testplan/testing/multitest/entries/schemas/base.py
+++ b/testplan/testing/multitest/entries/schemas/base.py
@@ -93,3 +93,8 @@ class AttachmentSchema(BaseSchema):
     orig_filename = fields.String()
     filesize = fields.Integer()
     dst_path = fields.String()
+
+
+@registry.bind(base.Plotly)
+class PlotlySchema(AttachmentSchema):
+    style = fields.Dict(allow_none=True)

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -9,6 +9,7 @@ after testcases have finished running.
 import inspect
 import os
 import re
+import json
 
 from testplan import defaults
 from testplan.defaults import STDOUT_STYLE
@@ -2207,6 +2208,19 @@ class Result(object):
         self.attachments.append(matplot)
         _bind_entry(matplot, self)
         return matplot
+
+    def plotly(self, fig, description=None, style=None):
+        filename = "{0}.json".format(strings.uuid4())
+        data_file_path = os.path.join(self._scratch, filename)
+        chart = base.Plotly(
+            fig,
+            data_file_path=data_file_path,
+            style=style,
+            description=description,
+        )
+        self.attachments.append(chart)
+        _bind_entry(chart, self)
+        return chart
 
     @property
     def serialized_entries(self):

--- a/testplan/web_ui/testing/package.json
+++ b/testplan/web_ui/testing/package.json
@@ -3,11 +3,12 @@
   "version": "0.2.0",
   "private": true,
   "resolutions": {
-    "@babel/core": "^7.0.0",
-    "@babel/preset-env": "^7.8.7",
-    "watchpack": "1.6.1"
+    "@babel/core": "7.13.15",
+    "@babel/preset-env": "7.13.15"
   },
   "dependencies": {
+    "@babel/core": "^7.13.15",
+    "@babel/preset-env": "^7.13.15",
     "@fortawesome/fontawesome-svg-core": "1.2.2",
     "@fortawesome/free-solid-svg-icons": "5.2.0",
     "@fortawesome/react-fontawesome": "0.1.3",
@@ -27,12 +28,14 @@
     "json5": "^2.2.0",
     "lodash": "~4.17.15",
     "pegjs": "^0.11.0-master.b7b87ea",
+    "plotly.js": "^1.58.4",
     "react": "16.13.1",
     "react-copy-html-to-clipboard": "6.0.4",
     "react-custom-scrollbars": "4.2.1",
     "react-debounce-input": "^3.2.2",
     "react-dom": "16.13.1",
     "react-markdown": "^4.3.1",
+    "react-plotly.js": "^2.5.1",
     "react-portal-tooltip": "2.4.0",
     "react-router": "^5.0.0",
     "react-router-dom": "^5.0.0",

--- a/testplan/web_ui/testing/src/AssertionPane/Assertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/Assertion.js
@@ -27,7 +27,8 @@ import XYGraphAssertion
 import DiscreteChartAssertion
   from './AssertionTypes/GraphAssertions/DiscreteChartAssertion';
 import SummaryBaseAssertion from './AssertionSummary';
-import AttachmentAssertion from './AssertionTypes/AttachmentAssertions.js';
+import AttachmentAssertion from './AssertionTypes/AttachmentAssertions';
+import PlotlyAssertion from './AssertionTypes/PlotlyAssertion';
 
 /**
  * Component to render one assertion.
@@ -123,6 +124,7 @@ class Assertion extends Component {
       MatPlot: AttachmentAssertion,
       Markdown: MarkdownAssertion,
       CodeLog: CodeLogAssertion,
+      Plotly: PlotlyAssertion,
     };
     if (assertionMap[assertionType]) {
       return assertionMap[assertionType];

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/AttachmentAssertions.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/AttachmentAssertions.js
@@ -14,6 +14,7 @@ import {
 
 import TextAttachment from "./TextAttachment";
 import AttachmentAssertionCardHeader from "./AttachmentAssertionCardHeader";
+import { getAttachmentUrl } from "../../Common/utils";
 
 // TODO: move theme out to a common place
 const theme = createMuiTheme({
@@ -106,20 +107,6 @@ const getAttachmentContent = (assertion, reportUid) => {
           />
         </Card>
       );
-  }
-};
-
-/**
- * Get the URL to retrieve the attachment from. Depending on whether we are
- * running in batch or interactive mode, the API for accessing attachments
- * is slightly different. We know we are running in interactive mode if there
- * is no report UID.
- */
-const getAttachmentUrl = (filePath, reportUid) => {
-  if (reportUid) {
-    return `/api/v1/reports/${reportUid}/attachments/${filePath}`;
-  } else {
-    return `/api/v1/interactive/attachments/${filePath}`;
   }
 };
 

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/PlotlyAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/PlotlyAssertion.js
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import axios from "axios";
+import Plot from "react-plotly.js";
+import CircularProgress from "@material-ui/core/CircularProgress";
+import { makeStyles } from "@material-ui/core/styles";
+import { getAttachmentUrl } from "../../Common/utils";
+import { GREEN, RED } from "../../Common/defaults";
+
+const useStyle = makeStyles({
+  circular: {
+    color: GREEN,
+  },
+});
+
+export default function PlotlyAssertion(props) {
+  const [plotlyData, setPlotlyData] = useState(null);
+  const [errorInfo, setErrorInfo] = useState(null);
+  const styles = useStyle();
+  const dataUrl = getAttachmentUrl(props.assertion.dst_path, props.reportUid);
+
+  useEffect(() => {
+    axios
+      .get(dataUrl)
+      .then((response) => {
+        setPlotlyData(response.data);
+      })
+      .catch((error) => {
+        setErrorInfo(error);
+      });
+  }, [dataUrl]);
+
+  if (plotlyData) {
+    return (
+      <Plot
+        data={plotlyData.data}
+        layout={plotlyData.layout}
+        useResizeHandler={true}
+        style={props.assertion.style || { width: "100%" }}
+      />
+    );
+  } else if (errorInfo) {
+    return <span style={{ color: { RED } }}>{errorInfo}</span>;
+  } else {
+    return (
+      <div>
+        <CircularProgress className={styles.circular} />
+      </div>
+    );
+  }
+}
+
+PlotlyAssertion.prototype = {
+  /** Assertion being rendered */
+  assertion: PropTypes.object,
+};

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TableAssertions/TableBaseAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TableAssertions/TableBaseAssertion.js
@@ -18,21 +18,27 @@ if (REACT_APP_AG_GRID_LICENSE) {
  */
 export default function TableBaseAssertion(props) {
 
-  const [gridApi, setGridApi] = useState(null);
-  const [, setGridColumnApi] = useState(null);
+  const [, setGridApi] = useState(null);
+  const [gridColumnApi, setGridColumnApi] = useState(null);
 
-  const sizeToFit = (api) => {
-    if (api) api.sizeColumnsToFit();
+  const autoSizeColumns = () => {
+    if (gridColumnApi) {
+      let allColumnIds = [];
+      gridColumnApi.getAllColumns().forEach(column => {
+        allColumnIds.push(column.colId);
+      });
+      gridColumnApi.autoSizeColumns(allColumnIds);
+    }
   };
 
   const onGridReady = (params) => {
     setGridApi(params.api);
     setGridColumnApi(params.columnApi);
-    sizeToFit(params.api);
+    autoSizeColumns();
   };
 
   useLayoutEffect(() => {
-    sizeToFit(gridApi?.api);
+    autoSizeColumns();
   });
 
   // table header + margin + column height * columns

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TableAssertions/__tests__/__snapshots__/TableLogAssertion.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TableAssertions/__tests__/__snapshots__/TableLogAssertion.test.js.snap
@@ -5,6 +5,7 @@ exports[`FixMatchAssertion shallow renders the correct HTML structure 1`] = `
   columns={
     Array [
       Object {
+        "cellRendererFramework": [Function],
         "field": "age",
         "filterParams": Object {
           "excelMode": "windows",
@@ -12,6 +13,7 @@ exports[`FixMatchAssertion shallow renders the correct HTML structure 1`] = `
         "headerName": "age",
       },
       Object {
+        "cellRendererFramework": [Function],
         "field": "name",
         "filterParams": Object {
           "excelMode": "windows",

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TableAssertions/tableAssertionUtils.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TableAssertions/tableAssertionUtils.js
@@ -1,5 +1,6 @@
 /** @module tableAssertionUtils */
 
+import React from "react";
 import {domToString} from './../../../Common/utils';
 
 
@@ -26,6 +27,23 @@ function tableCellStyle(params) {
 
   return cellStyle;
 }
+
+function tableLogCellRender(cell) {
+  if (typeof cell.value === "object") {
+    if (cell.value.type === "link") {
+      return (
+        <a
+          href={cell.value.link}
+          target={cell.value.new_window ? "_blank" : "_self"}
+        >
+          {cell.value.title || cell.value.link}
+        </a>
+      );
+    }
+  }
+  return cell.value;
+}
+
 
 /**
  * Function to prepare the column definitions for TableLog assertions.
@@ -56,7 +74,8 @@ export function prepareTableLogColumnDefs(columns, display_index) {
     columnDefs.push({
       headerName: column,
       field: column,
-      filterParams: {excelMode: 'windows'}
+      filterParams: {excelMode: 'windows'},
+      cellRendererFramework: tableLogCellRender
     });
   });
 

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/PlotlyAssertion.test.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/PlotlyAssertion.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {StyleSheetTestUtils} from "aphrodite";
+
+import PlotlyAssertion from '../PlotlyAssertion';
+
+function defaultProps() {
+  return {
+    assertion: {
+        "type": "Plotly",
+        "meta_type": "entry",
+        "utc_time": "2021-06-03T08:31:16.613418+00:00",
+        "category": "DEFAULT",
+        "flag": "DEFAULT",
+        "hash": "f97c8d4c90fccc79e6921ba62583c7ad99b71561",
+        "filesize": 7813,
+        "source_path": "1f8037cf-ec3e-48e2-8329-d2910ad04ca6.json",
+        "style": null,
+        "machine_time": "2021-06-03T16:31:16.613430+00:00",
+        "orig_filename": "1f8037cf-ec3e-48e2-8329-d2910ad04ca6.json",
+        "dst_path": "1f8037cf-ec3e-48e2-8329-d2910ad04ca6-f97c8d4c90fccc79e6921ba62583c7ad99b71561-7813.json",
+        "line_no": 71,
+        "description": "Task"
+      }
+  };
+}
+
+
+describe('PlotlyAssertion', () => {
+  let props;
+  let shallowComponent;
+
+  beforeEach(() => {
+    // Stop Aphrodite from injecting styles, this crashes the tests.
+    StyleSheetTestUtils.suppressStyleInjection();
+    props = defaultProps();
+    shallowComponent = undefined;
+  });
+
+  it('shallow renders the correct HTML structure', () => {
+    shallowComponent = shallow(<PlotlyAssertion {...props} />);
+    expect(shallowComponent).toMatchSnapshot();
+  });
+});

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/__snapshots__/PlotlyAssertion.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/__snapshots__/PlotlyAssertion.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PlotlyAssertion shallow renders the correct HTML structure 1`] = `
+<div>
+  <WithStyles(ForwardRef(CircularProgress))
+    className="makeStyles-circular-1"
+  />
+</div>
+`;

--- a/testplan/web_ui/testing/src/Common/utils.js
+++ b/testplan/web_ui/testing/src/Common/utils.js
@@ -232,3 +232,17 @@ export const parseToJson = (data) => {
 
   return result;
 };
+
+/**
+ * Get the URL to retrieve the attachment from. Depending on whether we are
+ * running in batch or interactive mode, the API for accessing attachments
+ * is slightly different. We know we are running in interactive mode if there
+ * is no report UID.
+ */
+export const getAttachmentUrl = (filePath, reportUid) => {
+  if (reportUid) {
+    return `/api/v1/reports/${reportUid}/attachments/${filePath}`;
+  } else {
+    return `/api/v1/interactive/attachments/${filePath}`;
+  }
+};

--- a/testplan/web_ui/testing/src/setupTests.js
+++ b/testplan/web_ui/testing/src/setupTests.js
@@ -1,7 +1,13 @@
 import 'react-app-polyfill/stable';
+import 'jest-canvas-mock';
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import enableHooks from 'jest-react-hooks-shallow';
 
 configure({ adapter: new Adapter() });
 enableHooks(jest);
+
+// Fix the issue: https://github.com/plotly/react-plotly.js/issues/115
+if (typeof window !== 'undefined') {
+  window.URL.createObjectURL = function() {};
+}


### PR DESCRIPTION
## Bug / Requirement Description
Add an assertion for displaying [Plotly](https://plotly.com/) in report

## Solution description
Use plotly.js on web ui & save plotly figure object on attachment file. Adjust ag-grid column auto resize setting


## Checklist:
- [x] Test
- [x] Example (both test_plan.py and .rst)
- [x] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [x] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
