### PR TITLE
Update schema library to later version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -e .
 pylint
 scikit-learn < 0.21.0
-black==19.10b0; python_version >= '3.0'
+black==19.10b0; python_version >= '3.6'
 kazoo
 confluent-kafka
 plotly

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ REQUIRED = [
     "pytest",
     "py",
     "psutil",
-    "schema<0.7.0",
+    "schema",
     "pytz",
     "lxml",
     "python-dateutil",

--- a/testplan/testing/multitest/driver/http/client.py
+++ b/testplan/testing/multitest/driver/http/client.py
@@ -7,7 +7,7 @@ from threading import Thread, Event
 import requests
 from schema import Use, Or
 
-from testplan.common.config import ConfigOption as Optional
+from testplan.common.config import ConfigOption
 from testplan.common.utils.context import expand, is_context
 from testplan.common.utils.strings import slugify
 
@@ -28,12 +28,12 @@ class HTTPClientConfig(DriverConfig):
         """
         return {
             "host": Or(str, lambda x: is_context(x)),
-            Optional("port", default=None): Or(
+            ConfigOption("port", default=None): Or(
                 None, Use(int), lambda x: is_context(x)
             ),
-            Optional("protocol", default="http"): str,
-            Optional("timeout", default=5): Use(int),
-            Optional("interval", default=0.01): Use(float),
+            ConfigOption("protocol", default="http"): str,
+            ConfigOption("timeout", default=5): Use(int),
+            ConfigOption("interval", default=0.01): Use(float),
         }
 
 

--- a/testplan/testing/multitest/driver/http/server.py
+++ b/testplan/testing/multitest/driver/http/server.py
@@ -7,7 +7,7 @@ from threading import Thread
 
 from schema import Use
 
-from testplan.common.config import ConfigOption as Optional
+from testplan.common.config import ConfigOption
 from testplan.common.utils.strings import slugify
 
 from ..base import Driver, DriverConfig
@@ -156,14 +156,14 @@ class HTTPServerConfig(DriverConfig):
         Schema for options validation and assignment of default values.
         """
         return {
-            Optional("host", default="localhost"): str,
-            Optional("port", default=0): Use(int),
-            Optional(
+            ConfigOption("host", default="localhost"): str,
+            ConfigOption("port", default=0): Use(int),
+            ConfigOption(
                 "request_handler", default=HTTPRequestHandler
             ): lambda v: issubclass(v, http_server.BaseHTTPRequestHandler),
-            Optional("handler_attributes", default={}): dict,
-            Optional("timeout", default=5): Use(int),
-            Optional("interval", default=0.01): Use(float),
+            ConfigOption("handler_attributes", default={}): dict,
+            ConfigOption("timeout", default=5): Use(int),
+            ConfigOption("interval", default=0.01): Use(float),
         }
 
 

--- a/testplan/testing/multitest/driver/zmq/client.py
+++ b/testplan/testing/multitest/driver/zmq/client.py
@@ -3,7 +3,7 @@
 from schema import Use, Or
 import zmq
 
-from testplan.common.config import ConfigOption as Optional
+from testplan.common.config import ConfigOption
 from testplan.common.utils.context import ContextValue, expand
 from testplan.common.utils.convert import make_iterables
 from testplan.common.utils.timing import retry_until_timeout
@@ -25,10 +25,10 @@ class ZMQClientConfig(DriverConfig):
         return {
             "hosts": Or(*make_iterables([str, ContextValue])),
             "ports": Or(*make_iterables([int, ContextValue])),
-            Optional("message_pattern", default=zmq.PAIR): Or(
+            ConfigOption("message_pattern", default=zmq.PAIR): Or(
                 zmq.PAIR, zmq.REQ, zmq.SUB, zmq.PULL
             ),
-            Optional("connect_at_start", default=True): bool,
+            ConfigOption("connect_at_start", default=True): bool,
         }
 
 

--- a/testplan/testing/multitest/driver/zmq/server.py
+++ b/testplan/testing/multitest/driver/zmq/server.py
@@ -3,7 +3,7 @@
 from schema import Use, Or
 import zmq
 
-from testplan.common.config import ConfigOption as Optional
+from testplan.common.config import ConfigOption
 from testplan.common.utils.timing import retry_until_timeout
 
 from ..base import Driver, DriverConfig
@@ -21,9 +21,9 @@ class ZMQServerConfig(DriverConfig):
         Schema for options validation and assignment of default values.
         """
         return {
-            Optional("host", default="localhost"): str,
-            Optional("port", default=0): Use(int),
-            Optional("message_pattern", default=zmq.PAIR): Or(
+            ConfigOption("host", default="localhost"): str,
+            ConfigOption("port", default=0): Use(int),
+            ConfigOption("message_pattern", default=zmq.PAIR): Or(
                 zmq.PAIR, zmq.REP, zmq.PUB, zmq.PUSH
             ),
         }

--- a/tests/functional/testplan/runners/pools/test_task_rerun.py
+++ b/tests/functional/testplan/runners/pools/test_task_rerun.py
@@ -15,7 +15,7 @@ from testplan import Task, TestplanMock
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 from testplan.testing.multitest.driver.base import Driver, DriverConfig
 from testplan.runners.pools import ThreadPool, ProcessPool
-from testplan.common.config import ConfigOption as Optional
+from testplan.common.config import ConfigOption
 from testplan.common.utils.path import makedirs
 from testplan.report import ReportCategories
 
@@ -24,8 +24,8 @@ class MockDriverConfig(DriverConfig):
     @classmethod
     def get_options(cls):
         return {
-            Optional("start_raises", default=False): bool,
-            Optional("stop_raises", default=False): bool,
+            ConfigOption("start_raises", default=False): bool,
+            ConfigOption("stop_raises", default=False): bool,
         }
 
 

--- a/tests/unit/testplan/web_ui/test_web_app.py
+++ b/tests/unit/testplan/web_ui/test_web_app.py
@@ -9,14 +9,14 @@ from testplan import defaults
 from testplan.web_ui.web_app import app as tp_web_app
 
 STATIC_REPORTS = {
-    "testing": {"uid": str(uuid.uuid4()), "contents": str(uuid.uuid4())}
+    "testing": {"uid": "static-uid", "contents": "Static content"}
 }
 
 DATA_REPORTS = {
     "testplan": {
         "report_name": "report.json",
-        "uid": str(uuid.uuid4()),
-        "contents": str(uuid.uuid4()),
+        "uid": "test-report-uid",
+        "contents": "This is a JSON report",
     }
 }
 
@@ -36,7 +36,7 @@ def _create_tmp_file(tmp_file, contents):
         os.makedirs(base_dir)
 
     with open(tmp_file, "w") as tmp_file:
-        tmp_file.write(str(contents))
+        tmp_file.write(contents)
 
 
 def _create_tmp_static_files(base_dir):


### PR DESCRIPTION
* Some users work with schema whose version >= 0.7.0, however there
  is a known issue which makes it incompatible with current version
  0.6.6 because in several places we have passed callable objects as
  default value of `schema.Optional`, but in the latest version these
  callables will be instantiated during schema validation. So we have
  to solve this issue.
* Fix a security issue reported from CodeQL scanning.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
