### PR TITLE
better naming in history

### DIFF
--- a/testplan/web_ui/testing/src/Report/BatchReport.js
+++ b/testplan/web_ui/testing/src/Report/BatchReport.js
@@ -21,6 +21,8 @@ import { generateSelectionPath } from './path';
 import { COLUMN_WIDTH } from "../Common/defaults";
 import { fakeReportAssertions } from "../Common/fakeReport";
 
+import _ from 'lodash';
+
 /**
  * BatchReport component:
  *   * fetch Testplan report.
@@ -227,16 +229,19 @@ class BatchReport extends React.Component {
 
   render() {
 
-    const { reportStatus, reportFetchMessage } = GetReportState(this.state);
-
-    if (this.state.report && this.state.report.name) {
-      window.document.title = this.state.report.name;
-    }
+    const { reportStatus, reportFetchMessage } = GetReportState(this.state);    
 
     const selectedEntries = GetSelectedEntries(
       getSelectedUIDsFromPath(this.props.match.params),
       this.state.filteredReport.report
     );
+
+    if (selectedEntries.length) {
+      window.document.title = `${_.last(selectedEntries).name} | \
+                               ${selectedEntries.slice(0, -1)
+                                                .map(entry => entry.name)
+                                                .join(" > ")}`;
+    }
 
     const centerPane = GetCenterPane(
       this.state,


### PR DESCRIPTION
document title is now looks like as breadcrumbs.
Looking better in browsers history

## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
