### PR TITLE
Upgrade testplan dependencies - marshmallow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ REQUIRED = [
     "lxml",
     "python-dateutil",
     "reportlab",
-    "marshmallow==3.0.0b2",
+    "marshmallow==3.11.1",
     "termcolor",
     "colorama",
     "pyzmq",

--- a/testplan/common/serialization/fields.py
+++ b/testplan/common/serialization/fields.py
@@ -3,35 +3,24 @@ Custom marshmallow fields.
 """
 import abc
 import pprint
-import warnings
 
-try:
-    from lxml import etree
-except Exception as exc:
-    warnings.warn("lxml need to be supported: {}".format(exc))
-from dateutil import parser
 import pytz
+from dateutil import parser
+from lxml import etree
 
 from marshmallow import fields
-from marshmallow.compat import text_type, binary_type
-from marshmallow.utils import missing as missing_
-from marshmallow.base import SchemaABC
 from marshmallow import class_registry
-from marshmallow.fields import _RECURSIVE_NESTED
-from marshmallow.exceptions import ValidationError
+from marshmallow.base import SchemaABC
+from marshmallow.utils import missing as missing_
 
 from testplan.common.utils import comparison
-
-# from testip.alpha import util
-
-
-# pylint: disable=unused-argument
-
 
 # We explicitly enumerate types that are known to be safe to serialize by
 # pickle. All other types will be converted to strings before pickling.
 # types.NoneType is gone in python3 so we inspect the type of None directly.
 COMPATIBLE_TYPES = (bool, float, type(None), str, bytes, int)
+
+# pylint: disable=unused-argument, no-self-use
 
 
 class Serializable(metaclass=abc.ABCMeta):
@@ -147,14 +136,14 @@ class Unicode(fields.Field):
 
     codecs = ["utf-8", "latin-1"]  # Ideally we will let users override this
 
-    def _serialize(self, value, attr, obj):
-        if isinstance(value, text_type) or value is None:
+    def _serialize(self, value, attr, obj, **kwargs):
+        if isinstance(value, str) or value is None:
             return value
 
-        elif isinstance(value, binary_type):
+        elif isinstance(value, bytes):
             for codec in self.codecs:
                 try:
-                    return text_type(value, codec)
+                    return str(value, codec)
                 except UnicodeDecodeError:
                     pass
             raise ValueError(
@@ -164,7 +153,7 @@ class Unicode(fields.Field):
                 )
             )
         else:
-            return text_type(value)
+            return str(value)
 
 
 class NativeOrPretty(fields.Field):
@@ -173,7 +162,7 @@ class NativeOrPretty(fields.Field):
     or pretty formatted str representation.
     """
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         if isinstance(value, Serializable):
             return value.serialize()
         else:
@@ -187,7 +176,7 @@ class NativeOrPrettyDict(fields.Field):
     should be used for flat dicts only.
     """
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         if not isinstance(value, dict):
             raise TypeError(
                 "`value` ({value}) should be"
@@ -210,7 +199,7 @@ class NativeOrPrettyDict(fields.Field):
 class RowComparisonField(fields.Field):
     """Serialization logic for RowComparison"""
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         idx, row, diff, errors, extra = value
         return (
             idx,
@@ -224,7 +213,7 @@ class RowComparisonField(fields.Field):
 class SliceComparisonField(fields.Field):
     """Serialization logic for SliceComparison"""
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         def str_or_iterable(val):
             return val if isinstance(val, str) else native_or_pformat_list(val)
 
@@ -242,7 +231,7 @@ class SliceComparisonField(fields.Field):
 class ColumnContainComparisonField(fields.Field):
     """Serialization logic for ColumnContainComparison"""
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
 
         return (value.idx, native_or_pformat(value.value), value.passed)
 
@@ -250,7 +239,7 @@ class ColumnContainComparisonField(fields.Field):
 class XMLElementField(fields.Field):
     """Custom field for `lxml.etree.Element serialization`."""
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         return etree.tostring(value, pretty_print=True).decode("utf-8")
 
 
@@ -262,12 +251,12 @@ class ClassName(fields.Field):
     class Meta:  # pylint: disable=bad-option-value,old-style-class,missing-docstring,no-init
         dump_only = True
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         return obj.__class__.__name__
 
 
 class DictMatch(fields.Field):
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         keys = ("value", "ignore", "only")
         return {key: getattr(value, key) for key in keys}
 
@@ -298,6 +287,9 @@ class GenericNested(fields.Field):
     def _get_schema_obj(self, schema_value):
         parent_ctx = getattr(self.parent, "context", {})
 
+        if callable(schema_value) and not isinstance(schema_value, type):
+            schema_value = schema_value()
+
         if isinstance(schema_value, SchemaABC):
             schema_value.context.update(parent_ctx)
             return schema_value
@@ -308,8 +300,7 @@ class GenericNested(fields.Field):
             return schema_value(many=self.many, context=parent_ctx)
 
         elif isinstance(schema_value, str):
-
-            if schema_value == _RECURSIVE_NESTED:
+            if schema_value == "self":
                 return self.parent.__class__(
                     many=self.many, context=parent_ctx
                 )
@@ -341,7 +332,7 @@ class GenericNested(fields.Field):
             result[key] = self._get_schema_obj(schema_value)
         return result
 
-    def _serialize(self, nested_obj, attr, obj):
+    def _serialize(self, nested_obj, attr, obj, **kwargs):
 
         if nested_obj is None:
             return None
@@ -360,35 +351,48 @@ class GenericNested(fields.Field):
             )
 
         schema_obj = schemas[class_name]
-
-        ret, errors = schema_obj.dump(
-            nested_obj, many=False, update_fields=False
-        )
-
-        if errors:
-            raise ValidationError(errors, data=ret)
-        return ret
+        return schema_obj.dump(nested_obj, many=False)
 
 
 class UTCDateTime(fields.DateTime):
     """
-    While parsing timestamps, original `fields.Datetime` tries
-    to use ``dateutil`` if it's available.
-
-    Unfortunately, the way it does the check for ``dateutil``
-    availability is not compatible with our internal environment
-
-    If the ``dateutil`` is not available, it falls back to
-    ``datetime.datetime.strptime`` which leaves the
-    millisecond information out.
-
-    So we specify the deserialization logic explicitly to
-    make use of dateutil. In addition we use ``pytz``
-    timezones instead of ``dateutil.tz``.
+    A formatted datetime string that represents UTC time. Naive datetime
+    will be thought as in UTC timezone.
+    Example: 2014-12-22T03:12:58.019077+00:00  (always ends with '+00:00')
     """
 
-    def _deserialize(self, value, attr, data):
-        return parser.parse(value).replace(tzinfo=pytz.UTC)
+    def _serialize(self, value, attr, obj, **kwargs):
+        dt = (
+            value.replace(tzinfo=pytz.UTC)
+            if value.tzinfo is None
+            else value.astimezone(tz=pytz.UTC)
+        )
+        return dt.isoformat()
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        dt = parser.parse(value)
+        return (
+            dt.replace(tzinfo=pytz.UTC)
+            if dt.tzinfo is None
+            else dt.astimezone(tz=pytz.UTC)
+        )
+
+
+class LocalDateTime(fields.DateTime):
+    """
+    A formatted datetime string that represents machine time. Naive datetime
+    will be thought as in local timezone.
+    Example: 2014-12-22T11:12:58.019077+08:00
+
+    Note: Since Python 3.6 `datetime.datetime.astimezone` method can be called
+    on naive instances that are presumed to represent system local time.
+    """
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        return value.astimezone().isoformat()
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        return parser.parse(value).astimezone()
 
 
 class ExceptionField(fields.Field):
@@ -396,5 +400,5 @@ class ExceptionField(fields.Field):
     Serialize exceptions type and message.
     """
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         return (str(type(value)), str(value))

--- a/testplan/common/serialization/schemas.py
+++ b/testplan/common/serialization/schemas.py
@@ -27,15 +27,13 @@ def load_tree_data(
 
         if obj_type == node_type:
             child_data = _data.pop(nodes_field)
-            res = node_schema(strict=True).load(_data)
-            obj = res.data
-
+            obj = node_schema().load(_data)
             nodes = [_load(c_data) for c_data in child_data]
             setattr(obj, nodes_attr_name, nodes)
             return obj
 
         elif obj_type == leaf_type:
-            return leaf_schema(strict=True).load(_data).data
+            return leaf_schema().load(_data)
         else:
             raise ValueError("Invalid object type: {}".format(obj_type))
 
@@ -66,4 +64,4 @@ class SchemaRegistry(Registry):
     """
 
     def serialize(self, obj):
-        return self[obj](strict=True).dump(obj).data
+        return self[obj]().dump(obj)

--- a/testplan/exporters/testing/http/__init__.py
+++ b/testplan/exporters/testing/http/__init__.py
@@ -89,8 +89,8 @@ class HTTPExporter(Exporter):
     def export(self, source):
 
         http_url = self.cfg.http_url
-        test_plan_schema = TestReportSchema(strict=True)
-        data = test_plan_schema.dump(source).data
+        test_plan_schema = TestReportSchema()
+        data = test_plan_schema.dump(source)
         _, errmsg = self._upload_report(http_url, data)
 
         if errmsg:

--- a/testplan/exporters/testing/json/__init__.py
+++ b/testplan/exporters/testing/json/__init__.py
@@ -78,8 +78,8 @@ class JSONExporter(Exporter):
         if len(source):
             json_path.parent.mkdir(parents=True, exist_ok=True)
 
-            test_plan_schema = TestReportSchema(strict=True)
-            data = test_plan_schema.dump(source).data
+            test_plan_schema = TestReportSchema()
+            data = test_plan_schema.dump(source)
             attachments_dir = json_path.parent / defaults.ATTACHMENTS
 
             # Save the Testplan report.

--- a/testplan/exporters/testing/webserver/base.py
+++ b/testplan/exporters/testing/webserver/base.py
@@ -74,8 +74,8 @@ class WebServerExporter(Exporter):
             )
             return
 
-        test_plan_schema = TestReportSchema(strict=True)
-        data = test_plan_schema.dump(source).data
+        test_plan_schema = TestReportSchema()
+        data = test_plan_schema.dump(source)
 
         # Save the Testplan report as a JSON.
         with open(defaults.JSON_PATH, "w") as json_file:

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -560,7 +560,7 @@ class TestReport(BaseReportGroup):
         """
         from .schemas import TestReportSchema
 
-        return TestReportSchema(strict=True).dump(self).data
+        return TestReportSchema().dump(self)
 
     @classmethod
     def deserialize(cls, data):
@@ -570,13 +570,13 @@ class TestReport(BaseReportGroup):
         """
         from .schemas import TestReportSchema
 
-        return TestReportSchema(strict=True).load(data).data
+        return TestReportSchema().load(data)
 
     def shallow_serialize(self):
         """Shortcut for shallow-serializing test report data."""
         from .schemas import ShallowTestReportSchema
 
-        return ShallowTestReportSchema(strict=True).dump(self).data
+        return ShallowTestReportSchema().dump(self)
 
     @classmethod
     def shallow_deserialize(cls, data, old_report):
@@ -586,7 +586,7 @@ class TestReport(BaseReportGroup):
         """
         from .schemas import ShallowTestReportSchema
 
-        deserialized = ShallowTestReportSchema(strict=True).load(data).data
+        deserialized = ShallowTestReportSchema().load(data)
         deserialized.entries = old_report.entries
         deserialized._index = old_report._index
 
@@ -674,14 +674,14 @@ class TestGroupReport(BaseReportGroup):
         if self.tags_index or item.tags_index:
             self.propagate_tag_indices()
 
-    def serialize(self, strict=True):
+    def serialize(self):
         """
         Shortcut for serializing TestGroupReport data to nested python
         dictionaries.
         """
         from .schemas import TestGroupReportSchema
 
-        return TestGroupReportSchema(strict=strict).dump(self).data
+        return TestGroupReportSchema().dump(self)
 
     @classmethod
     def deserialize(cls, data):
@@ -691,13 +691,13 @@ class TestGroupReport(BaseReportGroup):
         """
         from .schemas import TestGroupReportSchema
 
-        return TestGroupReportSchema(strict=True).load(data).data
+        return TestGroupReportSchema().load(data)
 
     def shallow_serialize(self):
         """Shortcut for shallow-serializing test report data."""
         from .schemas import ShallowTestGroupReportSchema
 
-        return ShallowTestGroupReportSchema(strict=True).dump(self).data
+        return ShallowTestGroupReportSchema().dump(self)
 
     @classmethod
     def shallow_deserialize(cls, data, old_report):
@@ -707,9 +707,7 @@ class TestGroupReport(BaseReportGroup):
         """
         from .schemas import ShallowTestGroupReportSchema
 
-        deserialized = (
-            ShallowTestGroupReportSchema(strict=True).load(data).data
-        )
+        deserialized = ShallowTestGroupReportSchema().load(data)
         deserialized.entries = old_report.entries
         deserialized._index = old_report._index
         return deserialized
@@ -940,7 +938,7 @@ class TestCaseReport(Report):
         """
         from .schemas import TestCaseReportSchema
 
-        return TestCaseReportSchema(strict=True).dump(self).data
+        return TestCaseReportSchema().dump(self)
 
     @classmethod
     def deserialize(cls, data):
@@ -950,7 +948,7 @@ class TestCaseReport(Report):
         """
         from .schemas import TestCaseReportSchema
 
-        return TestCaseReportSchema(strict=True).load(data).data
+        return TestCaseReportSchema().load(data)
 
     @property
     def hash(self):

--- a/testplan/report/testing/schemas.py
+++ b/testplan/report/testing/schemas.py
@@ -6,16 +6,20 @@ import json
 from boltons.iterutils import remap, is_scalar
 
 from marshmallow import Schema, fields, post_load
+from marshmallow.utils import EXCLUDE
 
 from testplan.common.serialization.schemas import load_tree_data
-from testplan.common.report.schemas import ReportSchema, ReportLogSchema
 from testplan.common.serialization import fields as custom_fields
+from testplan.common.report.schemas import ReportSchema, ReportLogSchema
 
 from testplan.common.utils import timing
 
 from .base import TestCaseReport, TestGroupReport, TestReport
 
+
 __all__ = ["TestCaseReportSchema", "TestGroupReportSchema", "TestReportSchema"]
+
+# pylint: disable=unused-argument, no-self-use
 
 
 class IntervalSchema(Schema):
@@ -25,7 +29,7 @@ class IntervalSchema(Schema):
     end = custom_fields.UTCDateTime(allow_none=True)
 
     @post_load
-    def make_interval(self, data):  # pylint: disable=no-self-use
+    def make_interval(self, data, **kwargs):
         """Create an Interal object."""
         return timing.Interval(**data)
 
@@ -33,13 +37,13 @@ class IntervalSchema(Schema):
 class TagField(fields.Field):
     """Field for serializing tag data, which is a ``dict`` of ``set``."""
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         return {
             tag_name: list(tag_values)
             for tag_name, tag_values in value.items()
         }
 
-    def _deserialize(self, value, attr, data):
+    def _deserialize(self, value, attr, data, **kwargs):
         return {
             tag_name: set(tag_values) for tag_name, tag_values in value.items()
         }
@@ -51,18 +55,12 @@ class TimerField(fields.Field):
     of ``timer.Interval``.
     """
 
-    def _serialize(self, value, attr, obj):
-        return {
-            k: IntervalSchema(strict=True).dump(v).data
-            for k, v in value.items()
-        }
+    def _serialize(self, value, attr, obj, **kwargs):
+        return {k: IntervalSchema().dump(v) for k, v in value.items()}
 
-    def _deserialize(self, value, attr, data):
+    def _deserialize(self, value, attr, data, **kwargs):
         return timing.Timer(
-            {
-                k: IntervalSchema(strict=True).load(v).data
-                for k, v in value.items()
-            }
+            {k: IntervalSchema().load(v) for k, v in value.items()}
         )
 
 
@@ -80,7 +78,7 @@ class EntriesField(fields.Field):
         else:
             return True
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         # we don't need a _deserialize() here as we don't (and can't)
         # convert str back to non-json-serializable.
         def visit(parent, key, _value):
@@ -117,7 +115,7 @@ class TestCaseReportSchema(ReportSchema):
     status_reason = fields.String(allow_none=True)
 
     @post_load
-    def make_report(self, data):
+    def make_report(self, data, **kwargs):
         """
         Create the report object, assign ``timer`` &
         ``status_override`` attributes explicitly
@@ -154,13 +152,13 @@ class TestGroupReportSchema(TestCaseReportSchema):
     entries = custom_fields.GenericNested(
         schema_context={
             TestCaseReport: TestCaseReportSchema,
-            TestGroupReport: "self",
+            TestGroupReport: lambda: TestGroupReportSchema(),
         },
         many=True,
     )
 
     @post_load
-    def make_report(self, data):
+    def make_report(self, data, **kwargs):
         """
         Propagate tag indices after deserialization
         """
@@ -171,6 +169,9 @@ class TestGroupReportSchema(TestCaseReportSchema):
 
 class TestReportSchema(Schema):
     """Schema for test report root, ``testing.TestReport``."""
+
+    class Meta:
+        unknown = EXCLUDE
 
     name = fields.String(required=True)
     description = fields.String(allow_none=True)
@@ -196,7 +197,7 @@ class TestReportSchema(Schema):
     )
 
     @post_load
-    def make_test_report(self, data):  # pylint: disable=no-self-use
+    def make_test_report(self, data, **kwargs):
         """Create report object & deserialize sub trees."""
         load_tree = functools.partial(
             load_tree_data,
@@ -222,11 +223,15 @@ class TestReportSchema(Schema):
         test_plan_report.timer = timer
         test_plan_report.timeout = timeout
         test_plan_report.logs = logs
+
         return test_plan_report
 
 
 class ShallowTestGroupReportSchema(Schema):
     """Schema for shallow serialization of ``TestGroupReport``."""
+
+    class Meta:
+        unknown = EXCLUDE
 
     name = fields.String(required=True)
     description = fields.String(allow_none=True)
@@ -243,15 +248,15 @@ class ShallowTestGroupReportSchema(Schema):
     suite_related = fields.Bool()
     tags = TagField()
 
-    entry_uids = fields.List(fields.Str(), dump_only=True)
-    parent_uids = fields.List(fields.Str())
+    entry_uids = fields.List(fields.String(), dump_only=True)
+    parent_uids = fields.List(fields.String())
     logs = fields.Nested(ReportLogSchema, many=True)
     hash = fields.Integer(dump_only=True)
     env_status = fields.String(allow_none=True)
     strict_order = fields.Bool()
 
     @post_load
-    def make_testgroup_report(self, data):
+    def make_testgroup_report(self, data, **kwargs):
         status_override = data.pop("status_override", None)
         timer = data.pop("timer")
         logs = data.pop("logs", [])
@@ -269,6 +274,9 @@ class ShallowTestGroupReportSchema(Schema):
 class ShallowTestReportSchema(Schema):
     """Schema for shallow serialization of ``TestReport``."""
 
+    class Meta:
+        unknown = EXCLUDE
+
     name = fields.String(required=True)
     description = fields.String(allow_none=True)
     uid = fields.String(required=True)
@@ -281,13 +289,13 @@ class ShallowTestReportSchema(Schema):
     status_override = fields.String(allow_none=True)
     counter = fields.Dict(dump_only=True)
     attachments = fields.Dict()
-    entry_uids = fields.List(fields.Str(), dump_only=True)
-    parent_uids = fields.List(fields.Str())
+    entry_uids = fields.List(fields.String(), dump_only=True)
+    parent_uids = fields.List(fields.String())
     logs = fields.Nested(ReportLogSchema, many=True)
     hash = fields.Integer(dump_only=True)
 
     @post_load
-    def make_test_report(self, data):
+    def make_test_report(self, data, **kwargs):
         status_override = data.pop("status_override", None)
         timer = data.pop("timer")
         logs = data.pop("logs", [])

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -482,7 +482,7 @@ class TestRunnerIHandler(entity.Entity):
         if exclude_assertions is True:
             report = report.filter(_exclude_assertions_filter)
         if serialized:
-            return report.serialize(strict=False)
+            return report.serialize()
         return report
 
     def test_case_report(self, test_uid, suite_uid, case_uid, serialized=True):
@@ -508,7 +508,7 @@ class TestRunnerIHandler(entity.Entity):
 
         report = report.filter(case_filter, is_assertion)
         if serialized:
-            return report.serialize(strict=False)
+            return report.serialize()
         return report
 
     def start_environment(self, env_uid):

--- a/testplan/testing/multitest/entries/schemas/assertions.py
+++ b/testplan/testing/multitest/entries/schemas/assertions.py
@@ -175,7 +175,7 @@ class XMLCheckSchema(AssertionSchema):
 
     xml = custom_fields.XMLElementField(attribute="element")
 
-    namespaces = fields.Dict(fields.String())
+    namespaces = fields.Dict()
     data = fields.List(fields.List(custom_fields.NativeOrPretty()))
     message = fields.String()
 

--- a/testplan/testing/multitest/entries/schemas/base.py
+++ b/testplan/testing/multitest/entries/schemas/base.py
@@ -18,14 +18,14 @@ registry = AssertionSchemaRegistry()
 
 
 class GenericEntryList(fields.Field):
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         return [registry.serialize(entry) for entry in value]
 
 
 @registry.bind_default()
 class BaseSchema(Schema):
-    utc_time = fields.LocalDateTime()
-    machine_time = custom_fields.UTCDateTime()
+    utc_time = custom_fields.UTCDateTime()
+    machine_time = custom_fields.LocalDateTime()
     type = custom_fields.ClassName()
     meta_type = fields.String()
     description = custom_fields.Unicode()
@@ -79,8 +79,12 @@ class DictLogSchema(BaseSchema):
 @registry.bind(base.Graph)
 class GraphSchema(BaseSchema):
     graph_type = fields.String()
-    graph_data = fields.Dict(fields.List(fields.Dict()))
-    series_options = fields.Dict(fields.Dict(), allow_none=True)
+    graph_data = fields.Dict(
+        keys=fields.String(), values=fields.List(fields.Dict())
+    )
+    series_options = fields.Dict(
+        keys=fields.String(), values=fields.Dict(), allow_none=True
+    )
     type = fields.String()
     graph_options = fields.Dict(allow_none=True)
     discrete_chart = fields.Bool()

--- a/testplan/vendor/tempita/_looper.py
+++ b/testplan/vendor/tempita/_looper.py
@@ -15,8 +15,8 @@ looper you can get a better sense of the context.  Use like::
     3 c
 """
 
-import sys
 from .compat3 import basestring_
+
 
 __all__ = ['looper']
 

--- a/tests/unit/testplan/report/test_testing.py
+++ b/tests/unit/testplan/report/test_testing.py
@@ -393,9 +393,9 @@ def test_report_serialization(dummy_test_plan_report):
 
 def test_report_json_serialization(dummy_test_plan_report):
     """JSON Serialized & deserialized reports should be equal."""
-    test_plan_schema = TestReportSchema(strict=True)
-    data = test_plan_schema.dumps(dummy_test_plan_report).data
-    deserialized_report = test_plan_schema.loads(data).data
+    test_plan_schema = TestReportSchema()
+    data = test_plan_schema.dumps(dummy_test_plan_report)
+    deserialized_report = test_plan_schema.loads(data)
     check_report(actual=deserialized_report, expected=dummy_test_plan_report)
 
 
@@ -403,10 +403,8 @@ def test_report_json_binary_serialization(
     dummy_test_plan_report_with_binary_asserts,
 ):
     """JSON Serialized & deserialized reports should be equal."""
-    test_plan_schema = TestReportSchema(strict=True)
-    data = test_plan_schema.dumps(
-        dummy_test_plan_report_with_binary_asserts
-    ).data
+    test_plan_schema = TestReportSchema()
+    data = test_plan_schema.dumps(dummy_test_plan_report_with_binary_asserts)
 
     j = json.loads(data)
 


### PR DESCRIPTION
* Now Testplan 2 should fully supports Python 3, the current version
  3.0.0b2 still supports Python 2 and it will be deprecated. We have
  to update marshmallow to the latest but some incompatible changes
  have been introduced and need to be solved.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
