### PR TITLE
Added custom db_path argument for SQLite driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !/tests/**/fixtures/*.xml
 
 .idea/
+.vscode/
 build/
 dist/
 *.egg-info/

--- a/examples/DB/Sqlite3/test_plan.py
+++ b/examples/DB/Sqlite3/test_plan.py
@@ -112,7 +112,7 @@ def main(plan):
     :return: Testplan result object.
     :rtype:  ``testplan.base.TestplanResult``
     """
-    my_db_path = os.path.join(tempfile.gettempdir(), "new_db_name")
+    my_db_path = tempfile.gettempdir()
     plan.add(
         MultiTest(
             name="Sqlite3Test",

--- a/examples/DB/Sqlite3/test_plan.py
+++ b/examples/DB/Sqlite3/test_plan.py
@@ -57,8 +57,8 @@ class DBQueries(object):
                 items,
             )
         result.log(
-            'Database file "{}" of driver "{}" created at "{}"'.format(
-                env.db.cfg.db_name, env.db.cfg.name, env.db.db_path
+            'Database file of driver "{}" created at "{}"'.format(
+                env.db.cfg.name, env.db.db_path
             )
         )
 
@@ -112,13 +112,14 @@ def main(plan):
     :return: Testplan result object.
     :rtype:  ``testplan.base.TestplanResult``
     """
-    my_db_path = tempfile.gettempdir()
+    db_file_name = "mydb"
+    my_db_path = os.path.join(tempfile.gettempdir(), db_file_name)
     plan.add(
         MultiTest(
             name="Sqlite3Test",
             suites=[DBQueries()],
             environment=[
-                Sqlite3(name="db", db_name="mydb", db_path=my_db_path)
+                Sqlite3(name="db", db_path=my_db_path)
             ],
         )
     )

--- a/examples/DB/Sqlite3/test_plan.py
+++ b/examples/DB/Sqlite3/test_plan.py
@@ -117,7 +117,9 @@ def main(plan):
         MultiTest(
             name="Sqlite3Test",
             suites=[DBQueries()],
-            environment=[Sqlite3(name="db", db_name="mydb", db_path=my_db_path)],
+            environment=[
+                Sqlite3(name="db", db_name="mydb", db_path=my_db_path)
+            ],
         )
     )
 

--- a/examples/DB/Sqlite3/test_plan.py
+++ b/examples/DB/Sqlite3/test_plan.py
@@ -118,9 +118,7 @@ def main(plan):
         MultiTest(
             name="Sqlite3Test",
             suites=[DBQueries()],
-            environment=[
-                Sqlite3(name="db", db_path=my_db_path)
-            ],
+            environment=[Sqlite3(name="db", db_path=my_db_path)],
         )
     )
 

--- a/examples/DB/Sqlite3/test_plan.py
+++ b/examples/DB/Sqlite3/test_plan.py
@@ -4,6 +4,8 @@ Demostrates Sqlite3 driver usage from within the testcases.
 """
 
 import sys
+import os
+import tempfile
 
 from testplan.testing.multitest import MultiTest
 from testplan.testing.multitest.driver.sqlite import Sqlite3
@@ -110,11 +112,12 @@ def main(plan):
     :return: Testplan result object.
     :rtype:  ``testplan.base.TestplanResult``
     """
+    my_db_path = os.path.join(tempfile.gettempdir(), "new_db_name")
     plan.add(
         MultiTest(
             name="Sqlite3Test",
             suites=[DBQueries()],
-            environment=[Sqlite3(name="db", db_name="mydb")],
+            environment=[Sqlite3(name="db", db_name="mydb", db_path=my_db_path)],
         )
     )
 

--- a/testplan/testing/multitest/driver/sqlite.py
+++ b/testplan/testing/multitest/driver/sqlite.py
@@ -24,8 +24,7 @@ class Sqlite3Config(DriverConfig):
 
         """
         return {
-            ConfigOption("db_name", default=""): str,
-            ConfigOption("db_path", default=None): str,
+            "db_path": str,
             ConfigOption("connect_at_start", default=True): bool,
         }
 
@@ -52,15 +51,8 @@ class Sqlite3(Driver):
     Basic sqlite3 driver to add to a MultiTest environment, connect to
     a database and perform sql queries etc.
 
-    :param db_name: Database file name to connect to.
-    :type db_name: ``str``
-    :param db_path: Path to the database to connect to. If an absolute
-        path is provided it will use that with the `db_name` to connect
-        to the database file.
-        In case a relative path is provided it will be appended to the runpath
-        and look for a file named `db_name` in that path to connect to.
-        When no value is provided it will look for a file inside the runpath
-        that has the same name as the value of `db_name`
+    :param db_path: Path to the database file to connect to. In case a relative
+        path is provided it will be appended to the runpath.
     :type db_path: ``str``
     :param connect_at_start: Connect to the database when driver starts.
       Default: True
@@ -69,7 +61,7 @@ class Sqlite3(Driver):
 
     CONFIG = Sqlite3Config
 
-    def __init__(self, name, db_name, connect_at_start=True, **options):
+    def __init__(self, name, db_path, connect_at_start=True, **options):
         options.update(self.filter_locals(locals()))
         super(Sqlite3, self).__init__(**options)
         self.db = None
@@ -78,19 +70,8 @@ class Sqlite3(Driver):
     @property
     def db_path(self):
         """Database file path."""
-        default_db_path = os.path.join(self.runpath, self.cfg.db_name)
-        custom_db_path = self._get_custom_db_path()
-        return custom_db_path or default_db_path
-
-    def _get_custom_db_path(self):
-        if self.cfg.db_path is None:
-            return None
-        is_db_path_absolute = os.path.isabs(self.cfg.db_path)
-        absolute_db_path = os.path.join(self.runpath, self.cfg.db_path)
-        custom_db_path = (
-            self.cfg.db_path if is_db_path_absolute else absolute_db_path
-        )
-        return os.path.join(custom_db_path, self.cfg.db_name)
+        # if self.cfg.db_path is an absolute path it will return self.cfg.db_path
+        return os.path.join(self.runpath, self.cfg.db_path)
 
     def connect(self):
         """Connect to the database and set the internal db cursor."""

--- a/testplan/testing/multitest/driver/sqlite.py
+++ b/testplan/testing/multitest/driver/sqlite.py
@@ -21,9 +21,10 @@ class Sqlite3Config(DriverConfig):
     def get_options(cls):
         """
         Schema for options validation and assignment of default values.
+
         """
         return {
-            "db_name": str,
+            ConfigOption("db_name", default=""): str,
             ConfigOption("db_path", default=None): str,
             ConfigOption("connect_at_start", default=True): bool,
         }
@@ -53,6 +54,12 @@ class Sqlite3(Driver):
 
     :param db_name: Database name to connect to.
     :type db_name: ``str``
+    :param db_path: Path to the database to connect to. If an absolute
+        path is provided it will use that to connect to the database.
+        In case a relative path is provided the runpath will be considered 
+        it's parent path. When no value is provided it will look for a file
+        inside the runpath that has the same name as the value of 'db_name'
+    :type db_path: ``str``
     :param connect_at_start: Connect to the database when driver starts.
       Default: True
     :type connect_at_start: ``bool``
@@ -60,7 +67,7 @@ class Sqlite3(Driver):
 
     CONFIG = Sqlite3Config
 
-    def __init__(self, name, db_name, connect_at_start=True, **options):
+    def __init__(self, name, connect_at_start=True, **options):
         options.update(self.filter_locals(locals()))
         super(Sqlite3, self).__init__(**options)
         self.db = None

--- a/testplan/testing/multitest/driver/sqlite.py
+++ b/testplan/testing/multitest/driver/sqlite.py
@@ -70,7 +70,17 @@ class Sqlite3(Driver):
     def db_path(self):
         """Database file path."""
         default_db_path = os.path.join(self.runpath, self.cfg.db_name)
-        return self.cfg.db_path or default_db_path
+        custom_db_path = self._get_custom_db_path()
+        return custom_db_path or default_db_path
+
+    def _get_custom_db_path(self):
+        if self.cfg.db_path is None:
+            return None
+        is_db_path_absolute = os.path.isabs(self.cfg.db_path)
+        absolute_db_path = os.path.join(self.runpath, self.cfg.db_path)
+        custom_db_path = self.cfg.db_path if is_db_path_absolute else absolute_db_path
+        return custom_db_path
+
 
     def connect(self):
         """Connect to the database and set the internal db cursor."""

--- a/testplan/testing/multitest/driver/sqlite.py
+++ b/testplan/testing/multitest/driver/sqlite.py
@@ -56,7 +56,7 @@ class Sqlite3(Driver):
     :type db_name: ``str``
     :param db_path: Path to the database to connect to. If an absolute
         path is provided it will use that to connect to the database.
-        In case a relative path is provided the runpath will be considered 
+        In case a relative path is provided the runpath will be considered
         it's parent path. When no value is provided it will look for a file
         inside the runpath that has the same name as the value of 'db_name'
     :type db_path: ``str``
@@ -85,9 +85,10 @@ class Sqlite3(Driver):
             return None
         is_db_path_absolute = os.path.isabs(self.cfg.db_path)
         absolute_db_path = os.path.join(self.runpath, self.cfg.db_path)
-        custom_db_path = self.cfg.db_path if is_db_path_absolute else absolute_db_path
+        custom_db_path = (
+            self.cfg.db_path if is_db_path_absolute else absolute_db_path
+        )
         return custom_db_path
-
 
     def connect(self):
         """Connect to the database and set the internal db cursor."""

--- a/testplan/testing/multitest/driver/sqlite.py
+++ b/testplan/testing/multitest/driver/sqlite.py
@@ -52,13 +52,15 @@ class Sqlite3(Driver):
     Basic sqlite3 driver to add to a MultiTest environment, connect to
     a database and perform sql queries etc.
 
-    :param db_name: Database name to connect to.
+    :param db_name: Database file name to connect to.
     :type db_name: ``str``
     :param db_path: Path to the database to connect to. If an absolute
-        path is provided it will use that to connect to the database.
-        In case a relative path is provided the runpath will be considered
-        it's parent path. When no value is provided it will look for a file
-        inside the runpath that has the same name as the value of 'db_name'
+        path is provided it will use that with the `db_name` to connect
+        to the database file.
+        In case a relative path is provided it will be appended to the runpath
+        and look for a file named `db_name` in that path to connect to.
+        When no value is provided it will look for a file inside the runpath
+        that has the same name as the value of `db_name`
     :type db_path: ``str``
     :param connect_at_start: Connect to the database when driver starts.
       Default: True
@@ -67,7 +69,7 @@ class Sqlite3(Driver):
 
     CONFIG = Sqlite3Config
 
-    def __init__(self, name, connect_at_start=True, **options):
+    def __init__(self, name, db_name, connect_at_start=True, **options):
         options.update(self.filter_locals(locals()))
         super(Sqlite3, self).__init__(**options)
         self.db = None
@@ -88,7 +90,7 @@ class Sqlite3(Driver):
         custom_db_path = (
             self.cfg.db_path if is_db_path_absolute else absolute_db_path
         )
-        return custom_db_path
+        return os.path.join(custom_db_path, self.cfg.db_name)
 
     def connect(self):
         """Connect to the database and set the internal db cursor."""

--- a/testplan/testing/multitest/driver/sqlite.py
+++ b/testplan/testing/multitest/driver/sqlite.py
@@ -24,6 +24,7 @@ class Sqlite3Config(DriverConfig):
         """
         return {
             "db_name": str,
+            ConfigOption("db_path", default=None): str,
             ConfigOption("connect_at_start", default=True): bool,
         }
 
@@ -68,7 +69,8 @@ class Sqlite3(Driver):
     @property
     def db_path(self):
         """Database file path."""
-        return os.path.join(self.runpath, self.cfg.db_name)
+        default_db_path = os.path.join(self.runpath, self.cfg.db_name)
+        return self.cfg.db_path or default_db_path
 
     def connect(self):
         """Connect to the database and set the internal db cursor."""


### PR DESCRIPTION
## Bug / Requirement Description
db_path for SQLite3 driver was not customizable.

## Solution description
Added custom db_path argument for SQLite3 driver.

## Checklist:
- [x] Test
- [x] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
