### PR TITLE
parts + rerun: do not merge rerun multitest part

### DIFF
--- a/testplan/common/utils/path.py
+++ b/testplan/common/utils/path.py
@@ -22,7 +22,6 @@ def fix_home_prefix(path):
     directory.
     """
 
-    path = path.replace(" ", r"\ ")
     userhome = os.path.expanduser("~")
     realhome = os.path.realpath(userhome)
     if path.startswith(realhome):
@@ -79,7 +78,8 @@ def change_directory(directory):
     :param directory: Directory to change into.
     :type directory: ``str``
     """
-    old_directory = os.getcwd()
+    old_directory = os.environ["PWD"]
+    directory = fix_home_prefix(directory)
     os.chdir(directory)
     if "PWD" in os.environ:
         os.environ["PWD"] = directory

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -628,7 +628,10 @@ class TestRunner(Runnable):
             run, report = test_results[uid].run, test_results[uid].report
 
             if report.part:
-                if self.cfg.merge_scheduled_parts:
+                if (
+                    report.category != "task_rerun"
+                    and self.cfg.merge_scheduled_parts
+                ):
                     report.uid = report.name
                     # Save the report temporarily and later will merge it
                     test_rep_lookup.setdefault(report.uid, []).append(
@@ -647,6 +650,7 @@ class TestRunner(Runnable):
                             runnable.cfg._options["part"] = None
                             runnable._test_context = None
                             report = runnable.dry_run().report
+
                         else:
                             report = report.__class__(
                                 report.name,

--- a/tests/functional/testplan/runners/pools/test_task_rerun.py
+++ b/tests/functional/testplan/runners/pools/test_task_rerun.py
@@ -359,7 +359,10 @@ def test_task_rerun_with_parts():
             "failed": 1,
         }
 
+        # Run2 of part0 are merged with part1 and part2
         assert mockplan.report.entries[0].name == "MultiTestParts"
+
+        # Run1 of part0 (task_rerun) are left unmerged
         assert (
             mockplan.report.entries[1].name
             == "MultiTestParts - part(0/3) => Run 1"


### PR DESCRIPTION
## Bug / Requirement Description
Currently testplan will attempt to merge rerun part as well, and it raises exception.

## Solution description
disable merging for "task_rerun" type of entries.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
