### PR TITLE
Driver name conflicts with internal testplan named entities

### DIFF
--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -129,8 +129,8 @@ A MultiTest instance can be constructed from the following parameters:
   required for interacting with it, such as network connections.
 
 * **Runtime Information**: The environment always contains a member called
-  ``multitest_runtime_info`` which contains information about the current state of
-  the run. See: :py:class:`MultiTestRuntimeInfo <testplan.testing.multitest.base.MultiTestRuntimeInfo>`
+  ``runtime_info`` which contains information about the current state of the
+  run. See: :py:class:`MultiTestRuntimeInfo <testplan.testing.multitest.base.MultiTestRuntimeInfo>`
 
 * **Initial Context**: The initial context is an optional way to pass
   information to be used by drivers and from within testcases. When drivers are

--- a/examples/Attachments/test_plan.py
+++ b/examples/Attachments/test_plan.py
@@ -119,7 +119,7 @@ class TestSuite(object):
             draw.rectangle([x1, y1, x2, y2], outline=(0, 0, 0, 255))
 
         # Save image
-        img_path = os.path.join(env.runpath, "image.png")
+        img_path = os.path.join(env.parent.runpath, "image.png")
         im.save(img_path)
 
         # Attach to report.

--- a/examples/Multitest/Basic/Name Customization/test_plan.py
+++ b/examples/Multitest/Basic/Name Customization/test_plan.py
@@ -35,9 +35,7 @@ class SimpleSuite(object):
 
     @testcase(name="A simple testcase")
     def test_example(self, env, result):
-        result.equal(
-            env.multitest_runtime_info.testcase.name, "A simple testcase"
-        )
+        result.equal(env.runtime_info.testcase.name, "A simple testcase")
 
     @testcase(
         name="Parametrized testcases",
@@ -47,7 +45,7 @@ class SimpleSuite(object):
     def test_equal(self, env, result, a, b, expected):
         result.equal(a + b, expected, description="Equality test")
         result.equal(
-            env.multitest_runtime_info.testcase.name,
+            env.runtime_info.testcase.name,
             case_name_func(
                 "Parametrized testcases",
                 {"a": a, "b": b, "expected": expected},

--- a/testplan/common/utils/context.py
+++ b/testplan/common/utils/context.py
@@ -65,12 +65,12 @@ class ContextValue(object):
         """
         if ctx is None:
             raise ValueError(
-                "Could not retrieve driver {0} value from "
-                "NoneType context.".format(self.driver)
+                f'Could not retrieve driver "{self.driver}" value'
+                " from NoneType context."
             )
         if self.driver not in ctx:
-            raise Exception(
-                "Driver {0} is not present in context.".format(self.driver)
+            raise RuntimeError(
+                f'Driver "{self.driver}" is not present in context.'
             )
         return self.value.substitute(ctx[self.driver].context_input())
 

--- a/testplan/environment.py
+++ b/testplan/environment.py
@@ -96,13 +96,13 @@ class Environments(Resource):
 
     def starting(self):
         """Start all added environments."""
-        for env in self._envs:
-            env.start()
+        for uid in self._envs:
+            self._envs[uid].start()
 
     def stopping(self):
         """Stop all added environments."""
-        for env in self._envs:
-            env.stop()
+        for uid in self._envs:
+            self._envs[uid].stop()
 
     def abort_dependencies(self):
         """Abort all resources on all environments."""

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -133,6 +133,7 @@ class Test(Runnable):
                 )
             )
 
+        self.resources._initial_context = self.cfg.initial_context
         for resource in self.cfg.environment:
             resource.parent = self
             resource.cfg.parent = self.cfg

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -11,7 +11,6 @@ from schema import Or, And, Use
 
 from testplan.common import config
 from testplan.common import entity
-from testplan.common.entity import Environment
 from testplan.common.utils import interface
 from testplan.common.utils import validation
 from testplan.common.utils import timing
@@ -63,12 +62,12 @@ def iterable_suites(obj):
 
 class MultiTestRuntimeInfo(object):
     """
-    This class provide information about the state of the actual test run
-    that is accessible from the testcases through the environment as:
-    ``env.multitest_runtime_info``
+    This class provides information about the state of the actual test run
+    that is accessible from the testcase through the environment as:
+    ``env.runtime_info``
 
     Currently only the actual testcase name is accessible as:
-    ``env.multitest_runtime_info.testcase.name`` more info to come.
+    ``env.runtime_info.testcase.name``, more info to come.
     """
 
     class TestcaseInfo(object):
@@ -80,20 +79,23 @@ class MultiTestRuntimeInfo(object):
 
 class RuntimeEnvironment(object):
     """
-    A collection of drivers accessible through either items or named attributes,
-    representing the environment of a Multitest environment instance with runtime
-    information about the currently executing testcase
+    A collection of resources accessible through either items or named
+    attributes, representing a test environment instance with runtime
+    information about the currently executing testcase.
 
-    This class is a tiny wrapper around the multitest's :class:`Environment`,
-    delegate all calls to it but multitest_runtime_info which serves the runtime information
-    of the current thread of execution.
+    This class is a tiny wrapper around the :py:class:`Environment` of
+    :py:class:`~testplan.testing.base.Test`, delegates all calls to it
+    but with a `runtime_info` which serves the runtime information of
+    the current thread of execution.
     """
 
     def __init__(
-        self, environment: Environment, runtime_info: MultiTestRuntimeInfo
+        self,
+        environment: entity.Environment,
+        runtime_info: MultiTestRuntimeInfo,
     ):
         self.__dict__["_environment"] = environment
-        self.__dict__["multitest_runtime_info"] = runtime_info
+        self.__dict__["runtime_info"] = runtime_info
 
     def __getattr__(self, attr):
         return getattr(self._environment, attr)
@@ -935,7 +937,6 @@ class MultiTest(testing_base.Test):
 
         runtime_info = MultiTestRuntimeInfo()
         runtime_info.testcase.name = testcase.name
-
         resources = RuntimeEnvironment(self.resources, runtime_info)
 
         with testcase_report.timer.record("run"):

--- a/testplan/testing/py_test.py
+++ b/testplan/testing/py_test.py
@@ -11,7 +11,6 @@ from schema import Or
 from testplan.common.utils import validation
 from testplan.common.config import ConfigOption
 from testplan.testing import base as testing
-from testplan.testing.base import TestResult
 from testplan.testing.multitest.entries import assertions
 from testplan.testing.multitest.entries import base as entries_base
 from testplan.testing.multitest.result import Result as MultiTestResult

--- a/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
+++ b/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
@@ -15,10 +15,10 @@ class MySuite(object):
     @testcase
     def test_comparison(self, env, result):
         result.equal(1, 1, "equality description")
-        result.log(env.runpath)
-        assert isinstance(env.cfg, MultiTestConfig)
-        assert os.path.exists(env.runpath) is True
-        assert env.runpath.endswith(slugify(env.cfg.name))
+        result.log(env.parent.runpath)
+        assert isinstance(env.parent.cfg, MultiTestConfig)
+        assert os.path.exists(env.parent.runpath) is True
+        assert env.parent.runpath.endswith(slugify(env.parent.cfg.name))
 
 
 def get_mtest(name):
@@ -44,10 +44,10 @@ class SuiteKillingWorker(object):
             print("Killing worker {}".format(os.getpid()))
             os.kill(os.getpid(), 9)
         result.equal(1, 1, "equality description")
-        result.log(env.runpath)
-        assert isinstance(env.cfg, MultiTestConfig)
-        assert os.path.exists(env.runpath) is True
-        assert env.runpath.endswith(slugify(env.cfg.name))
+        result.log(env.parent.runpath)
+        assert isinstance(env.parent.cfg, MultiTestConfig)
+        assert os.path.exists(env.parent.runpath) is True
+        assert env.parent.runpath.endswith(slugify(env.parent.cfg.name))
 
 
 def multitest_kill_one_worker(parent_pid, size):

--- a/tests/functional/testplan/runners/pools/test_pool_base.py
+++ b/tests/functional/testplan/runners/pools/test_pool_base.py
@@ -14,9 +14,9 @@ class MySuite(object):
     @testcase
     def test_comparison(self, env, result):
         result.equal(1, 1, "equality description")
-        assert isinstance(env.cfg, MultiTestConfig)
-        assert os.path.exists(env.runpath)
-        assert env.runpath.endswith(slugify(env.cfg.name))
+        assert isinstance(env.parent.cfg, MultiTestConfig)
+        assert os.path.exists(env.parent.runpath)
+        assert env.parent.runpath.endswith(slugify(env.parent.cfg.name))
 
 
 def get_mtest(name):

--- a/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
+++ b/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
@@ -3,7 +3,6 @@
 import os
 import re
 import time
-import pytest
 
 
 from testplan.testing.filtering import Filter

--- a/tests/unit/testplan/testing/multitest/test_multitest.py
+++ b/tests/unit/testplan/testing/multitest/test_multitest.py
@@ -86,7 +86,7 @@ class Suite(object):
         """Basic testcase."""
         result.true(True)
         assert (
-            env.multitest_runtime_info.testcase.name == "case"
+            env.runtime_info.testcase.name == "case"
         )  # using pytest assert to check multitest runtime info
 
     @multitest.testcase(parameters=[1, 2, 3])
@@ -94,7 +94,7 @@ class Suite(object):
         """Parametrized testcase."""
         result.gt(val, 0)
         assert (
-            env.multitest_runtime_info.testcase.name
+            env.runtime_info.testcase.name
             == "parametrized <val={}>".format(val)
         )
 
@@ -117,7 +117,7 @@ class ParallelSuite(object):
         """Testcase 1"""
         self._barrier.wait()
         result.eq(0, 0)
-        assert env.multitest_runtime_info.testcase.name == "case1"
+        assert env.runtime_info.testcase.name == "case1"
         self._barrier.wait()
 
     @multitest.testcase(execution_group="A")
@@ -125,7 +125,7 @@ class ParallelSuite(object):
         """Testcase 2"""
         self._barrier.wait()
         result.eq(1, 1)
-        assert env.multitest_runtime_info.testcase.name == "case2"
+        assert env.runtime_info.testcase.name == "case2"
         self._barrier.wait()
 
     @multitest.testcase(execution_group="A")
@@ -133,7 +133,7 @@ class ParallelSuite(object):
         """Testcase 3"""
         self._barrier.wait()
         result.eq(2, 2)
-        assert env.multitest_runtime_info.testcase.name == "case3"
+        assert env.runtime_info.testcase.name == "case3"
         self._barrier.wait()
 
     @multitest.testcase(execution_group="B", parameters=[1, 2, 3])
@@ -142,7 +142,7 @@ class ParallelSuite(object):
         self._barrier.wait()
         result.gt(val, 0)
         assert (
-            env.multitest_runtime_info.testcase.name
+            env.runtime_info.testcase.name
             == "parametrized <val={}>".format(val)
         )
         self._barrier.wait()


### PR DESCRIPTION
* If there's a driver (e.g. called "logger" or "first") in Multitest
  environment, unfortunately the `Environment` object itself has a
  member with the same name, so when Testplan tries resolving the name
  in context, it will not get the expected driver. `RuntimeEnvironment`
  is presented in user's testcase by argument `env` and we make it
  fetch the drivers with priority by changing `__setattr__` method.
* `Environment` provides a `get` method for compatibility issue.
* Prevent user from modifying context of drivers, or raise.
* Fix an invalid expression in `testplan.environment.Environments`.
* Fix an issue that `Environment.__contains__` does not check the
  initial context.
* `Environment` is not a subclass of `Entity`, so some properties are
  removed from this class and should explicitly access them through
  the `parent`, also `initial_context` is owned by `Environment`.