### PR TITLE
Add a simple fix parser that recogonise tag 9 for FixServer/FixClient…

### DIFF
--- a/testplan/common/utils/sockets/client.py
+++ b/testplan/common/utils/sockets/client.py
@@ -6,8 +6,7 @@ import socket
 
 class Client(object):
     """
-    A Basic TCP Client
-    Connects to a server via the standard Session Protocol.
+    A Basic TCP Client that connects to a server via socket interface.
 
     To use this type:
 

--- a/testplan/common/utils/sockets/fix/client.py
+++ b/testplan/common/utils/sockets/fix/client.py
@@ -5,13 +5,13 @@ import socket
 
 from testplan.common.utils.sockets.fix.utils import utc_timestamp
 
-from .parser import tagsoverride
+from .parser import tagsoverride, FixParser
 
 
 class Client(object):
     """
     A Basic FIX Client
-    Connects to a FIX server via the standard Session Protocol.
+    Connects to a FIX server via the FIX session protocol.
     """
 
     def __init__(
@@ -154,19 +154,15 @@ class Client(object):
         """
         self.socket.settimeout(float(timeout))
 
-        buffer = self.socket.recv(8)  # 7 + 1 delimiter + checksum tag
-        while 1:
-            data = self.socket.recv(1)
-            if not data:
-                break
-            buffer += data
-            if buffer.endswith(b"\x01"):
-                if buffer[-8:].startswith(
-                    b"\x0110="
-                ):  # If received checksum tag
-                    break
+        data = self.socket.recv(1)
+
+        parser = FixParser()
+        size = parser.consume(data)
+        while size:
+            size = parser.consume(self.socket.recv(size))
+
         self.in_seqno += 1
-        return self.msgclass.from_buffer(buffer, self.codec)
+        return self.msgclass.from_buffer(parser.buffer, self.codec)
 
     def sendlogoff(self, custom_tags=None):
         """

--- a/testplan/common/utils/sockets/fix/parser.py
+++ b/testplan/common/utils/sockets/fix/parser.py
@@ -1,6 +1,7 @@
 """
 FIX messages parser.
 """
+from enum import Enum
 
 
 def tagsoverride(msg, override):
@@ -14,3 +15,62 @@ def tagsoverride(msg, override):
         else:
             msg[tag] = value
     return msg
+
+
+class FixParser(object):
+    """
+    A barebones FIX parser
+    """
+
+    class State(Enum):
+        """
+        State enum for FixParser
+        """
+
+        NotStarted = 0
+        ReadingHeader = 1
+        ReadingLength = 2
+        ReadingBody = 3
+        ReadingCheckSum = 4
+
+    def __init__(self):
+        """
+        Default constructor for FixParser
+        """
+        self.buffer = b""
+        self.length_buffer = b""
+        self.length = 0
+        self.state = self.State.NotStarted
+
+    def consume(self, buf):
+        """
+        Consume buf and return the number of bytes to read
+        """
+        if self.state == self.State.NotStarted:
+            if buf == b"8" or buf == b"9":
+                self.buffer += buf
+                self.state = self.State.ReadingHeader
+                return 1
+            return 0
+        elif self.state == self.State.ReadingHeader:
+            self.buffer += buf
+            if self.buffer[-3:] == b"\x019=" or self.buffer == b"9=":
+                self.state = self.State.ReadingLength
+            return 1
+        elif self.state == self.State.ReadingLength:
+            if buf == b"\x01":
+                self.buffer += self.length_buffer + buf
+                self.state = self.State.ReadingBody
+                return int(self.length_buffer, 10)
+            else:
+                self.length_buffer += buf
+                return 1
+        elif self.state == self.State.ReadingBody:
+            self.buffer += buf
+            self.state = self.State.ReadingCheckSum
+            return 7
+        elif self.state == self.State.ReadingCheckSum:
+            if not (buf.startswith(b"10=") and buf.endswith(b"\x01")):
+                raise Exception('Incorrect checksum: "{}"'.format(buf))
+            self.buffer += buf
+            return 0

--- a/testplan/common/utils/sockets/server.py
+++ b/testplan/common/utils/sockets/server.py
@@ -10,7 +10,7 @@ from testplan.common.utils.timing import wait
 
 class Server(object):
     """
-    A server that can send and receive messages over the session protocol.
+    A server that can send and receive messages based on socket interface.
     Supports multiple connections.
 
     :param host: The host address the server is bound to.
@@ -167,9 +167,9 @@ class Server(object):
         connection.settimeout(timeout)
 
         if wait_full_size is False:
-            connection.settimeout(timeout)
-            msg = connection.recv(size)
             connection.settimeout(0)
+            msg = connection.recv(size)
+            connection.settimeout(timeout)
         else:
             with self._lock:
                 msg = b""

--- a/testplan/testing/multitest/driver/base.py
+++ b/testplan/testing/multitest/driver/base.py
@@ -142,7 +142,7 @@ class Driver(Resource):
         post_start=None,
         pre_stop=None,
         post_stop=None,
-        **options
+        **options,
     ):
 
         options.update(self.filter_locals(locals()))
@@ -433,3 +433,8 @@ class Driver(Resource):
                 content.extend(["  {}".format(line) for line in lines])
 
         return content
+
+    def __repr__(self):
+        """String representation."""
+
+        return f"{self.__class__.__name__} driver [{self.name}]"

--- a/tests/unit/testplan/testing/multitest/driver/test_fix_server.py
+++ b/tests/unit/testplan/testing/multitest/driver/test_fix_server.py
@@ -1,0 +1,82 @@
+"""Unit tests for TCP Server driver."""
+
+import os
+import pytest
+
+pytest.importorskip("pyfixmsg")
+
+from pyfixmsg.fixmessage import FixMessage
+from pyfixmsg.codecs.stringfix import Codec
+from pyfixmsg.reference import FixSpec
+from testplan.testing.multitest.driver.fix import FixServer, FixClient
+
+SPEC_FILE = os.environ["FIX_SPEC_FILE"]
+CODEC = Codec(spec=FixSpec(SPEC_FILE))
+
+
+@pytest.fixture(scope="function")
+def fix_server(mockplan):
+    """Start and yield a TCP server driver."""
+    server = FixServer(
+        name="server",
+        msgclass=FixMessage,
+        codec=CODEC,
+    )
+    server.parent = mockplan
+
+    with server:
+        yield server
+
+
+@pytest.fixture(scope="function")
+def fix_client(fix_server, mockplan):
+    """Start and yield a TCP client driver."""
+
+    client = FixClient(
+        name="client",
+        host=fix_server.host,
+        port=fix_server.port,
+        sender="TW",
+        target="ISLD",
+        msgclass=FixMessage,
+        codec=CODEC,
+    )
+    client.parent = mockplan
+
+    with client:
+        yield client
+
+
+def fixmsg(source):
+    msg = FixMessage(source)
+    msg.codec = CODEC
+    return msg
+
+
+def test_successive_send(fix_client, fix_server):
+    msg1 = fixmsg(
+        {
+            8: "FIX.4.2",
+            35: "D",
+        }
+    )
+    msg2 = fixmsg(
+        {
+            8: "FIX.4.2",
+            35: "8",
+        }
+    )
+
+    for sender, receiver in (
+        (fix_client, fix_server),
+        (fix_server, fix_client),
+    ):
+
+        sender.send(msg1)
+        sender.send(msg2)
+
+        rcv1 = receiver.receive()
+        rcv2 = receiver.receive()
+
+        assert rcv1[35] == "D"
+        assert rcv2[35] == "8"


### PR DESCRIPTION
… to read fix message from socket.

## Bug / Requirement Description
FixServer is not able to read from socket correctly, when client side sends message successively.

## Solution description
The issue is that it is receiving with a fixed buffer size. This change is to employ a simple fix parser that would look at tag 9 and read proper size of data from the socket.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
