### PR TITLE
Add plotly in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ REQUIRED = [
     "Werkzeug<1.0.0",
     "boltons",
     "Pillow",
+    "plotly",
 ]
 
 WEB_UI_PACKAGE_DIR = "testplan/web_ui/"


### PR DESCRIPTION
## Bug / Requirement Description
Fixes Plotly is missing from setup.py #676


## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
