### PR TITLE
Avoid propagate testplan log to root logger

### DIFF
--- a/testplan/base.py
+++ b/testplan/base.py
@@ -451,6 +451,7 @@ class TestplanMock(Testplan):
         kwargs.setdefault("abort_signals", [])
         kwargs.setdefault("runpath", default_runpath_mock)
         kwargs.setdefault("parse_cmdline", False)
+        kwargs.setdefault("logger_level", logger.DEBUG)
 
         super(TestplanMock, self).__init__(*args, **kwargs)
         self._runnable._reset_report_uid = False

--- a/testplan/common/utils/logger.py
+++ b/testplan/common/utils/logger.py
@@ -134,6 +134,7 @@ def _initial_setup():
     stdout_handler.setFormatter(stdout_formatter)
     stdout_handler.setLevel(TEST_INFO)
     root_logger.addHandler(stdout_handler)
+    root_logger.propagate = False
 
     return root_logger, stdout_handler
 

--- a/testplan/common/utils/testing.py
+++ b/testplan/common/utils/testing.py
@@ -82,6 +82,17 @@ def disable_log_propagation(logger):
 
 
 @contextmanager
+def log_level_changed(logger, level):
+    """
+    Change log level for the given logger.
+    """
+    old_level = logger.level
+    logger.setLevel(level)
+    yield
+    logger.setLevel(old_level)
+
+
+@contextmanager
 def captured_logging(logger, level=logging.INFO):
     """
     Utility for capturing a logger object's output at a specific level, with a

--- a/tests/functional/testplan/exporters/testing/test_pdf.py
+++ b/tests/functional/testplan/exporters/testing/test_pdf.py
@@ -6,12 +6,8 @@ from testplan.testing.multitest.entries import base
 from testplan.testing.multitest.entries.schemas.base import registry
 
 from testplan import TestplanMock, defaults
-from testplan.common.utils.testing import (
-    log_propagation_disabled,
-    argv_overridden,
-)
+from testplan.common.utils.testing import argv_overridden
 from testplan.exporters.testing.pdf import PDFExporter, TagFilteredPDFExporter
-from testplan.common.utils.logger import TESTPLAN_LOGGER
 from testplan.report import (
     TestReport,
     TestCaseReport,
@@ -78,9 +74,7 @@ def test_create_pdf(tmpdir):
             passing="assertion-detail", failing="assertion-detail"
         ),
     )
-
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        exporter.export(report)
+    exporter.export(report)
 
     assert os.path.exists(pdf_path)
     assert os.stat(pdf_path).st_size > 0
@@ -128,9 +122,7 @@ def test_tag_filtered_pdf(tmpdir):
             {"simple": ("foo", "bar"), "color": "green"},
         ],
     )
-
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        exporter.export(report)
+    exporter.export(report)
 
     should_exist = [
         "report-tags-all-bar__foo.pdf",
@@ -177,20 +169,18 @@ def test_implicit_exporter_initialization(tmpdir):
         def test_membership(self, env, result):
             result.contain(1, [1, 2, 3])
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        with argv_overridden(
-            "--pdf",
-            pdf_path,
-            "--report-tags",
-            "foo",
-            "--report-dir",
-            pdf_dir.strpath,
-        ):
-            multitest = MultiTest(name="MyMultitest", suites=[MySuite()])
-
-            plan = TestplanMock(name="plan", parse_cmdline=True)
-            plan.add(multitest)
-            plan.run()
+    with argv_overridden(
+        "--pdf",
+        pdf_path,
+        "--report-tags",
+        "foo",
+        "--report-dir",
+        pdf_dir.strpath,
+    ):
+        multitest = MultiTest(name="MyMultitest", suites=[MySuite()])
+        plan = TestplanMock(name="plan", parse_cmdline=True)
+        plan.add(multitest)
+        plan.run()
 
     tag_pdf_path = pdf_dir.join("report-tags-any-foo.pdf").strpath
     assert os.path.exists(pdf_path)

--- a/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
+++ b/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
@@ -3,9 +3,7 @@
 import os
 import psutil
 
-from testplan.common.utils.logger import TESTPLAN_LOGGER
 from testplan.report import Status
-from testplan.common.utils.testing import log_propagation_disabled
 from testplan.common.utils.path import fix_home_prefix
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 from testplan.testing.multitest.base import MultiTestConfig
@@ -76,11 +74,6 @@ def multitest_kills_worker(parent_pid):
 
 def schedule_tests_to_pool(plan, pool, schedule_path=None, **pool_cfg):
     pool_name = pool.__name__
-
-    # Enable debug:
-    # from testplan.common.utils.logger import DEBUG
-    # TESTPLAN_LOGGER.setLevel(DEBUG)
-
     pool = pool(name=pool_name, **pool_cfg)
     plan.add_resource(pool)
 
@@ -101,8 +94,7 @@ def schedule_tests_to_pool(plan, pool, schedule_path=None, **pool_cfg):
             )
         )
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        res = plan.run()
+    res = plan.run()
 
     assert res.run is True
     assert res.success is True

--- a/tests/functional/testplan/runners/pools/test_pool_base.py
+++ b/tests/functional/testplan/runners/pools/test_pool_base.py
@@ -8,9 +8,6 @@ from testplan.testing.multitest.base import MultiTestConfig
 from testplan.runners.pools.base import Pool, Worker
 from testplan.common.utils.strings import slugify
 
-# from testplan.common.utils.testing import log_propagation_disabled
-# from testplan.common.utils.logger import TESTPLAN_LOGGER
-
 
 @testsuite
 class MySuite(object):
@@ -83,7 +80,6 @@ def schedule_tests_to_pool(plan, pool, **pool_cfg):
         )
     )
 
-    # with log_propagation_disabled(TESTPLAN_LOGGER):
     assert plan.run().run is True
 
     assert plan.report.passed is True

--- a/tests/functional/testplan/runners/pools/test_pool_process.py
+++ b/tests/functional/testplan/runners/pools/test_pool_process.py
@@ -4,10 +4,8 @@ import os
 
 import pytest
 
-from testplan.common.utils.testing import log_propagation_disabled
 from testplan.report import Status
 from testplan.runners.pools import ProcessPool
-from testplan.common.utils.logger import TESTPLAN_LOGGER
 from testplan.testing import multitest
 
 from tests.functional.testplan.runners.pools.func_pool_base_tasks import (
@@ -59,8 +57,7 @@ def test_kill_one_worker(mockplan):
             )
         )
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        res = mockplan.run()
+    res = mockplan.run()
 
     # Check that the worker killed by test was aborted
     assert (
@@ -110,8 +107,7 @@ def test_kill_all_workers(mockplan):
         resource=pool_name,
     )
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        res = mockplan.run()
+    res = mockplan.run()
 
     # Check that the worker killed by test was aborted
     assert (
@@ -157,8 +153,7 @@ def test_reassign_times_limit(mockplan):
         resource=pool_name,
     )
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        res = mockplan.run()
+    res = mockplan.run()
 
     # Check that the worker killed by test was aborted
     assert (
@@ -207,8 +202,7 @@ def test_disable_rerun_in_pool(mockplan):
         rerun=rerun_limit,
     )
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        res = mockplan.run()
+    res = mockplan.run()
 
     assert (
         len(
@@ -326,8 +320,7 @@ def test_restart_worker(mockplan):
             resource=pool_name,
         )
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        res = mockplan.run()
+    res = mockplan.run()
 
     # Check that all workers are restarted
     assert (

--- a/tests/functional/testplan/runners/pools/test_runner_e2e.py
+++ b/tests/functional/testplan/runners/pools/test_runner_e2e.py
@@ -9,13 +9,9 @@ import pytest
 from testplan import TestplanMock, Task
 from testplan.runners.pools import ProcessPool
 
-from testplan.common.utils.testing import (
-    check_report,
-    log_propagation_disabled,
-)
+from testplan.common.utils.testing import check_report
 
 from testplan.exporters.testing import PDFExporter
-from testplan.common.utils.logger import TESTPLAN_LOGGER
 
 
 from ..fixtures import assertions_failing, assertions_passing
@@ -95,9 +91,7 @@ def test_local_pool_integration(
     plan.add(multitest_maker())
 
     assert not os.path.exists(pdf_path)
-
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        assert plan.run().run is True
+    assert plan.run().run is True
 
     for log in plan.report.flattened_logs:
         if all(word in log["message"] for word in ["tkinter", "TclError"]):
@@ -169,9 +163,7 @@ def test_process_pool_integration(
     plan.schedule(task, resource="MyProcessPool")
 
     assert not os.path.exists(pdf_path)
-
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        assert plan.run().run is True
+    assert plan.run().run is True
 
     for log in plan.report.flattened_logs:
         if all(word in log["message"] for word in ["tkinter", "TclError"]):

--- a/tests/functional/testplan/testing/cpp/test_cppunit.py
+++ b/tests/functional/testplan/testing/cpp/test_cppunit.py
@@ -2,11 +2,7 @@ import os
 
 import pytest
 
-from testplan.common.utils.testing import (
-    log_propagation_disabled,
-    check_report,
-)
-from testplan.common.utils.logger import TESTPLAN_LOGGER
+from testplan.common.utils.testing import check_report
 from testplan.testing.cpp import Cppunit
 from testplan.report import Status
 
@@ -57,8 +53,7 @@ def test_cppunit(mockplan, binary_dir, expected_report, report_status):
 
     mockplan.add(Cppunit(name="My Cppunit", binary=binary_path))
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        assert mockplan.run().run is True
+    assert mockplan.run().run is True
 
     check_report(expected=expected_report, actual=mockplan.report)
 
@@ -74,8 +69,6 @@ def test_cppunit_no_report(mockplan):
         Cppunit(name="My Cppunit", binary=binary_path, file_output_flag="-y")
     )
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        assert mockplan.run().run is True
-
+    assert mockplan.run().run is True
     assert mockplan.report.status == Status.ERROR
     assert "FileNotFoundError" in mockplan.report.flattened_logs[-1]["message"]

--- a/tests/functional/testplan/testing/cpp/test_gtest.py
+++ b/tests/functional/testplan/testing/cpp/test_gtest.py
@@ -2,11 +2,7 @@ import os
 
 import pytest
 
-from testplan.common.utils.testing import (
-    log_propagation_disabled,
-    check_report,
-)
-from testplan.common.utils.logger import TESTPLAN_LOGGER
+from testplan.common.utils.testing import check_report
 from testplan.testing.cpp import GTest
 from testplan.report import Status
 
@@ -57,8 +53,7 @@ def test_gtest(mockplan, binary_dir, expected_report, report_status):
 
     mockplan.add(GTest(name="My GTest", binary=binary_path))
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        assert mockplan.run().run is True
+    assert mockplan.run().run is True
 
     check_report(expected=expected_report, actual=mockplan.report)
 
@@ -72,8 +67,6 @@ def test_gtest_no_report(mockplan):
 
     mockplan.add(GTest(name="My GTest", binary=binary_path))
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        assert mockplan.run().run is True
-
+    assert mockplan.run().run is True
     assert mockplan.report.status == Status.ERROR
     assert "FileNotFoundError" in mockplan.report.flattened_logs[-1]["message"]

--- a/tests/functional/testplan/testing/cpp/test_hobbestest.py
+++ b/tests/functional/testplan/testing/cpp/test_hobbestest.py
@@ -4,7 +4,6 @@ import pytest
 
 from testplan import TestplanMock
 from testplan.common.utils.testing import (
-    log_propagation_disabled,
     check_report,
     captured_logging,
     argv_overridden,
@@ -58,8 +57,7 @@ def test_hobbestest(mockplan, binary_dir, expected_report):
         )
     )
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        assert mockplan.run().run is True
+    assert mockplan.run().run is True
 
     check_report(expected=expected_report, actual=mockplan.report)
 
@@ -82,16 +80,15 @@ def test_hobbestest_listing(binary_dir, expected_output):
     with argv_overridden(*cmdline_args):
         plan = TestplanMock(name="plan", parse_cmdline=True)
 
-        with log_propagation_disabled(TESTPLAN_LOGGER):
-            with captured_logging(TESTPLAN_LOGGER) as log_capture:
-                plan.add(
-                    HobbesTest(
-                        name="My HobbesTest",
-                        binary=binary_path,
-                        tests=["Hog", "Net", "Recursives"],
-                    )
+        with captured_logging(TESTPLAN_LOGGER) as log_capture:
+            plan.add(
+                HobbesTest(
+                    name="My HobbesTest",
+                    binary=binary_path,
+                    tests=["Hog", "Net", "Recursives"],
                 )
-                result = plan.run()
-                print(log_capture.output)
-                assert log_capture.output == expected_output
-                assert len(result.test_report) == 0, "No tests should be run."
+            )
+            result = plan.run()
+            print(log_capture.output)
+            assert log_capture.output == expected_output
+            assert len(result.test_report) == 0, "No tests should be run."

--- a/tests/functional/testplan/testing/junit/test_junit.py
+++ b/tests/functional/testplan/testing/junit/test_junit.py
@@ -2,13 +2,9 @@
 import os
 
 import testplan.report
-from testplan.common.utils.logger import TESTPLAN_LOGGER
 from testplan.testing import junit
 from testplan.report import TestGroupReport, TestCaseReport
-from testplan.common.utils.testing import (
-    log_propagation_disabled,
-    check_report,
-)
+from testplan.common.utils.testing import check_report
 from pytest_test_filters import skip_on_windows
 
 CURRENT_PATH = os.path.dirname(os.path.abspath(__file__))
@@ -127,11 +123,11 @@ def test_run_test(mockplan):
         )
     )
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        assert mockplan.run().run is True
+    assert mockplan.run().run is True
 
     report = mockplan.report
     assert report.status == testplan.report.Status.FAILED
+
     mt_report = report.entries[0]
     assert len(mt_report.entries) == 3
 

--- a/tests/functional/testplan/testing/multitest/test_execution_groups.py
+++ b/tests/functional/testplan/testing/multitest/test_execution_groups.py
@@ -2,10 +2,7 @@ import time
 from collections import OrderedDict
 
 from testplan.testing.multitest import MultiTest, testsuite, testcase
-
-from testplan.common.utils.testing import log_propagation_disabled
 from testplan.report import TestGroupReport
-from testplan.common.utils.logger import TESTPLAN_LOGGER
 
 EXECUTION_PERIOD = 0.001
 
@@ -87,11 +84,8 @@ def test_execution_order(mockplan):
     multitest = MultiTest(
         name="MyMultitest", suites=[MySuite()], thread_pool_size=2
     )
-
     mockplan.add(multitest)
-
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        mockplan.run()
+    mockplan.run()
 
     result = get_testcase_execution_time(mockplan.report)
 

--- a/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
+++ b/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
@@ -16,13 +16,10 @@ from testplan import TestplanMock, defaults
 from testplan.common.entity.base import Environment, ResourceStatus
 from testplan.common.utils.context import context
 from testplan.common.utils.path import StdFiles, default_runpath
-from testplan.common.utils.testing import log_propagation_disabled
+from testplan.common.utils.strings import slugify
 from testplan.common.utils.timing import TimeoutException
 from testplan.testing.multitest.driver.base import Driver
 from testplan.testing.multitest.driver.tcp import TCPServer, TCPClient
-
-from testplan.common.utils.logger import TESTPLAN_LOGGER
-from testplan.common.utils.strings import slugify
 
 
 @testsuite
@@ -148,10 +145,9 @@ def test_multitest_drivers_in_testplan(runpath):
         assert server.status.tag == ResourceStatus.NONE
         assert client.status.tag == ResourceStatus.NONE
 
-        with log_propagation_disabled(TESTPLAN_LOGGER):
-            plan.run()
-
+        plan.run()
         res = plan.result
+
         assert res.run is True
         assert res.report.passed
         if idx == 0:
@@ -237,8 +233,7 @@ def test_multitest_driver_startup_failure(mockplan):
             ],
         )
     )
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        mockplan.run()
+    mockplan.run()
 
     res = mockplan.result
     assert res.run is True
@@ -269,8 +264,7 @@ def test_multitest_driver_fetch_error_log(mockplan):
             ],
         )
     )
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        mockplan.run()
+    mockplan.run()
 
     res = mockplan.result
     assert res.run is True

--- a/tests/functional/testplan/testing/multitest/test_multitest_parts.py
+++ b/tests/functional/testplan/testing/multitest/test_multitest_parts.py
@@ -6,8 +6,6 @@ from testplan import TestplanMock
 from testplan.runners.pools import ThreadPool
 from testplan.runners.pools.tasks import Task
 from testplan.report import Status
-from testplan.common.utils.testing import log_propagation_disabled
-from testplan.common.utils.logger import TESTPLAN_LOGGER
 
 
 @testsuite
@@ -76,8 +74,7 @@ def test_multi_parts_not_merged():
         task = Task(target=get_mtest(part_tuple=(idx, 3)))
         plan.schedule(task, resource="MyThreadPool")
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        assert plan.run().run is True
+    assert plan.run().run is True
 
     assert len(plan.report.entries) == 3
     assert plan.report.entries[0].name == "MTest - part(0/3)"
@@ -113,8 +110,7 @@ def test_multi_parts_merged():
         Task(target=get_mtest(part_tuple=(0, 3))), resource="MyThreadPool"
     )
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        assert plan.run().run is True
+    assert plan.run().run is True
 
     assert len(plan.report.entries) == 1
     assert plan.report.entries[0].name == "MTest"
@@ -148,8 +144,7 @@ def test_multi_parts_incorrect_schedule():
 
     assert len(plan._tests) == 5
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        assert plan.run().run is False
+    assert plan.run().run is False
 
     assert len(plan.report.entries) == 6  # one placeholder report & 5 siblings
     assert len(plan.report.entries[0].entries) == 0  # already cleared
@@ -178,8 +173,7 @@ def test_multi_parts_duplicate_part():
 
     assert len(plan._tests) == 4
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        assert plan.run().run is False
+    assert plan.run().run is False
 
     assert len(plan.report.entries) == 5  # one placeholder report & 4 siblings
     assert len(plan.report.entries[0].entries) == 0  # already cleared
@@ -203,8 +197,7 @@ def test_multi_parts_missing_parts():
         task = Task(target=get_mtest(part_tuple=(idx, 3)))
         plan.schedule(task, resource="MyThreadPool")
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        assert plan.run().run is False
+    assert plan.run().run is False
 
     assert len(plan.report.entries) == 3  # one placeholder report & 2 siblings
     assert len(plan.report.entries[0].entries) == 0  # already cleared
@@ -224,8 +217,7 @@ def test_multi_parts_not_successfully_executed():
     plan.add(MockMultiTest(name="MTest", suites=[Suite1()], part=(0, 2)))
     plan.add(MockMultiTest(name="MTest", suites=[Suite1()], part=(1, 2)))
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        assert plan.run().run is False
+    assert plan.run().run is False
 
     assert len(plan.report.entries) == 3  # one placeholder report & 2 siblings
     assert len(plan.report.entries[0].entries) == 0  # already cleared

--- a/tests/functional/testplan/testing/multitest/test_parametrization.py
+++ b/tests/functional/testplan/testing/multitest/test_parametrization.py
@@ -18,12 +18,7 @@ from testplan.report import (
     TestCaseReport,
     ReportCategories,
 )
-from testplan.common.utils.testing import (
-    check_report,
-    warnings_suppressed,
-    log_propagation_disabled,
-)
-from testplan.common.utils.logger import TESTPLAN_LOGGER
+from testplan.common.utils.testing import check_report, warnings_suppressed
 
 LOGGER = logging.getLogger()
 
@@ -56,9 +51,7 @@ def check_parametrization(
     tag_dict = tag_dict or {}
     multitest = MultiTest(name="MyMultitest", suites=[suite_kls()])
     mockplan.add(multitest)
-
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        mockplan.run()
+    mockplan.run()
 
     if testcase_uids:
         suite_report = mockplan.report.entries[0].entries[0]
@@ -487,9 +480,7 @@ def test_unwanted_testcase_name(mockplan):
 
         multitest = MultiTest(name="MyMultitest", suites=[MySuite()])
         mockplan.add(multitest)
-
-        with log_propagation_disabled(TESTPLAN_LOGGER):
-            mockplan.run()
+        mockplan.run()
 
     mock_warn.assert_called_once()
 

--- a/tests/functional/testplan/testing/multitest/test_pre_post_steps.py
+++ b/tests/functional/testplan/testing/multitest/test_pre_post_steps.py
@@ -1,18 +1,13 @@
 import os
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 
-from testplan.common.utils.testing import (
-    check_report,
-    log_propagation_disabled,
-)
+from testplan.common.utils.testing import check_report
 from testplan.report import (
     TestReport,
     TestGroupReport,
     TestCaseReport,
     ReportCategories,
 )
-from testplan.common.utils.logger import TESTPLAN_LOGGER
-
 
 CURRENT_FILE = os.path.abspath(__file__)
 
@@ -98,9 +93,7 @@ def test_pre_post_steps(mockplan):
     )
 
     mockplan.add(multitest)
-
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        mockplan.run()
+    mockplan.run()
 
     check_report(expected_report, mockplan.report)
     assert len(mockplan.report.attachments) == 2

--- a/tests/functional/testplan/testing/multitest/test_stop_on_error.py
+++ b/tests/functional/testplan/testing/multitest/test_stop_on_error.py
@@ -2,10 +2,7 @@ import time
 
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 
-from testplan.common.utils.testing import (
-    check_report,
-    log_propagation_disabled,
-)
+from testplan.common.utils.testing import check_report
 from testplan.report import (
     Status,
     TestReport,
@@ -13,7 +10,6 @@ from testplan.report import (
     TestCaseReport,
     ReportCategories,
 )
-from testplan.common.utils.logger import TESTPLAN_LOGGER
 
 
 @testsuite
@@ -111,9 +107,7 @@ def test_execution_order(mockplan):
 
     mockplan.add(multitest_1)
     mockplan.add(multitest_2)
-
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        mockplan.run()
+    mockplan.run()
 
     expected_report = TestReport(
         name="plan",

--- a/tests/functional/testplan/testing/multitest/test_suite_decorators.py
+++ b/tests/functional/testplan/testing/multitest/test_suite_decorators.py
@@ -14,8 +14,6 @@ from testplan.testing.multitest.suite import (
     skip_if_testcase,
 )
 from testplan.common.utils.callable import pre, post
-from testplan.common.utils.testing import log_propagation_disabled
-from testplan.common.utils.logger import TESTPLAN_LOGGER
 from testplan.report import (
     TestReport,
     TestGroupReport,
@@ -113,9 +111,7 @@ def test_basic_multitest(mockplan):
         name="MTest", suites=[Suite1(), Suite2(0), Suite2(1), Suite3()]
     )
     mockplan.add(mtest)
-
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        res = mockplan.run()
+    res = mockplan.run()
 
     assert res.run is True
     assert isinstance(res.test_results["MTest"].report, TestGroupReport)
@@ -168,9 +164,7 @@ def test_unwanted_testsuite_name(mockplan, suite_name):
 
         multitest = MultiTest(name="MTest", suites=[MySuite()])
         mockplan.add(multitest)
-
-        with log_propagation_disabled(TESTPLAN_LOGGER):
-            mockplan.run()
+        mockplan.run()
 
     mock_warn.assert_called_once()
 
@@ -190,9 +184,7 @@ def test_duplicate_testsuite_names(mockplan):
 
         multitest = MultiTest(name="MTest", suites=[MySuite(0), MySuite(1)])
         mockplan.add(multitest)
-
-        with log_propagation_disabled(TESTPLAN_LOGGER):
-            mockplan.run()
+        mockplan.run()
 
         pytest.fail("Duplicate test suite name found in a Multitest.")
 
@@ -217,9 +209,7 @@ def test_invalid_name_attribute_in_suite_class(mockplan, deco, attr_name):
         MySuite = deco(MySuite)
         multitest = MultiTest(name="MyMultitest", suites=[MySuite()])
         mockplan.add(multitest)
-
-        with log_propagation_disabled(TESTPLAN_LOGGER):
-            mockplan.run()
+        mockplan.run()
 
         pytest.fail("Attribute `name` defined in test suite class is invalid.")
 
@@ -241,9 +231,7 @@ def test_unexpected_name_attribute_in_suite_object(mockplan):
         suite.name = lambda cls_name, suite: cls_name
         multitest = MultiTest(name="MyMultitest", suites=[suite])
         mockplan.add(multitest)
-
-        with log_propagation_disabled(TESTPLAN_LOGGER):
-            mockplan.run()
+        mockplan.run()
 
         pytest.fail("Attribute `name` of test suite object is invalid.")
 
@@ -273,8 +261,7 @@ def test_testcase_related_with_inivalid_arguments_in_suite_object(mockplan):
     mockplan.add(
         MultiTest(name="MyMultitest", suites=[MySuite()], stop_on_error=False)
     )
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        mockplan.run()
+    mockplan.run()
 
     multitest_report = mockplan.result.report["MyMultitest"]
     case_report = multitest_report["MySuite"]["sample_test"]
@@ -326,8 +313,7 @@ def test_pre_post_on_testcase(mockplan):
             result.equal(a + b, expect)
 
     mockplan.add(MultiTest(name="MyMultitest", suites=[SimpleTest()]))
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        mockplan.run()
+    mockplan.run()
 
     multitest_report = mockplan.result.report["MyMultitest"]
     case_report = multitest_report["SimpleTest"]["add_simple"]

--- a/tests/functional/testplan/testing/multitest/test_timeout_on_testcases.py
+++ b/tests/functional/testplan/testing/multitest/test_timeout_on_testcases.py
@@ -5,10 +5,7 @@ from testplan.testing.multitest import MultiTest, testsuite, testcase
 from testplan.runners.pools import ThreadPool
 from testplan.runners.pools.tasks import Task
 
-from testplan.common.utils.testing import (
-    check_report,
-    log_propagation_disabled,
-)
+from testplan.common.utils.testing import check_report
 from testplan.report import (
     Status,
     TestReport,
@@ -16,7 +13,6 @@ from testplan.report import (
     TestCaseReport,
     ReportCategories,
 )
-from testplan.common.utils.logger import TESTPLAN_LOGGER
 
 
 @testsuite
@@ -71,8 +67,7 @@ def test_timeout_on_testcases(mockplan):
     task = Task(target=get_mtest())
     mockplan.schedule(task, resource="MyPool")
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        mockplan.run()
+    mockplan.run()
 
     expected_report = TestReport(
         name="plan",

--- a/tests/functional/testplan/testing/test_base.py
+++ b/tests/functional/testplan/testing/test_base.py
@@ -7,12 +7,7 @@ from testplan.testing.base import ProcessRunnerTest
 from testplan.testing.multitest.driver.base import Driver, DriverConfig
 
 from testplan.common.config import ConfigOption
-from testplan.common.utils.testing import (
-    log_propagation_disabled,
-    check_report,
-)
-
-from testplan.common.utils.logger import TESTPLAN_LOGGER
+from testplan.common.utils.testing import check_report
 
 from .fixtures import base
 
@@ -89,10 +84,7 @@ fixture_root = os.path.join(os.path.dirname(__file__), "fixtures", "base")
 def test_process_runner(mockplan, binary_path, expected_report, test_kwargs):
 
     process_test = DummyTest(name="MyTest", binary=binary_path, **test_kwargs)
-
     mockplan.add(process_test)
-
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        assert mockplan.run().run is True
+    assert mockplan.run().run is True
 
     check_report(expected=expected_report, actual=mockplan.report)

--- a/tests/functional/testplan/testing/test_filtering.py
+++ b/tests/functional/testplan/testing/test_filtering.py
@@ -4,11 +4,9 @@ from testplan.testing.multitest import MultiTest, testsuite, testcase
 
 from testplan import TestplanMock
 from testplan.common.utils.testing import (
-    log_propagation_disabled,
     argv_overridden,
     check_report_context,
 )
-from testplan.common.utils.logger import TESTPLAN_LOGGER
 from testplan.testing import filtering
 
 
@@ -179,9 +177,7 @@ def test_programmatic_filtering(filter_obj, report_ctx):
     plan = TestplanMock(name="plan", test_filter=filter_obj)
     plan.add(multitest_x)
     plan.add(multitest_y)
-
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        plan.run()
+    plan.run()
 
     test_report = plan.report
     check_report_context(test_report, report_ctx)
@@ -281,9 +277,7 @@ def test_command_line_filtering(cmdline_args, report_ctx):
         plan = TestplanMock(name="plan", parse_cmdline=True)
         plan.add(multitest_x)
         plan.add(multitest_y)
-
-        with log_propagation_disabled(TESTPLAN_LOGGER):
-            plan.run()
+        plan.run()
 
     test_report = plan.report
     check_report_context(test_report, report_ctx)

--- a/tests/functional/testplan/testing/test_label.py
+++ b/tests/functional/testplan/testing/test_label.py
@@ -1,9 +1,5 @@
-from testplan.common.utils.testing import (
-    log_propagation_disabled,
-)
 from testplan import TestplanMock
 from testplan.testing.multitest import MultiTest, testsuite, testcase
-from testplan.common.utils.logger import TESTPLAN_LOGGER
 
 
 @testsuite
@@ -21,8 +17,6 @@ def test_label():
         suites=[AlphaSuite()],
     )
     mockplan.add(multitest)
-
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        mockplan.run()
+    mockplan.run()
 
     assert mockplan.report.label == "my_label"

--- a/tests/functional/testplan/testing/test_listing.py
+++ b/tests/functional/testplan/testing/test_listing.py
@@ -5,7 +5,6 @@ from testplan.testing.multitest import MultiTest, testsuite, testcase
 from testplan import TestplanMock
 from testplan.common.utils.testing import (
     captured_logging,
-    log_propagation_disabled,
     argv_overridden,
     to_stdout,
 )
@@ -176,15 +175,14 @@ def test_programmatic_listing(
         runpath=runpath,
     )
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        with captured_logging(TESTPLAN_LOGGER) as log_capture:
-            plan.add(multitest_x)
-            plan.add(multitest_y)
+    with captured_logging(TESTPLAN_LOGGER) as log_capture:
+        plan.add(multitest_x)
+        plan.add(multitest_y)
 
-            assert log_capture.output == expected_output
+        assert log_capture.output == expected_output
 
-            result = plan.run()
-            assert len(result.test_report) == 0, "No tests should be run."
+        result = plan.run()
+        assert len(result.test_report) == 0, "No tests should be run."
 
 
 @pytest.mark.parametrize(
@@ -214,15 +212,14 @@ def test_command_line_listing(runpath, cmdline_args, expected_output):
     with argv_overridden(*cmdline_args):
         plan = TestplanMock(name="plan", parse_cmdline=True, runpath=runpath)
 
-        with log_propagation_disabled(TESTPLAN_LOGGER):
-            with captured_logging(TESTPLAN_LOGGER) as log_capture:
-                plan.add(multitest_x)
-                plan.add(multitest_y)
+        with captured_logging(TESTPLAN_LOGGER) as log_capture:
+            plan.add(multitest_x)
+            plan.add(multitest_y)
 
-                result = plan.run()
+            result = plan.run()
 
-                assert log_capture.output == expected_output
-                assert len(result.test_report) == 0, "No tests should be run."
+            assert log_capture.output == expected_output
+            assert len(result.test_report) == 0, "No tests should be run."
 
 
 NUM_TESTS = 100
@@ -289,11 +286,10 @@ def test_testcase_trimming(runpath, listing_obj, expected_output):
 
     plan = TestplanMock(name="plan", test_lister=listing_obj, runpath=runpath)
 
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        with captured_logging(TESTPLAN_LOGGER) as log_capture:
-            plan.add(multitest_x)
+    with captured_logging(TESTPLAN_LOGGER) as log_capture:
+        plan.add(multitest_x)
 
-            assert log_capture.output == expected_output
+        assert log_capture.output == expected_output
 
-            result = plan.run()
-            assert len(result.test_report) == 0, "No tests should be run."
+        result = plan.run()
+        assert len(result.test_report) == 0, "No tests should be run."

--- a/tests/functional/testplan/testing/test_ordering.py
+++ b/tests/functional/testplan/testing/test_ordering.py
@@ -4,11 +4,9 @@ from testplan.testing.multitest import MultiTest, testsuite, testcase
 
 from testplan import TestplanMock
 from testplan.common.utils.testing import (
-    log_propagation_disabled,
     argv_overridden,
     check_report_context,
 )
-from testplan.common.utils.logger import TESTPLAN_LOGGER
 from testplan.testing import ordering
 
 
@@ -224,9 +222,7 @@ def test_programmatic_ordering(sorter, report_ctx):
     multitest = MultiTest(name="Multitest", suites=[Beta(), Alpha()])
     plan = TestplanMock(name="plan", test_sorter=sorter)
     plan.add(multitest)
-
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        plan.run()
+    plan.run()
 
     test_report = plan.report
     check_report_context(test_report, report_ctx)
@@ -404,9 +400,7 @@ def test_command_line_ordering(cmdline_args, report_ctx):
     with argv_overridden(*cmdline_args):
         plan = TestplanMock(name="plan", parse_cmdline=True)
         plan.add(multitest)
-
-        with log_propagation_disabled(TESTPLAN_LOGGER):
-            plan.run()
+        plan.run()
 
     test_report = plan.report
     check_report_context(test_report, report_ctx)

--- a/tests/functional/testplan/testing/test_tagging.py
+++ b/tests/functional/testplan/testing/test_tagging.py
@@ -1,13 +1,9 @@
 import pytest
 
-from testplan.common.utils.testing import (
-    check_report,
-    log_propagation_disabled,
-)
+from testplan.common.utils.testing import check_report
 
 from testplan.report import TestReport, TestGroupReport, TestCaseReport
 from testplan.testing.multitest import MultiTest, testsuite, testcase
-from testplan.common.utils.logger import TESTPLAN_LOGGER
 
 
 @testsuite(tags={"color": ["red", "blue"]})
@@ -203,11 +199,8 @@ def test_multitest_tagging(mockplan, multitest_tags, expected_report):
         suites=[AlphaSuite(), BetaSuite(), GammaSuite()],
         tags=multitest_tags,
     )
-
     mockplan.add(multitest)
-
-    with log_propagation_disabled(TESTPLAN_LOGGER):
-        mockplan.run()
+    mockplan.run()
 
     check_report(
         expected=TestReport(name="plan", entries=[expected_report]),

--- a/tests/unit/testplan/report/test_testing.py
+++ b/tests/unit/testplan/report/test_testing.py
@@ -16,7 +16,7 @@ from testplan.report.testing.base import (
     TestReport,
     ReportCategories,
 )
-from testplan.report.testing.schemas import TestReportSchema, EntriesField
+from testplan.report.testing.schemas import TestReportSchema
 from testplan.common import report, entity
 from testplan.common.utils.testing import check_report
 from testplan.testing.multitest.result import Result

--- a/tests/unit/testplan/test_plan_base.py
+++ b/tests/unit/testplan/test_plan_base.py
@@ -13,11 +13,7 @@ from testplan.common.entity import (
 )
 from testplan.common.utils.exceptions import should_raise
 from testplan.common.utils.path import default_runpath
-from testplan.common.utils.testing import (
-    argv_overridden,
-    log_propagation_disabled,
-)
-from testplan.common.utils.logger import TESTPLAN_LOGGER
+from testplan.common.utils.testing import argv_overridden
 from testplan.report import TestGroupReport, ReportCategories
 from testplan.runnable import TestRunnerStatus, TestRunner
 from testplan.runners.local import LocalRunner
@@ -171,23 +167,22 @@ def test_testplan_decorator():
 
     pdf_path = "mypdf.pdf"
     with argv_overridden("--pdf", pdf_path):
-        with log_propagation_disabled(TESTPLAN_LOGGER):
 
-            @test_plan(name="MyPlan", port=800)
-            def main2(plan, parser):
-                args = parser.parse_args()
+        @test_plan(name="MyPlan", port=800)
+        def main2(plan, parser):
+            args = parser.parse_args()
 
-                assert args.verbose is False
-                assert args.pdf_path == pdf_path
-                assert plan.cfg.pdf_path == pdf_path
-                plan.add(DummyTest(name="bob"))
+            assert args.verbose is False
+            assert args.pdf_path == pdf_path
+            assert plan.cfg.pdf_path == pdf_path
+            plan.add(DummyTest(name="bob"))
 
-            res = (
-                main2()
-            )  # pylint:disable=assignment-from-no-return,no-value-for-parameter
-            assert isinstance(res, TestplanResult)
-            assert res.decorated_value is None
-            assert res.run is True
+        res = (
+            main2()
+        )  # pylint:disable=assignment-from-no-return,no-value-for-parameter
+        assert isinstance(res, TestplanResult)
+        assert res.decorated_value is None
+        assert res.run is True
 
 
 def test_testplan_runpath():


### PR DESCRIPTION
* In Testplan project the top-level logger is 'testplan', its has a
  stream handler and a file handler. Then it should not propagate any
  log record to its parent (system root logger) since that other libs
  may add handlers to root logger then unwanted content be printed to
  console. So we don't need that `log_propagation_disabled` decorator.
* Mock plan set `logger_level` to DEBUG so the details can be captured
  by PyTest as standard output. And in our test no need to disable log
  propagation everywhere (if no verbose output is expected just set
  `logger_level` of mockplan).
