### PR TITLE
Fix file log encoding error on windows.

### DIFF
--- a/testplan/common/utils/logger.py
+++ b/testplan/common/utils/logger.py
@@ -169,7 +169,7 @@ def configure_file_logger(level, runpath):
     # user's code. We specify a formatter to add additional information
     # useful for debugging.
     try:
-        file_handler = logging.FileHandler(logfile_path)
+        file_handler = logging.FileHandler(logfile_path, encoding="utf-8")
     except IOError as err:
         # If we cannot open the logfile for any reason just continue
         # regardless, but log the error (it will go to stdout).

--- a/testplan/runners/pools/child.py
+++ b/testplan/runners/pools/child.py
@@ -112,7 +112,7 @@ class ChildLoop(object):
         mode = "w" if platform.python_version().startswith("3") else "wb"
 
         sys.stderr = open(stderr_file, mode)
-        fhandler = logging.FileHandler(log_file)
+        fhandler = logging.FileHandler(log_file, encoding="utf-8")
         from testplan.common.utils.logger import LOGFILE_FORMAT
 
         formatter = logging.Formatter(LOGFILE_FORMAT)


### PR DESCRIPTION
## Bug / Requirement Description
UnicodeEncodeError on windows if log contains non-ASCII characters.

## Solution description
Set FileHandler encoding to utf-8

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
