### PR TITLE
Fix an issue that on Windows file paths are case-insensitive

### DIFF
--- a/testplan/exporters/testing/json/__init__.py
+++ b/testplan/exporters/testing/json/__init__.py
@@ -26,7 +26,7 @@ def gen_attached_report_names(json_path):
     """
     basename, _ = os.path.splitext(os.path.basename(json_path))
     digest = hashlib.md5(
-        os.path.realpath(json_path).encode("utf-8")
+        os.path.normcase(os.path.realpath(json_path)).encode("utf-8")
     ).hexdigest()
 
     return (
@@ -69,7 +69,7 @@ class JSONExporter(Exporter):
     CONFIG = JSONExporterConfig
 
     def __init__(self, name="JSON exporter", **options):
-        super(JSONExporter, self).__init__(**options)
+        super(JSONExporter, self).__init__(name=name, **options)
 
     def export(self, source):
 

--- a/testplan/exporters/testing/webserver/base.py
+++ b/testplan/exporters/testing/webserver/base.py
@@ -49,8 +49,8 @@ class WebServerExporter(Exporter):
 
     CONFIG = WebServerExporterConfig
 
-    def __init__(self, **options):
-        super(WebServerExporter, self).__init__(**options)
+    def __init__(self, name="Web Server exporter", **options):
+        super(WebServerExporter, self).__init__(name=name, **options)
         self._report_url = None
 
     @property

--- a/tests/unit/testplan/web_ui/test_web_app.py
+++ b/tests/unit/testplan/web_ui/test_web_app.py
@@ -163,3 +163,35 @@ def test_testplan_attachment(webapp_test_client):
     expected_contents = str(DATA_REPORTS["testplan"]["contents"])
     assert response.status_code == 200
     assert expected_contents in str(response.data)
+
+
+def test_testplan_fix_spec(webapp_test_client):
+    """Does /api/v1/metadata/fix-spec/tags return the correct dictionary."""
+    # Expect information of all tags
+    path = "/api/v1/metadata/fix-spec/tags"
+    response = webapp_test_client.get(path)
+    assert response.status_code == 200
+    tags_info = response.json
+    assert isinstance(tags_info, dict)
+    assert tags_info["8"]["names"][0] == "BeginString"
+    assert tags_info["9"]["names"][0] == "BodyLength"
+    assert tags_info["10"]["names"][0] == "CheckSum"
+
+    # Use valid tag number and get the enumeration information
+    tag = 40
+    path = f"/api/v1/metadata/fix-spec/tags/{tag}/enum-vals"
+    response = webapp_test_client.get(path)
+    assert response.status_code == 200
+    enum_info = response.json
+    assert isinstance(enum_info, list)
+    assert len(enum_info) > 0
+    assert set(enum_info[0].keys()) == {"value", "descr"}
+
+    # Use invalid tag number still 200 response but no data.
+    tag = 10
+    path = f"/api/v1/metadata/fix-spec/tags/{tag}/enum-vals"
+    response = webapp_test_client.get(path)
+    assert response.status_code == 200
+    enum_info = response.json
+    assert isinstance(enum_info, list)
+    assert len(enum_info) == 0


### PR DESCRIPTION
* The `JSONExporter` splits test report and renames its attachments
  with a postfix which is generated by the path of main Json report.
  However on Windows paths are case-insensitive so sometimes (e.g.
  with `pathlib.Path.resolve` the lowercase may become uppercase).
  So `os.path.normcase` is called before generating postfix.
* Update a testcase of webapp.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
