### PR TITLE
Add FormattedValue type in TableLog assertion

### DIFF
--- a/examples/Assertions/Basic/test_plan.py
+++ b/examples/Assertions/Basic/test_plan.py
@@ -14,6 +14,7 @@ from testplan.testing.multitest import MultiTest, testsuite, testcase
 
 from testplan.common.utils import comparison
 from testplan.report.testing.styles import Style, StyleEnum
+from testplan.common.serialization.fields import LogLink, FormattedValue
 
 import matplotlib
 
@@ -423,6 +424,45 @@ print(os.uname())
             ["Sabine Wurfel", "31", "88 Clasper Way, HEXWORTHY, PL20 4BG"],
         ]
         result.table.log(long_cell_table, description="Table Log: long cells")
+
+        # Add external/internal link in the table log
+        result.table.log(
+            [
+                ["Description", "Data"],
+                [
+                    "External Link",
+                    LogLink(link="https://www.google.com", title="Google"),
+                ],
+                # Require plan.runnable.disable_reset_report_uid() in main function
+                # to avoid generating uuid4 as the report uid so that we can use
+                # the test name as the link in the report.
+                [
+                    "Internal Link",
+                    LogLink(
+                        link="/Assertions%20Test/SampleSuite/test_basic_assertions",
+                        title="test_basic_assertions",
+                        inner=True,
+                    ),
+                ],
+            ],
+            description="Link to external/internal",
+        )
+
+        # Customize formatted value in the table log
+        result.table.log(
+            [
+                ["Description", "Data"],
+                [
+                    "Formatted Value - 0.6",
+                    FormattedValue(display="60%", value=0.6),
+                ],
+                [
+                    "Formatted Value - 0.08",
+                    FormattedValue(display="8%", value=0.08),
+                ],
+            ],
+            description="Formatted value",
+        )
 
         result.table.match(
             list_of_lists,
@@ -843,6 +883,10 @@ print(os.uname())
     ),
 )
 def main(plan):
+    # For saving the internal link in the report, use test
+    # name instead of uuid4 as report uid.
+    plan.runnable.disable_reset_report_uid()
+
     plan.add(MultiTest(name="Assertions Test", suites=[SampleSuite()]))
 
 

--- a/testplan/common/serialization/fields.py
+++ b/testplan/common/serialization/fields.py
@@ -45,7 +45,7 @@ class LogLink(Serializable):
     Save an HTML link in WebUI
     """
 
-    def __init__(self, link, title=None, new_window=True):
+    def __init__(self, link, title=None, new_window=True, inner=False):
         """
         :param link: The URL of the page the link goes to.
         :type link: ``str``
@@ -53,17 +53,44 @@ class LogLink(Serializable):
         :type title: ``str``
         :param new_window: Open the link on new window or not. Default is True.
         :type new_window: ``bool``
+        :param inner: Link to internal page (report uid as the prefix). Default is False.
+        :type new_window: ``bool``
         """
         self.link = link
         self.title = title or link
         self.new_window = new_window
+        self.inner = inner
 
     def serialize(self):
         return {
             "link": self.link,
             "title": self.title,
             "new_window": self.new_window,
+            "inner": self.inner,
             "type": "link",
+        }
+
+
+class FormattedValue(Serializable):
+    """
+    Save a formatted value in WebUI
+    """
+
+    def __init__(self, value, display):
+        """
+        :param value: The value of the data for sorting in the report.
+        :type value: ``Union[str, numbers.Real]``
+        :param display: Formatted value for display in the report.
+        :type display: ``str``
+        """
+        self.value = value
+        self.display = display
+
+    def serialize(self):
+        return {
+            "value": self.value,
+            "display": self.display,
+            "type": "formattedValue",
         }
 
 

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -322,6 +322,10 @@ class TestRunner(Runnable):
                 exporter.parent = self
         return self._exporters
 
+    def disable_reset_report_uid(self):
+        """Do not generate unique strings in uuid4 format as report uid"""
+        self._reset_report_uid = False
+
     def get_default_exporters(self):
         """
         Instantiate certain exporters if related cmdline argument (e.g. --pdf)

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TableAssertions/TableBaseAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TableAssertions/TableBaseAssertion.js
@@ -6,6 +6,7 @@ import 'ag-grid-community/dist/styles/ag-theme-balham.css';
 import {AgGridReact} from 'ag-grid-react';
 import 'ag-grid-enterprise';
 import {LicenseManager} from "ag-grid-enterprise";
+import {processCellForClipboard} from "./tableAssertionUtils";
 
 
 const REACT_APP_AG_GRID_LICENSE = process.env.REACT_APP_AG_GRID_LICENSE;
@@ -66,6 +67,7 @@ export default function TableBaseAssertion(props) {
           }}
           groupMultiAutoColumn={true}
           enableRangeSelection={true}
+          processCellForClipboard={processCellForClipboard}
         />
       </div>
     </>

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TableAssertions/__tests__/TableLogAssertion.test.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TableAssertions/__tests__/TableLogAssertion.test.js
@@ -27,18 +27,87 @@ function defaultProps() {
 }
 
 
-describe('FixMatchAssertion', () => {
-  let props;
+function advancedTableProps() {
+  return {
+    assertion: {
+      "flag": "DEFAULT",
+      "machine_time": "2021-06-25T16:06:10.622340+00:00",
+      "line_no": 92,
+      "display_index": false,
+      "description": "table log assertion",
+      "table": [
+        [
+          "External Link",
+          {
+            "link": "https://www.google.com",
+            "title": "Google",
+            "new_window": true,
+            "inner": false,
+            "type": "link"
+          }
+        ],
+        [
+          "Internal Link",
+          {
+            "link": "/",
+            "title": "Home",
+            "new_window": true,
+            "inner": true,
+            "type": "link"
+          }
+        ],
+        [
+          "Formatted Value - 0.6",
+          {
+            "value": 0.6,
+            "display": "60%",
+            "type": "formattedValue"
+          }
+        ],
+        [
+          "Formatted Value - 0.08",
+          {
+            "value": 0.08,
+            "display": "8%",
+            "type": "formattedValue"
+          }
+        ]
+      ],
+      "columns": [
+        "Description",
+        "Data"
+      ],
+      "meta_type": "entry",
+      "category": "DEFAULT",
+      "type": "TableLog",
+      "indices": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "utc_time": "2021-06-25T08:06:10.622331+00:00"
+    }
+  }
+}
+
+describe('TableLogAssertion', () => {
   let shallowComponent;
 
   beforeEach(() => {
     // Stop Aphrodite from injecting styles, this crashes the tests.
     StyleSheetTestUtils.suppressStyleInjection();
-    props = defaultProps();
     shallowComponent = undefined;
   });
 
-  it('shallow renders the correct HTML structure', () => {
+  it('shallow renders the table log HTML structure', () => {
+    let props = defaultProps();
+    shallowComponent = shallow(<TableLogAssertion {...props}/>);
+    expect(shallowComponent).toMatchSnapshot();
+  });
+
+  it('shallow renders the advanced table log HTML structure', () => {
+    let props = advancedTableProps();
     shallowComponent = shallow(<TableLogAssertion {...props}/>);
     expect(shallowComponent).toMatchSnapshot();
   });

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TableAssertions/__tests__/__snapshots__/TableLogAssertion.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TableAssertions/__tests__/__snapshots__/TableLogAssertion.test.js.snap
@@ -1,11 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FixMatchAssertion shallow renders the correct HTML structure 1`] = `
+exports[`TableLogAssertion shallow renders the advanced table log HTML structure 1`] = `
 <TableBaseAssertion
   columns={
     Array [
       Object {
         "cellRendererFramework": [Function],
+        "comparator": [Function],
+        "field": "Description",
+        "filterParams": Object {
+          "excelMode": "windows",
+        },
+        "headerName": "Description",
+      },
+      Object {
+        "cellRendererFramework": [Function],
+        "comparator": [Function],
+        "field": "Data",
+        "filterParams": Object {
+          "excelMode": "windows",
+        },
+        "headerName": "Data",
+      },
+    ]
+  }
+  rows={
+    Array [
+      Object {
+        "Data": Object {
+          "inner": false,
+          "link": "https://www.google.com",
+          "new_window": true,
+          "title": "Google",
+          "type": "link",
+        },
+        "Description": "External Link",
+      },
+      Object {
+        "Data": Object {
+          "inner": true,
+          "link": "/",
+          "new_window": true,
+          "title": "Home",
+          "type": "link",
+        },
+        "Description": "Internal Link",
+      },
+      Object {
+        "Data": Object {
+          "display": "60%",
+          "type": "formattedValue",
+          "value": 0.6,
+        },
+        "Description": "Formatted Value - 0.6",
+      },
+      Object {
+        "Data": Object {
+          "display": "8%",
+          "type": "formattedValue",
+          "value": 0.08,
+        },
+        "Description": "Formatted Value - 0.08",
+      },
+    ]
+  }
+/>
+`;
+
+exports[`TableLogAssertion shallow renders the table log HTML structure 1`] = `
+<TableBaseAssertion
+  columns={
+    Array [
+      Object {
+        "cellRendererFramework": [Function],
+        "comparator": [Function],
         "field": "age",
         "filterParams": Object {
           "excelMode": "windows",
@@ -14,6 +82,7 @@ exports[`FixMatchAssertion shallow renders the correct HTML structure 1`] = `
       },
       Object {
         "cellRendererFramework": [Function],
+        "comparator": [Function],
         "field": "name",
         "filterParams": Object {
           "excelMode": "windows",

--- a/testplan/web_ui/testing/src/Common/fakeReport.js
+++ b/testplan/web_ui/testing/src/Common/fakeReport.js
@@ -1527,6 +1527,65 @@ var fakeReportAssertions = {
                             "tags": {},
                             "entries": [
                                 {
+                                    "flag": "DEFAULT",
+                                    "machine_time": "2021-06-25T16:06:10.622340+00:00",
+                                    "line_no": 92,
+                                    "display_index": false,
+                                    "description": "table log assertion",
+                                    "table": [
+                                      [
+                                        "External Link",
+                                        {
+                                          "link": "https://www.google.com",
+                                          "title": "Google",
+                                          "new_window": true,
+                                          "inner": false,
+                                          "type": "link"
+                                        }
+                                      ],
+                                      [
+                                        "Internal Link",
+                                        {
+                                          "link": "/",
+                                          "title": "Home",
+                                          "new_window": true,
+                                          "inner": true,
+                                          "type": "link"
+                                        }
+                                      ],
+                                      [
+                                        "Formatted Value - 0.6",
+                                        {
+                                          "value": 0.6,
+                                          "display": "60%",
+                                          "type": "formattedValue"
+                                        }
+                                      ],
+                                      [
+                                        "Formatted Value - 0.08",
+                                        {
+                                          "value": 0.08,
+                                          "display": "8%",
+                                          "type": "formattedValue"
+                                        }
+                                      ]
+                                    ],
+                                    "columns": [
+                                      "Description",
+                                      "Data"
+                                    ],
+                                    "meta_type": "entry",
+                                    "category": "DEFAULT",
+                                    "type": "TableLog",
+                                    "indices": [
+                                      0,
+                                      1,
+                                      2,
+                                      3
+                                    ],
+                                    "utc_time": "2021-06-25T08:06:10.622331+00:00"
+                                },
+                                {
                                     "category": "DEFAULT",
                                     "description": "Table Match: list of list vs list of list",
                                     "meta_type": "assertion",


### PR DESCRIPTION
* Add FormattedValue type in TableLog assertion
* Add internal link support
* Fix some small bugs of ag-grid


## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
