### PR TITLE
rename EnvWithRuntime to RuntimeEnvironment

### DIFF
--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -11,6 +11,7 @@ from schema import Or, And, Use
 
 from testplan.common import config
 from testplan.common import entity
+from testplan.common.entity import Environment
 from testplan.common.utils import interface
 from testplan.common.utils import validation
 from testplan.common.utils import timing
@@ -77,8 +78,20 @@ class MultiTestRuntimeInfo(object):
         self.testcase = self.TestcaseInfo()
 
 
-class EnvWithRuntimeInfo(object):
-    def __init__(self, environment, runtime_info):
+class RuntimeEnvironment(object):
+    """
+    A collection of drivers accessible through either items or named attributes,
+    representing the environment of a Multitest environment instance with runtime
+    information about the currently executing testcase
+
+    This class is a tiny wrapper around the multitest's :class:`Environment`,
+    delegate all calls to it but multitest_runtime_info which serves the runtime information
+    of the current thread of execution.
+    """
+
+    def __init__(
+        self, environment: Environment, runtime_info: MultiTestRuntimeInfo
+    ):
         self.__dict__["_environment"] = environment
         self.__dict__["multitest_runtime_info"] = runtime_info
 
@@ -923,7 +936,7 @@ class MultiTest(testing_base.Test):
         runtime_info = MultiTestRuntimeInfo()
         runtime_info.testcase.name = testcase.name
 
-        resources = EnvWithRuntimeInfo(self.resources, runtime_info)
+        resources = RuntimeEnvironment(self.resources, runtime_info)
 
         with testcase_report.timer.record("run"):
             with testcase_report.logged_exceptions():

--- a/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
+++ b/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
@@ -7,7 +7,7 @@ import pytest
 
 
 from testplan.testing.filtering import Filter
-from testplan.testing.multitest.base import EnvWithRuntimeInfo
+from testplan.testing.multitest.base import RuntimeEnvironment
 from testplan.testing.ordering import NoopSorter
 
 from testplan.testing.multitest import MultiTest, testsuite, testcase
@@ -29,7 +29,7 @@ from testplan.common.utils.strings import slugify
 class MySuite(object):
     @testcase
     def test_drivers(self, env, result):
-        assert isinstance(env, EnvWithRuntimeInfo)
+        assert isinstance(env, RuntimeEnvironment)
         assert isinstance(env.server, TCPServer)
         assert env.server.cfg.name == "server"
         assert os.path.exists(env.server.runpath)
@@ -72,7 +72,7 @@ class MySuite(object):
         """
         Test context access from env and drivers.
         """
-        assert isinstance(env, EnvWithRuntimeInfo)
+        assert isinstance(env, RuntimeEnvironment)
         assert env.test_key == env["test_key"] == "test_value"
         assert env._environment is env.server.context
         assert env._environment is env.client.context


### PR DESCRIPTION
## Bug / Requirement Description
The EnvWithRuntime is not so nice name

## Solution description
 - changed the clas name to RuntimeEnvironment
 - added docs
 - added type annotation

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [x] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
