### PR TITLE
Improvement in reloading tasks in interactive mode

### DIFF
--- a/testplan/common/entity/__init__.py
+++ b/testplan/common/entity/__init__.py
@@ -3,8 +3,6 @@
 from .base import (
     Entity,
     EntityConfig,
-    RunnableManager,
-    RunnableManagerConfig,
     Resource,
     ResourceStatus,
     ResourceConfig,
@@ -13,6 +11,8 @@ from .base import (
     RunnableStatus,
     RunnableConfig,
     RunnableResult,
+    RunnableManager,
+    RunnableManagerConfig,
     FailedAction,
     DEFAULT_RUNNABLE_ABORT_SIGNALS,
 )

--- a/testplan/exporters/testing/json/__init__.py
+++ b/testplan/exporters/testing/json/__init__.py
@@ -13,7 +13,6 @@ from testplan import defaults
 
 from testplan.common.config import ConfigOption
 from testplan.common.exporters import ExporterConfig
-from testplan.common.utils.path import makedirs
 
 from testplan.report import ReportCategories
 from testplan.report.testing.schemas import TestReportSchema

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -269,8 +269,12 @@ class TestRunner(Runnable):
     :param interactive_handler: Handler for interactive mode execution.
     :type interactive_handler: Subclass of :py:class:
         `TestRunnerIHandler <testplan.runnable.interactive.TestRunnerIHandler>`
-    :param extra_deps: Extra module dependencies for interactive reload.
-    :type extra_deps: ``list`` of ``module``
+    :param extra_deps: Extra module dependencies for interactive reload, or
+        paths of these modules.
+    :type extra_deps: ``list`` of ``module`` or ``str``
+    :param label: Label the test report with the given name, useful to
+        categorize or classify similar reports .
+    :type label: ``str`` or ``NoneType``
 
     Also inherits all
     :py:class:`~testplan.common.entity.base.Runnable` options.
@@ -374,14 +378,13 @@ class TestRunner(Runnable):
 
     def add_resource(self, resource, uid=None):
         """
-        Adds a test
-        :py:class:`executor <testplan.runners.base.Executor>`
+        Adds a test :py:class:`executor <testplan.runners.base.Executor>`
         resource in the test runner environment.
 
         :param resource: Test executor to be added.
         :type resource: Subclass of :py:class:`~testplan.runners.base.Executor`
         :param uid: Optional input resource uid.
-        :type uid: ``str``
+        :type uid: ``str`` or ``NoneType``
         :return: Resource uid assigned.
         :rtype:  ``str``
         """

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -3,7 +3,6 @@ Interactive handler for TestRunner runnable class.
 """
 
 import re
-import time
 import numbers
 import threading
 from concurrent import futures
@@ -20,6 +19,13 @@ from testplan.runnable.interactive import resource_loader
 from testplan.report import TestReport, TestGroupReport, Status, RuntimeStatus
 
 
+def _exclude_assertions_filter(obj):
+    try:
+        return obj["meta_type"] not in ("entry", "assertion")
+    except Exception:
+        return True
+
+
 class TestRunnerIHandlerConfig(config.Config):
     """
     Configuration object for
@@ -29,14 +35,11 @@ class TestRunnerIHandlerConfig(config.Config):
 
     @classmethod
     def get_options(cls):
-        return {"target": object, "startup_timeout": int, "http_port": int}
-
-
-def _exclude_assertions_filter(obj):
-    try:
-        return obj["meta_type"] not in ("entry", "assertion")
-    except Exception:
-        return True
+        return {
+            "target": lambda obj: isinstance(obj, entity.Runnable),
+            config.ConfigOption("startup_timeout", default=10): int,
+            config.ConfigOption("http_port", default=0): int,
+        }
 
 
 class TestRunnerIHandler(entity.Entity):

--- a/testplan/runnable/interactive/http.py
+++ b/testplan/runnable/interactive/http.py
@@ -27,7 +27,6 @@ from testplan.report import (
     TestCaseReport,
     RuntimeStatus,
 )
-from .reloader import ModuleReloader
 
 
 class OutOfOrderError(Exception):

--- a/tests/functional/testplan/runners/pools/test_task_rerun.py
+++ b/tests/functional/testplan/runners/pools/test_task_rerun.py
@@ -193,13 +193,10 @@ def test_task_rerun_in_thread_pool(mockplan):
     pool = ThreadPool(name=pool_name, size=2)
     mockplan.add_resource(pool)
 
-    directory = os.path.dirname(os.path.abspath(__file__))
     tmp_file = os.path.join(
         tempfile.gettempdir(), getpass.getuser(), "{}.tmp".format(uuid.uuid4())
     )
-    task = Task(
-        target=make_multitest_1, path=directory, args=(tmp_file,), rerun=3
-    )
+    task = Task(target=make_multitest_1, args=(tmp_file,), rerun=3)
     uid = mockplan.schedule(task=task, resource=pool_name)
 
     assert mockplan.run().run is True
@@ -231,19 +228,14 @@ def test_task_rerun_in_process_pool(mockplan):
     pool = ProcessPool(name=pool_name, size=2)
     mockplan.add_resource(pool)
 
-    directory = os.path.dirname(os.path.abspath(__file__))
     tmp_file_1 = os.path.join(
         tempfile.gettempdir(), getpass.getuser(), "{}.tmp".format(uuid.uuid4())
     )
     tmp_file_2 = os.path.join(
         tempfile.gettempdir(), getpass.getuser(), "{}.tmp".format(uuid.uuid4())
     )
-    task1 = Task(
-        target=make_multitest_1, path=directory, args=(tmp_file_1,), rerun=2
-    )
-    task2 = Task(
-        target=make_multitest_2, path=directory, args=(tmp_file_2,), rerun=0
-    )
+    task1 = Task(target=make_multitest_1, args=(tmp_file_1,), rerun=2)
+    task2 = Task(target=make_multitest_2, args=(tmp_file_2,), rerun=0)
     uid1 = mockplan.schedule(task=task1, resource=pool_name)
     uid2 = mockplan.schedule(task=task2, resource=pool_name)
 
@@ -277,13 +269,10 @@ def test_task_rerun_with_more_times(mockplan):
     pool = ThreadPool(name=pool_name, size=1)
     mockplan.add_resource(pool)
 
-    directory = os.path.dirname(os.path.abspath(__file__))
     tmp_file = os.path.join(
         tempfile.gettempdir(), getpass.getuser(), "{}.tmp".format(uuid.uuid4())
     )
-    task = Task(
-        target=make_multitest_3, path=directory, args=(tmp_file,), rerun=2
-    )
+    task = Task(target=make_multitest_3, args=(tmp_file,), rerun=2)
     uid = mockplan.schedule(task=task, resource=pool_name)
 
     assert mockplan.run().run is True
@@ -309,13 +298,10 @@ def test_task_rerun_with_more_times_2(mockplan):
     pool = ThreadPool(name=pool_name, size=1)
     mockplan.add_resource(pool)
 
-    directory = os.path.dirname(os.path.abspath(__file__))
     tmp_file = os.path.join(
         tempfile.gettempdir(), getpass.getuser(), "{}.tmp".format(uuid.uuid4())
     )
-    task = Task(
-        target=make_multitest_3, path=directory, args=(tmp_file,), rerun=3
-    )
+    task = Task(target=make_multitest_3, args=(tmp_file,), rerun=3)
     uid = mockplan.schedule(task=task, resource=pool_name)
 
     assert mockplan.run().run is True
@@ -338,13 +324,10 @@ def test_task_rerun_with_parts():
         pool = ThreadPool(name=pool_name, size=1)
         mockplan.add_resource(pool)
 
-        directory = os.path.dirname(os.path.abspath(__file__))
-
         uids = []
         for idx in range(3):
             task = Task(
                 target=make_multitest_parts,
-                path=directory,
                 kwargs={"part_tuple": (idx, 3)},
                 rerun=1,
             )

--- a/tests/unit/testplan/runnable/interactive/test_api.py
+++ b/tests/unit/testplan/runnable/interactive/test_api.py
@@ -10,6 +10,22 @@ from testplan.runnable.interactive import base
 from testplan.common import entity
 
 
+class TestRunnerIHandlerConfig(base.TestRunnerIHandlerConfig):
+    """Only for testing."""
+
+    @classmethod
+    def get_options(cls):
+        return {
+            "target": object,
+        }
+
+
+class TestRunnerIHandler(base.TestRunnerIHandler):
+    """Only for testing."""
+
+    CONFIG = TestRunnerIHandlerConfig
+
+
 @pytest.fixture
 def example_report():
     """Create a new report skeleton."""
@@ -104,7 +120,7 @@ def api_env(example_report):
     ) as MockReloader:
         MockReloader.return_value = None
 
-        ihandler = base.TestRunnerIHandler(target=mock_target)
+        ihandler = TestRunnerIHandler(target=mock_target)
         ihandler.report = example_report
         ihandler.reset_all_tests = mock.MagicMock()
         ihandler.reset_test = mock.MagicMock()

--- a/tests/unit/testplan/runners/pools/tasks/data/relative/__init__.py
+++ b/tests/unit/testplan/runners/pools/tasks/data/relative/__init__.py
@@ -1,0 +1,1 @@
+from . import sample_tasks

--- a/tests/unit/testplan/runners/pools/tasks/data/relative/sample_tasks.py
+++ b/tests/unit/testplan/runners/pools/tasks/data/relative/sample_tasks.py
@@ -73,6 +73,12 @@ class Multiplier(Runnable):
     pass
 
 
+class Wrapper(object):
+    """TODO."""
+
+    InnerMultiplier = Multiplier
+
+
 def callable_to_non_runnable(number):
     """TODO."""
     return NonRunnable(number)

--- a/tests/unit/testplan/runners/pools/tasks/test_tasks.py
+++ b/tests/unit/testplan/runners/pools/tasks/test_tasks.py
@@ -166,27 +166,34 @@ class TestTaskInitAndMaterialization(object):
     def test_string_runnable_tgt_other_module(self):
         """TODO."""
         task = Task(
-            "tests.unit.testplan.runners.pools.tasks.data"
-            ".sample_tasks.Multiplier",
+            "Multiplier",
+            module="tests.unit.testplan.runners.pools.tasks.data.sample_tasks",
             args=(4,),
         )
         materialized_task_result(task, 8)
 
         task = Task(
-            "Multiplier",
-            module="tests.unit.testplan.runners.pools.tasks.data"
-            ".sample_tasks",
+            "Wrapper.InnerMultiplier",
+            module="tests.unit.testplan.runners.pools.tasks.data.sample_tasks",
             args=(5,),
         )
         materialized_task_result(task, 10)
 
         task = Task(
-            "tests.unit.testplan.runners.pools.tasks.data"
-            ".sample_tasks.Multiplier",
+            "sample_tasks.Multiplier",
+            module="tests.unit.testplan.runners.pools.tasks.data.relative",
             args=(4,),
             kwargs={"multiplier": 3},
         )
         materialized_task_result(task, 12)
+
+        task = Task(
+            "sample_tasks.Wrapper.InnerMultiplier",
+            module="tests.unit.testplan.runners.pools.tasks.data.relative",
+            args=(5,),
+            kwargs={"multiplier": 3},
+        )
+        materialized_task_result(task, 15)
 
     def test_callable_to_non_runnable_tgt(self):
         """TODO."""
@@ -196,8 +203,15 @@ class TestTaskInitAndMaterialization(object):
             Task(callable_to_non_runnable),
             Task(sample_tasks.callable_to_non_runnable, args=(2,)),
             Task(
-                "tests.unit.testplan.runners.pools.tasks.data"
-                ".relative.sample_tasks.multiply",
+                "multiply",
+                module=(
+                    "tests.unit.testplan.runners.pools.tasks.data.sample_tasks"
+                ),
+                args=(2,),
+            ),
+            Task(
+                "sample_tasks.multiply",
+                module="tests.unit.testplan.runners.pools.tasks.data.relative",
                 args=(2,),
             ),
         ):
@@ -215,8 +229,14 @@ class TestTaskInitAndMaterialization(object):
             Task(callable_to_none),
             Task(sample_tasks.callable_to_none),
             Task(
-                "tests.unit.testplan.runners.pools.tasks.data"
-                ".relative.sample_tasks.callable_to_none"
+                "callable_to_none",
+                module=(
+                    "tests.unit.testplan.runners.pools.tasks.data.sample_tasks"
+                ),
+            ),
+            Task(
+                "sample_tasks.callable_to_none",
+                module="tests.unit.testplan.runners.pools.tasks.data.relative",
             ),
         ):
             try:
@@ -256,15 +276,15 @@ class TestTaskInitAndMaterialization(object):
         materialized_task_result(task, 2)
 
         task = Task(
-            "tests.unit.testplan.runners.pools.tasks.data.sample_tasks"
-            ".callable_to_runnable",
+            "callable_to_runnable",
+            module="tests.unit.testplan.runners.pools.tasks.data.sample_tasks",
             args=(2,),
         )
         materialized_task_result(task, 4)
 
         task = Task(
-            "tests.unit.testplan.runners.pools.tasks.data"
-            ".sample_tasks.callable_to_adapted_runnable",
+            "sample_tasks.callable_to_adapted_runnable",
+            module="tests.unit.testplan.runners.pools.tasks.data.relative",
             args=(2,),
         )
         materialized_task_result(task, 4)
@@ -272,19 +292,28 @@ class TestTaskInitAndMaterialization(object):
     def test_path_usage(self):  # pylint: disable=R0201
         """TODO."""
         dirname = os.path.dirname(os.path.abspath(__file__))
-        path = os.path.join(dirname, "data", "relative")
+        path = os.path.join(dirname, "data")
 
-        task = Task("sample_tasks.Multiplier", args=(4,), path=path)
+        task = Task(
+            "Multiplier", module="relative.sample_tasks", args=(4,), path=path
+        )
         materialized_task_result(task, 8)
+
+        task = Task(
+            "callable_to_runnable",
+            module="relative.sample_tasks",
+            args=(2,),
+            path=path,
+        )
+        materialized_task_result(task, 4)
+
+        path = os.path.join(path, "relative")
 
         task = Task("Multiplier", module="sample_tasks", args=(4,), path=path)
         materialized_task_result(task, 8)
 
-        task = Task("sample_tasks.callable_to_runnable", args=(2,), path=path)
-        materialized_task_result(task, 4)
-
         task = Task(
-            "callable_to_runnable", args=(2,), module="sample_tasks", path=path
+            "callable_to_runnable", module="sample_tasks", args=(2,), path=path
         )
         materialized_task_result(task, 4)
 

--- a/tests/unit/testplan/test_plan_base.py
+++ b/tests/unit/testplan/test_plan_base.py
@@ -87,9 +87,8 @@ def test_testplan():
     """TODO."""
     from testplan.base import TestplanParser as MyParser
 
-    plan = TestplanMock(name="MyPlan", port=800, parser=MyParser)
+    plan = TestplanMock(name="MyPlan", parser=MyParser)
     assert plan._cfg.name == "MyPlan"
-    assert plan._cfg.port == 800
     assert plan._cfg.runnable == TestRunner
     assert plan.cfg.name == "MyPlan"
     assert plan._runnable.cfg.name == "MyPlan"


### PR DESCRIPTION
* If argument `extra_deps` is specified, the paths from where to
  import these modules should be added to `sys.path` for reloading.
  Also this ``list`` object can have both paths or modules.
* When scheduling a task, the argument `module` MUST be specified,
  and nested target in the module could be fetched, like "a.b.c".
* Refactor `RunnableManager`, `TestRunner` and `Testplan`.
* Add some missing arguments and fix annotations.
* Update testcases.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
