### PR TITLE
Use absolute binary path for ProcessRunnerTest if needed

### DIFF
--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -463,6 +463,11 @@ class ProcessRunnerTest(Test):
         self._test_process_killed = False
         self._test_has_run = False
 
+        # Need to use the binary's absolute path if `proc_cwd` is specified,
+        # otherwise won't be able to find the binary.
+        if self.cfg.proc_cwd:
+            self.cfg._options["binary"] = os.path.abspath(self.cfg.binary)
+
     @property
     def stderr(self):
         return os.path.join(self._runpath, "stderr")
@@ -516,7 +521,6 @@ class ProcessRunnerTest(Test):
             env=self.cfg.proc_env,
             stdout=subprocess.PIPE,
         )
-
         test_list_output = proc.communicate()[0]
 
         # with python3, stdout is bytes so need to decode.
@@ -606,11 +610,6 @@ class ProcessRunnerTest(Test):
                         self.cfg.binary, self
                     )
                 )
-
-            # Need to use the binary's absolute path if proc_cwd is specified,
-            # otherwise won't be able to find the binary.
-            if self.cfg.proc_cwd:
-                self.cfg._options["binary"] = os.path.abspath(self.cfg.binary)
 
             test_cmd = self.test_command()
 

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -248,7 +248,7 @@ class MultiTest(testing_base.Test):
     def uid(self):
         """
         Instance name uid.
-        A Multitest part isntance should not have the same uid as its name.
+        A Multitest part instance should not have the same uid as its name.
         """
         if self.cfg.part:
             return (


### PR DESCRIPTION
* If `proc_cwd` is specified for `ProcessRunnerTest` then need to set
  absolute path for the binary, or `list_command` and `test_command`
  may fail to execute since that binary is not found.
