### PR TITLE
Fix an issue that local runner is not necessarily the first executor

### DIFF
--- a/testplan/base.py
+++ b/testplan/base.py
@@ -18,7 +18,7 @@ from testplan.testing import ordering
 from testplan.runnable import TestRunnerConfig, TestRunnerResult, TestRunner
 from testplan.runnable.interactive import TestRunnerIHandler
 from testplan.parser import TestplanParser
-from testplan.runners import LocalRunner
+from testplan.runners import Executor, LocalRunner
 from testplan.environment import Environments
 
 
@@ -37,6 +37,7 @@ class TestplanConfig(entity.RunnableManagerConfig, TestRunnerConfig):
             ConfigOption("runnable", default=TestRunner): is_subclass(
                 entity.Runnable
             ),
+            ConfigOption("resources", default=[]): [Executor],
         }
 
 
@@ -226,7 +227,6 @@ class Testplan(entity.RunnableManager):
         # Define instance attributes
         self._parsed_args = argparse.Namespace()
         self._processed_args = {}
-        self._default_options = {}
 
         super(Testplan, self).__init__(
             name=name,
@@ -268,11 +268,11 @@ class Testplan(entity.RunnableManager):
             **options
         )
 
-        # By default, a LocalRunner is added to store and execute the tests.
-        self._runnable.add_resource(LocalRunner(), uid="local_runner")
+        # Stores local tests (default runner in interactive mode).
+        self._runnable.add_resource(LocalRunner(), default=True)
 
         # Stores independent environments.
-        self._runnable.add_resource(Environments(), uid="environments")
+        self._runnable.add_resource(Environments())
 
     @property
     def parser(self):

--- a/testplan/environment.py
+++ b/testplan/environment.py
@@ -66,6 +66,7 @@ class Environments(Resource):
 
     def __init__(self, **options):
         super(Environments, self).__init__(**options)
+        self._uid = "environments"
         self._envs = {}
 
     @property

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -157,7 +157,9 @@ class TestRunnerIHandler(entity.Entity):
 
         :param test_uid: UID of test to find.
         """
-        runner = self.target.resources[self.target.resources.first()]
+        runner = getattr(self.target, "default_runner", None)
+        if runner is None:
+            raise RuntimeError("Cannot find an available test executor")
         return runner.added_item(test_uid)
 
     def reset_all_tests(self, await_results=True):
@@ -622,9 +624,8 @@ class TestRunnerIHandler(entity.Entity):
 
     def all_tests(self):
         """Get all added tests."""
-        try:
-            runner = self.target.resources[self.target.resources.first()]
-        except StopIteration:
+        runner = getattr(self.target, "default_runner", None)
+        if runner is None:
             return
         for test_uid in runner.added_items:
             yield test_uid

--- a/testplan/runners/__init__.py
+++ b/testplan/runners/__init__.py
@@ -1,4 +1,5 @@
 """Execution runners."""
 
 from .pools.tasks import Task, TaskResult, RunnableTaskAdaptor
+from .base import Executor
 from .local import LocalRunner

--- a/tests/unit/testplan/runnable/interactive/test_irunner.py
+++ b/tests/unit/testplan/runnable/interactive/test_irunner.py
@@ -104,7 +104,7 @@ def irunner():
     for test in test_objs:
         local_runner.add(test, test.uid())
 
-    target.resources.add(local_runner)
+    target.add_resource(local_runner)
 
     with mock.patch("cheroot.wsgi.Server"), mock.patch(
         "testplan.runnable.interactive.reloader.ModuleReloader"
@@ -267,7 +267,7 @@ def test_run_all_tagged_tests(tags, num_of_suite_entries):
     for test in test_objs:
         local_runner.add(test, test.uid())
 
-    target.resources.add(local_runner)
+    target.add_resource(local_runner)
 
     with mock.patch("cheroot.wsgi.Server"), mock.patch(
         "testplan.runnable.interactive.reloader.ModuleReloader"


### PR DESCRIPTION
* The default executor is `LocalRunner`, when no resource is explicitly
  specified to execute test target, or running in interactive mode.
  However, `Testplan` (or `TestRunner`) supports adding other resources
  and they can be in front of `LocalRunner`. Seems no user has utilized
  this argument `resources` and no error reported, but it is in config
  options and this is a potential bug. Now support adding a default
  executor which has priority.
