### PR TITLE
Display line number

### DIFF
--- a/testplan/web_ui/testing/src/AssertionPane/Assertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/Assertion.js
@@ -1,7 +1,7 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {Card, CardBody, Collapse} from 'reactstrap';
-import {css, StyleSheet} from 'aphrodite';
+import { Card, CardBody, Collapse } from 'reactstrap';
+import { css, StyleSheet } from 'aphrodite';
 
 import BasicAssertion from './AssertionTypes/BasicAssertion';
 import MarkdownAssertion from './AssertionTypes/MarkdownAssertion';
@@ -21,7 +21,7 @@ import FixMatchAssertion
 import NotImplementedAssertion from './AssertionTypes/NotImplementedAssertion';
 import AssertionHeader from './AssertionHeader';
 import AssertionGroup from './AssertionGroup';
-import {BASIC_ASSERTION_TYPES} from '../Common/defaults';
+import { BASIC_ASSERTION_TYPES } from '../Common/defaults';
 import XYGraphAssertion
   from './AssertionTypes/GraphAssertions/XYGraphAssertion';
 import DiscreteChartAssertion
@@ -41,7 +41,7 @@ class Assertion extends Component {
       if (arr1 === undefined && arr2 === undefined) {
         return true;
       } else if (arr1 !== undefined && arr2 !== undefined &&
-                 arr1.length === arr2.length) {
+        arr1.length === arr2.length) {
         return true;
       } else {
         return false;
@@ -110,6 +110,7 @@ class Assertion extends Component {
             entries={this.props.assertion.entries}
             filter={this.props.filter}
             reportUid={this.props.reportUid}
+            displayPath={this.props.displayPath}
           />
         );
         break;
@@ -141,8 +142,10 @@ class Assertion extends Component {
       <Card className={css(styles.card)}>
         <AssertionHeader
           assertion={this.props.assertion}
-          onClick={this.props.toggleExpand}
+          uid={this.props.uid}
+          toggleExpand={this.props.toggleExpand}
           index={this.props.index}
+          displayPath={this.props.displayPath}
         />
         <Collapse
           isOpen={this.props.expand === EXPAND_STATUS.EXPAND}
@@ -159,12 +162,20 @@ class Assertion extends Component {
             }
           >
             {this.props.expand === EXPAND_STATUS.EXPAND ? assertionType : null}
+            {getLineNumber(this.props)}
           </CardBody>
         </Collapse>
       </Card>
     );
   }
 }
+
+const getLineNumber = (props) => {
+  if (props.assertion.file_path && props.assertion.line_no) {
+    return props.assertion.file_path + ":" + props.assertion.line_no;
+  }
+  return null;
+};
 
 Assertion.propTypes = {
   /** Assertion to be rendered */

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionGroup.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionGroup.js
@@ -59,6 +59,7 @@ const AssertionGroup = (props) => {
           }}
           index={index}
           filter={props.filter}
+          displayPath={props.displayPath}
           reportUid={props.reportUid}
         />
       );

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionHeader.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionHeader.js
@@ -1,10 +1,11 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {css, StyleSheet} from 'aphrodite';
-import {CardHeader, Tooltip} from 'reactstrap';
-import {library} from '@fortawesome/fontawesome-svg-core';
-import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {faLayerGroup} from '@fortawesome/free-solid-svg-icons';
+import { css, StyleSheet } from 'aphrodite';
+import { CardHeader, Tooltip } from 'reactstrap';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faLayerGroup } from '@fortawesome/free-solid-svg-icons';
+import Button from '@material-ui/core/Button';
 
 library.add(faLayerGroup);
 
@@ -17,10 +18,21 @@ class AssertionHeader extends Component {
 
     this.state = {
       isUTCTooltipOpen: false,
+      isPathTooltipOpen: false,
       isDurationTooltipOpen: false,
     };
     this.toggleUTCTooltip = this.toggleUTCTooltip.bind(this);
+    this.togglePathTooltip = this.togglePathTooltip.bind(this);
     this.toggleDurationTooltip = this.toggleDurationTooltip.bind(this);
+  }
+
+  /**
+   * Toggle the visibility of tooltip of file path.
+   */
+  togglePathTooltip() {
+    this.setState(prevState => ({
+      isPathTooltipOpen: !prevState.isPathTooltipOpen
+    }));
   }
 
   /**
@@ -59,59 +71,86 @@ class AssertionHeader extends Component {
         />
       </span>
     ) : ((timeInfoArray.length === 0) ? (
-        <span className={css(styles.cardHeaderAlignRight)}></span>
-      ) : (
-        <>
-          <span
-            className={css(styles.cardHeaderAlignRight)}
-            id={`tooltip_duration_${timeInfoArray[0]}`}
-          >
-            {timeInfoArray[2]}
-          </span>
-          <span className={css(styles.cardHeaderAlignRight)}>
-            &nbsp;&nbsp;
-          </span>
-          <span
-            className={css(styles.cardHeaderAlignRight)}
-            id={`tooltip_utc_${timeInfoArray[0]}`}
-          >
-            {timeInfoArray[1]}
-          </span>
-          <Tooltip
-            placement='bottom'
-            isOpen={this.state.isUTCTooltipOpen}
-            target={`tooltip_utc_${timeInfoArray[0]}`}
-            toggle={this.toggleUTCTooltip}
-          >
-            {"Assertion start time"}
-          </Tooltip>
-          <Tooltip
-            placement='bottom'
-            isOpen={this.state.isDurationTooltipOpen}
-            target={`tooltip_duration_${timeInfoArray[0]}`}
-            toggle={this.toggleDurationTooltip}
-          >
-            {"Assertion duration"}
-          </Tooltip>
-        </>
-      )
+      <span className={css(styles.cardHeaderAlignRight)}></span>
+    ) : (
+      <>
+        <span
+          className={css(styles.cardHeaderAlignRight, styles.timeInfo)}
+          id={`tooltip_duration_${timeInfoArray[0]}`}
+        >
+          {timeInfoArray[2]}
+        </span>
+        <span className={css(styles.cardHeaderAlignRight)}>
+          &nbsp;&nbsp;
+        </span>
+        <span
+          className={css(styles.cardHeaderAlignRight, styles.timeInfo)}
+          id={`tooltip_utc_${timeInfoArray[0]}`}
+        >
+          {timeInfoArray[1]}
+        </span>
+        <Tooltip
+          placement='bottom'
+          isOpen={this.state.isUTCTooltipOpen}
+          target={`tooltip_utc_${timeInfoArray[0]}`}
+          toggle={this.toggleUTCTooltip}
+        >
+          {"Assertion start time"}
+        </Tooltip>
+        <Tooltip
+          placement='bottom'
+          isOpen={this.state.isDurationTooltipOpen}
+          target={`tooltip_duration_${timeInfoArray[0]}`}
+          toggle={this.toggleDurationTooltip}
+        >
+          {"Assertion duration"}
+        </Tooltip>
+      </>
+    )
     );
+
+    let pathButton = this.props.displayPath ?
+      <>
+        <Button
+          size="small"
+          className={css(styles.cardHeaderAlignRight)}
+          onClick={() => {
+            navigator.clipboard.writeText(getPath(this.props.assertion));
+          }}
+        >
+          <span id={`tooltip_path_${this.props.uid}`}
+            className={css(cardHeaderStyle)}>
+            {renderPath(this.props.assertion)}
+          </span>
+        </Button>
+        <Tooltip
+          isOpen={this.state.isPathTooltipOpen}
+          target={`tooltip_path_${this.props.uid}`}
+          toggle={this.togglePathTooltip}
+        >
+          {getPath(this.props.assertion)}
+        </Tooltip>
+      </> : <></>;
 
     return (
       <CardHeader
         className={css(styles.cardHeader, cardHeaderStyle)}
-        onClick={this.props.onClick}
       >
-        <span>
-          <strong>
-            {this.props.assertion.description ? (
-             this.props.assertion.description + " ") : ""}
-          </strong>
-        </span>
-        <span>
-          ({this.props.assertion.type})
+        <span
+          className={css(styles.button)}
+          onClick={this.props.toggleExpand}>
+          <span>
+            <strong>
+              {this.props.assertion.description ? (
+                this.props.assertion.description + " ") : ""}
+            </strong>
+          </span>
+          <span>
+            ({this.props.assertion.type})
+          </span>
         </span>
         {component}
+        {pathButton}
         {/*
           TODO will be implemented when complete permalink feature
           linkIcon
@@ -130,13 +169,38 @@ AssertionHeader.propTypes = {
   onClick: PropTypes.func,
 };
 
+const renderPath = (assertion) => {
+  if (assertion.file_path && assertion.line_no) {
+    return (
+      <>
+        <span className={css(styles.icon)}>
+          <i class="fa fa-copy fa-s"></i>
+        </span>
+        <div className={css(styles.cardHeaderPath)}>
+          {getPath(assertion)}
+        </div>
+      </>);
+  }
+  return null;
+};
+
+const getPath = (assertion) => {
+  if (assertion.file_path && assertion.line_no) {
+    return assertion.file_path + ":" + assertion.line_no;
+  }
+  return null;
+};
+
 const styles = StyleSheet.create({
   cardHeader: {
     padding: '.25rem .75rem',
     fontSize: 'small',
     backgroundColor: 'rgba(0,0,0,0)', // Move to defaults?
-    cursor: 'pointer',
     borderBottom: '1px solid',
+  },
+
+  button: {
+    cursor: 'pointer'
   },
 
   cardHeaderColorLog: {
@@ -156,6 +220,22 @@ const styles = StyleSheet.create({
 
   cardHeaderAlignRight: {
     float: 'right',
+  },
+
+  timeInfo: {
+    padding: '4px 0px'
+  },
+
+  cardHeaderPath: {
+    float: 'right',
+    fontSize: 'small',
+    maxWidth: '400px',
+    "-webkit-line-clamp": 1,
+    "-webkit-box-orient": "vertical",
+    "white-space": "nowrap",
+    direction: 'rtl',
+    overflow: "hidden",
+    textOverflow: "ellipsis",
   },
 
   collapseDiv: {

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionPane.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionPane.js
@@ -77,6 +77,7 @@ class AssertionPane extends Component {
                 <AssertionGroup
                   entries={this.props.assertions}
                   filter={this.props.filter}
+                  displayPath={this.props.displayPath}
                   assertionGroupUid={this.props.testcaseUid}
                   reportUid={this.props.reportUid}
                 />

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionSummary.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionSummary.js
@@ -39,6 +39,7 @@ class SummaryBaseAssertion extends Component {
                   assertionGroupUid={this.props.assertionGroupUid}
                   entries={single_assertion_group.entries}
                   filter={this.props.filter}
+                  displayPath={this.props.displayPath}
                 />
               </Col>
             </Row>

--- a/testplan/web_ui/testing/src/AssertionPane/__tests__/__snapshots__/AssertionHeader.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/__tests__/__snapshots__/AssertionHeader.test.js.snap
@@ -2,17 +2,20 @@
 
 exports[`AssertionHeader shallow renders the correct HTML structure 1`] = `
 <CardHeader
-  className="cardHeader_1ggz856-o_O-cardHeaderColorPassed_1nxwz58"
-  onClick={[MockFunction]}
+  className="cardHeader_z4yav1-o_O-cardHeaderColorPassed_1nxwz58"
   tag="div"
 >
-  <span>
-    <strong />
-  </span>
-  <span>
-    (
-    Equal
-    )
+  <span
+    className="button_13xlah4"
+  >
+    <span>
+      <strong />
+    </span>
+    <span>
+      (
+      Equal
+      )
+    </span>
   </span>
   <span
     className="cardHeaderAlignRight_107ja4p"

--- a/testplan/web_ui/testing/src/Common/fakeReport.js
+++ b/testplan/web_ui/testing/src/Common/fakeReport.js
@@ -86,7 +86,8 @@ const TESTPLAN_REPORT = {
                   "category": "DEFAULT",
                   "machine_time": "2018-10-15T15:30:11.010098+00:00",
                   "description": "passing equality",
-                  "line_no": 24,
+                  "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
+                                    "line_no": 24,
                   "label": "==",
                   "second": 1,
                   "meta_type": "assertion",
@@ -118,7 +119,8 @@ const TESTPLAN_REPORT = {
                   "category": "DEFAULT",
                   "machine_time": "2018-10-15T15:30:11.510098+00:00",
                   "description": "passing equality",
-                  "line_no": 24,
+                  "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
+                                    "line_no": 24,
                   "label": "==",
                   "second": 1,
                   "meta_type": "assertion",
@@ -171,6 +173,7 @@ const TESTPLAN_REPORT = {
                   "category": "DEFAULT",
                   "machine_time": "2018-10-15T15:30:11.010098+00:00",
                   "description": "passing equality",
+                  "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                   "line_no": 24,
                   "label": "==",
                   "second": 1,
@@ -241,6 +244,7 @@ const TESTPLAN_REPORT = {
                   "category": "DEFAULT",
                   "machine_time": "2018-10-15T15:30:12.010098+00:00",
                   "description": "passing equality",
+                  "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                   "line_no": 24,
                   "label": "==",
                   "second": 1,
@@ -380,6 +384,7 @@ var fakeReportAssertions = {
                             "entries": [
                               {
                                 "hash": "ead907197415758fb6a15295336bd51da891a88a",
+                                "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                 "line_no": 44,
                                 "category": "DEFAULT",
                                 "meta_type": "entry",
@@ -444,6 +449,8 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "first": "foo",
                                     "machine_time": "2020-01-10T11:06:58.630129+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 25
                                 },
                                 {
@@ -459,6 +466,8 @@ var fakeReportAssertions = {
                                     "type_expected": "str",
                                     "first": "This is a long thing with some extra at the end",
                                     "machine_time": "2020-01-10T11:06:58.630129+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 25
                                 },
                                 {
@@ -472,6 +481,8 @@ var fakeReportAssertions = {
                                     "passed": false,
                                     "first": 1,
                                     "machine_time": "2020-01-10T11:06:58.893477+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 28
                                 },
                                 {
@@ -485,6 +496,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "first": "foo",
                                     "machine_time": "2020-01-10T11:06:58.895806+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 30
                                 },
                                 {
@@ -498,6 +510,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "first": 5,
                                     "machine_time": "2020-01-10T11:06:58.898084+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 31
                                 },
                                 {
@@ -511,6 +524,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "first": 2,
                                     "machine_time": "2020-01-10T11:06:58.899627+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 32
                                 },
                                 {
@@ -524,6 +538,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "first": 2,
                                     "machine_time": "2020-01-10T11:06:58.901163+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 33
                                 },
                                 {
@@ -537,6 +552,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "first": 10,
                                     "machine_time": "2020-01-10T11:06:58.902613+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 34
                                 },
                                 {
@@ -550,6 +566,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "first": 10,
                                     "machine_time": "2020-01-10T11:06:58.904117+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 35
                                 },
                                 {
@@ -563,6 +580,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "first": 10,
                                     "machine_time": "2020-01-10T11:06:58.905550+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 36
                                 },
                                 {
@@ -576,6 +594,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "first": 15,
                                     "machine_time": "2020-01-10T11:06:58.907002+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 41
                                 },
                                 {
@@ -589,6 +608,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "first": 10,
                                     "machine_time": "2020-01-10T11:06:58.908440+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 42
                                 },
                                 {
@@ -602,6 +622,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "first": 2,
                                     "machine_time": "2020-01-10T11:06:58.909954+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 43
                                 },
                                 {
@@ -615,6 +636,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "first": 3,
                                     "machine_time": "2020-01-10T11:06:58.911449+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 44
                                 },
                                 {
@@ -628,6 +650,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "first": 10,
                                     "machine_time": "2020-01-10T11:06:58.912928+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 45
                                 },
                                 {
@@ -641,6 +664,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "first": 15,
                                     "machine_time": "2020-01-10T11:06:58.914473+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 46
                                 },
                                 {
@@ -656,6 +680,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "first": 100,
                                     "machine_time": "2020-01-10T11:06:58.915984+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 50
                                 },
                                 {
@@ -671,6 +696,7 @@ var fakeReportAssertions = {
                                     "passed": false,
                                     "first": 100,
                                     "machine_time": "2020-01-10T11:06:58.917489+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 51
                                 },
                                 {
@@ -680,6 +706,7 @@ var fakeReportAssertions = {
                                     "type": "Log",
                                     "utc_time": "2020-01-10T03:06:58.919181+00:00",
                                     "machine_time": "2020-01-10T11:06:58.919189+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 56,
                                     "message": "This is a log message, it will be displayed along with other assertion details."
                                 },
@@ -692,6 +719,7 @@ var fakeReportAssertions = {
                                     "expr": true,
                                     "passed": true,
                                     "machine_time": "2020-01-10T11:06:58.921021+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 61
                                 },
                                 {
@@ -703,6 +731,7 @@ var fakeReportAssertions = {
                                     "expr": false,
                                     "passed": true,
                                     "machine_time": "2020-01-10T11:06:58.923064+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 62
                                 },
                                 {
@@ -713,6 +742,7 @@ var fakeReportAssertions = {
                                     "utc_time": "2020-01-10T03:06:58.924595+00:00",
                                     "passed": false,
                                     "machine_time": "2020-01-10T11:06:58.924621+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 64
                                 },
                                 {
@@ -724,6 +754,7 @@ var fakeReportAssertions = {
                                     "container": "foobar",
                                     "passed": true,
                                     "machine_time": "2020-01-10T11:06:58.926413+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 67,
                                     "member": "foo"
                                 },
@@ -736,6 +767,7 @@ var fakeReportAssertions = {
                                     "container": "{'a': 1, 'b': 2}",
                                     "passed": true,
                                     "machine_time": "2020-01-10T11:06:58.928515+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 71,
                                     "member": 10
                                 },
@@ -792,6 +824,7 @@ var fakeReportAssertions = {
                                         7,
                                         8
                                     ],
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 79,
                                     "actual": [
                                         1,
@@ -886,6 +919,7 @@ var fakeReportAssertions = {
                                         "e",
                                         "f"
                                     ],
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 91,
                                     "actual": [
                                         1,
@@ -920,6 +954,7 @@ var fakeReportAssertions = {
                                     ],
                                     "machine_time": "2020-01-10T11:06:58.934786+00:00",
                                     "ignore_space_change": false,
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 98,
                                     "ignore_whitespaces": false
                                 },
@@ -956,6 +991,7 @@ var fakeReportAssertions = {
                                     ],
                                     "machine_time": "2020-01-10T11:06:58.936983+00:00",
                                     "ignore_space_change": true,
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 102,
                                     "ignore_whitespaces": false
                                 }
@@ -1012,6 +1048,7 @@ var fakeReportAssertions = {
                                     "pattern_match": true,
                                     "machine_time": "2020-01-10T11:06:58.954275+00:00",
                                     "func": null,
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 112
                                 },
                                 {
@@ -1034,6 +1071,7 @@ var fakeReportAssertions = {
                                     "pattern_match": true,
                                     "machine_time": "2020-01-10T11:06:58.955871+00:00",
                                     "func": null,
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 121
                                 },
                                 {
@@ -1056,6 +1094,7 @@ var fakeReportAssertions = {
                                     "pattern_match": true,
                                     "machine_time": "2020-01-10T11:06:58.957497+00:00",
                                     "func": "<function SampleSuite.test_raised_exceptions.<locals>.custom_func at 0x7f9cfc64fea0>",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 139
                                 },
                                 {
@@ -1078,6 +1117,7 @@ var fakeReportAssertions = {
                                     "pattern_match": true,
                                     "machine_time": "2020-01-10T11:06:58.958964+00:00",
                                     "func": null,
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 146
                                 },
                                 {
@@ -1100,6 +1140,7 @@ var fakeReportAssertions = {
                                     "pattern_match": null,
                                     "machine_time": "2020-01-10T11:06:58.960510+00:00",
                                     "func": null,
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 157
                                 },
                                 {
@@ -1122,6 +1163,7 @@ var fakeReportAssertions = {
                                     "pattern_match": true,
                                     "machine_time": "2020-01-10T11:06:58.962031+00:00",
                                     "func": "<function SampleSuite.test_raised_exceptions.<locals>.custom_func at 0x7f9cfc64fea0>",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 165
                                 }
                             ]
@@ -1168,6 +1210,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "first": 1,
                                     "machine_time": "2020-01-10T11:06:58.971451+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 173
                                 },
                                 {
@@ -1187,7 +1230,8 @@ var fakeReportAssertions = {
                                             "passed": true,
                                             "first": 2,
                                             "machine_time": "2020-01-10T11:06:58.973047+00:00",
-                                            "line_no": 176
+                                            "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
+                                    "line_no": 176
                                         },
                                         {
                                             "category": "DEFAULT",
@@ -1200,7 +1244,8 @@ var fakeReportAssertions = {
                                             "passed": true,
                                             "first": 5,
                                             "machine_time": "2020-01-10T11:06:58.974586+00:00",
-                                            "line_no": 177
+                                            "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
+                                    "line_no": 177
                                         },
                                         {
                                             "description": "This is a sub group",
@@ -1219,7 +1264,8 @@ var fakeReportAssertions = {
                                                     "passed": false,
                                                     "first": 6,
                                                     "machine_time": "2020-01-10T11:06:58.976384+00:00",
-                                                    "line_no": 181
+                                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
+                                    "line_no": 181
                                                 }
                                             ]
                                         }
@@ -1236,6 +1282,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "first": "foo",
                                     "machine_time": "2020-01-10T11:06:58.978227+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 184
                                 }
                             ]
@@ -1287,6 +1334,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "string": "foobar",
                                     "machine_time": "2020-01-10T11:06:58.987146+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 196
                                 },
                                 {
@@ -1305,6 +1353,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "string": "foobar",
                                     "machine_time": "2020-01-10T11:06:58.988913+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 201
                                 },
                                 {
@@ -1323,6 +1372,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "string": "first line\nsecond line\nthird line",
                                     "machine_time": "2020-01-10T11:06:58.991285+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 212
                                 },
                                 {
@@ -1336,6 +1386,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "string": "foobar",
                                     "machine_time": "2020-01-10T11:06:58.992945+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 217
                                 },
                                 {
@@ -1349,6 +1400,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "string": "first line\nsecond line\nthird line",
                                     "machine_time": "2020-01-10T11:06:58.994527+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 222
                                 },
                                 {
@@ -1367,6 +1419,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "string": "first line\nsecond line\nthird line",
                                     "machine_time": "2020-01-10T11:06:58.996156+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 225
                                 },
                                 {
@@ -1380,6 +1433,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "string": "first line\nsecond line\nthird line",
                                     "machine_time": "2020-01-10T11:06:58.997768+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 230
                                 },
                                 {
@@ -1398,6 +1452,7 @@ var fakeReportAssertions = {
                                     "passed": false,
                                     "string": "first line\nsecond line\nthird line",
                                     "machine_time": "2020-01-10T11:06:58.999303+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 233
                                 },
                                 {
@@ -1430,6 +1485,7 @@ var fakeReportAssertions = {
                                     "string": "foo foo foo bar bar foo bar",
                                     "machine_time": "2020-01-10T11:06:59.000860+00:00",
                                     "condition_match": true,
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 243
                                 },
                                 {
@@ -1462,6 +1518,7 @@ var fakeReportAssertions = {
                                     "string": "foo foo foo bar bar foo bar",
                                     "machine_time": "2020-01-10T11:06:59.002676+00:00",
                                     "condition_match": true,
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 250
                                 },
                                 {
@@ -1491,6 +1548,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "string": "first line\nsecond line\nthird line",
                                     "machine_time": "2020-01-10T11:06:59.004630+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 257
                                 }
                             ]
@@ -1529,6 +1587,7 @@ var fakeReportAssertions = {
                                 {
                                     "flag": "DEFAULT",
                                     "machine_time": "2021-06-25T16:06:10.622340+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 92,
                                     "display_index": false,
                                     "description": "table log assertion",
@@ -1633,6 +1692,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "include_columns": null,
                                     "machine_time": "2020-01-10T11:06:59.016424+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 284,
                                     "message": null,
                                     "strict": false
@@ -1685,6 +1745,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "include_columns": null,
                                     "machine_time": "2020-01-10T11:06:59.018533+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 289,
                                     "message": null,
                                     "strict": false
@@ -1737,6 +1798,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "include_columns": null,
                                     "machine_time": "2020-01-10T11:06:59.020640+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 294,
                                     "message": null,
                                     "strict": false
@@ -1758,6 +1820,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "include_columns": null,
                                     "machine_time": "2020-01-10T11:06:59.023703+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 299,
                                     "message": null,
                                     "strict": false
@@ -1779,6 +1842,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "include_columns": null,
                                     "machine_time": "2020-01-10T11:06:59.026102+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 304,
                                     "message": null,
                                     "strict": false
@@ -1800,6 +1864,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "include_columns": null,
                                     "machine_time": "2020-01-10T11:06:59.027843+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 309,
                                     "message": null,
                                     "strict": false
@@ -1857,6 +1922,7 @@ var fakeReportAssertions = {
                                     "passed": false,
                                     "include_columns": null,
                                     "machine_time": "2020-01-10T11:06:59.029549+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 338,
                                     "message": null,
                                     "strict": false
@@ -1891,6 +1957,7 @@ var fakeReportAssertions = {
                                     "passed": false,
                                     "include_columns": null,
                                     "machine_time": "2020-01-10T11:06:59.031674+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 343,
                                     "message": null,
                                     "strict": false
@@ -1948,6 +2015,7 @@ var fakeReportAssertions = {
                                     "passed": false,
                                     "include_columns": null,
                                     "machine_time": "2020-01-10T11:06:59.034625+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 361,
                                     "message": null,
                                     "strict": false
@@ -1982,6 +2050,7 @@ var fakeReportAssertions = {
                                     "passed": false,
                                     "include_columns": null,
                                     "machine_time": "2020-01-10T11:06:59.037502+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 366,
                                     "message": null,
                                     "strict": false
@@ -2107,6 +2176,7 @@ var fakeReportAssertions = {
                                         "column_2"
                                     ],
                                     "machine_time": "2020-01-10T11:06:59.040052+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 383,
                                     "message": null,
                                     "strict": false
@@ -2131,6 +2201,7 @@ var fakeReportAssertions = {
                                         "column_2"
                                     ],
                                     "machine_time": "2020-01-10T11:06:59.042869+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 391,
                                     "message": null,
                                     "strict": false
@@ -2227,6 +2298,7 @@ var fakeReportAssertions = {
                                     "passed": false,
                                     "include_columns": null,
                                     "machine_time": "2020-01-10T11:06:59.046598+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 428,
                                     "message": null,
                                     "strict": false
@@ -2273,6 +2345,7 @@ var fakeReportAssertions = {
                                     "passed": false,
                                     "include_columns": null,
                                     "machine_time": "2020-01-10T11:06:59.049598+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 437,
                                     "message": null,
                                     "strict": false
@@ -2318,6 +2391,7 @@ var fakeReportAssertions = {
                                         "AAPL",
                                         "AMZN"
                                     ],
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 454,
                                     "report_fails_only": false
                                 },
@@ -2437,6 +2511,7 @@ var fakeReportAssertions = {
                                         "AAPL",
                                         "AMZN"
                                     ],
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 467,
                                     "report_fails_only": true
                                 },
@@ -2466,6 +2541,7 @@ var fakeReportAssertions = {
                                         "age"
                                     ],
                                     "machine_time": "2020-01-10T11:06:59.060020+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 472,
                                     "indices": [
                                         0,
@@ -2499,6 +2575,7 @@ var fakeReportAssertions = {
                                         "age"
                                     ],
                                     "machine_time": "2020-01-10T11:06:59.061718+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 473,
                                     "indices": [
                                         0,
@@ -2600,6 +2677,7 @@ var fakeReportAssertions = {
                                         "amount"
                                     ],
                                     "machine_time": "2020-01-10T11:06:59.063429+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 479,
                                     "indices": [
                                         0,
@@ -2876,6 +2954,7 @@ var fakeReportAssertions = {
                                         "col_19"
                                     ],
                                     "machine_time": "2020-01-10T11:06:59.065891+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 490,
                                     "indices": [
                                         0,
@@ -2935,6 +3014,7 @@ var fakeReportAssertions = {
                                         "Address"
                                     ],
                                     "machine_time": "2020-01-10T11:06:59.070780+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 504,
                                     "indices": [
                                         0,
@@ -3031,6 +3111,7 @@ var fakeReportAssertions = {
                                     "passed": false,
                                     "machine_time": "2020-01-10T11:06:59.087677+00:00",
                                     "exclude_keys": null,
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 524
                                 },
                                 {
@@ -3120,6 +3201,7 @@ var fakeReportAssertions = {
                                     "passed": false,
                                     "machine_time": "2020-01-10T11:06:59.089619+00:00",
                                     "exclude_keys": null,
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 542
                                 },
                                 {
@@ -3215,6 +3297,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "machine_time": "2020-01-10T11:06:59.091718+00:00",
                                     "exclude_keys": null,
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 560
                                 },
                                 {
@@ -3270,6 +3353,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "machine_time": "2020-01-10T11:06:59.093432+00:00",
                                     "exclude_keys": null,
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 572
                                 },
                                 {
@@ -3325,6 +3409,7 @@ var fakeReportAssertions = {
                                     "passed": false,
                                     "machine_time": "2020-01-10T11:06:59.094981+00:00",
                                     "exclude_keys": null,
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 578
                                 },
                                 {
@@ -3380,6 +3465,7 @@ var fakeReportAssertions = {
                                     "passed": true,
                                     "machine_time": "2020-01-10T11:06:59.096554+00:00",
                                     "exclude_keys": null,
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 587
                                 },
                                 {
@@ -3409,6 +3495,7 @@ var fakeReportAssertions = {
                                     "passed": false,
                                     "machine_time": "2020-01-10T11:06:59.098109+00:00",
                                     "exclude_keys": null,
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 601
                                 },
                                 {
@@ -3429,6 +3516,7 @@ var fakeReportAssertions = {
                                         "beta"
                                     ],
                                     "machine_time": "2020-01-10T11:06:59.099760+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 611,
                                     "has_keys": [
                                         "foo",
@@ -3494,6 +3582,7 @@ var fakeReportAssertions = {
                                         ]
                                     ],
                                     "machine_time": "2020-01-10T11:06:59.101290+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 620
                                 }
                             ]
@@ -3814,6 +3903,7 @@ var fakeReportAssertions = {
                                     "passed": false,
                                     "machine_time": "2020-01-10T11:06:59.111452+00:00",
                                     "exclude_keys": null,
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 708
                                 },
                                 {
@@ -3835,6 +3925,7 @@ var fakeReportAssertions = {
                                         555
                                     ],
                                     "machine_time": "2020-01-10T11:06:59.113697+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 716,
                                     "has_keys": [
                                         26,
@@ -3930,6 +4021,7 @@ var fakeReportAssertions = {
                                         ]
                                     ],
                                     "machine_time": "2020-01-10T11:06:59.115490+00:00",
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 729
                                 }
                             ]
@@ -3977,6 +4069,7 @@ var fakeReportAssertions = {
                                     "xml": "<Root>\n                <Test>Foo</Test>\n            </Root>\n",
                                     "machine_time": "2020-01-10T11:06:59.123821+00:00",
                                     "tags": null,
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 751,
                                     "message": "xpath: `/Root/Test` exists in the XML.",
                                     "xpath": "/Root/Test"
@@ -4009,6 +4102,7 @@ var fakeReportAssertions = {
                                         "Value1",
                                         "Value2"
                                     ],
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 765,
                                     "message": null,
                                     "xpath": "/Root/Test"
@@ -4036,6 +4130,7 @@ var fakeReportAssertions = {
                                     "tags": [
                                         "re.compile('Hello*')"
                                     ],
+                                    "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                                     "line_no": 784,
                                     "message": null,
                                     "xpath": "//*/a:message"

--- a/testplan/web_ui/testing/src/Report/BatchReport.js
+++ b/testplan/web_ui/testing/src/Report/BatchReport.js
@@ -6,7 +6,6 @@ import _ from 'lodash';
 
 import { parseToJson } from "../Common/utils";
 import Toolbar from "../Toolbar/Toolbar";
-import { TimeButton } from "../Toolbar/Buttons";
 import Nav from "../Nav/Nav";
 import {
   PropagateIndices,
@@ -41,6 +40,7 @@ class BatchReport extends React.Component {
     this.updateTreeView = this.updateTreeView.bind(this);
     this.updateTagsDisplay = this.updateTagsDisplay.bind(this);
     this.updateTimeDisplay = this.updateTimeDisplay.bind(this);
+    this.updatePathDisplay = this.updatePathDisplay.bind(this);
     this.updateDisplayEmpty = this.updateDisplayEmpty.bind(this);
     this.handleColumnResizing = this.handleColumnResizing.bind(this);
     this.updateGlobalExpand = this.updateGlobalExpand.bind(this);
@@ -60,6 +60,7 @@ class BatchReport extends React.Component {
       treeView: true,
       displayTags: false,
       displayTime: false,
+      displayPath: false,
       displayEmpty: true,
       assertionStatus: defaultAssertionStatus,
     };
@@ -274,6 +275,16 @@ class BatchReport extends React.Component {
   }
 
   /**
+   * Update file path and line number display of each assertion.
+   *
+   * @param {boolean} displayPath.
+   * @public
+   */
+  updatePathDisplay(displayPath) {
+    this.setState({ displayPath: displayPath });
+  }
+
+  /**
    * Update execution time display of each navigation entry and each assertion.
    *
    * @param {boolean} displayTime.
@@ -347,13 +358,8 @@ class BatchReport extends React.Component {
           updateEmptyDisplayFunc={this.updateDisplayEmpty}
           updateTreeViewFunc={this.updateTreeView}
           updateTagsDisplayFunc={this.updateTagsDisplay}
-          extraButtons={[
-            <TimeButton
-              key="time-button"
-              status={reportStatus}
-              updateTimeDisplayCbk={this.updateTimeDisplay}
-            />,
-          ]}
+          updatePathDisplayFunc={this.updatePathDisplay}
+          updateTimeDisplayFunc={this.updateTimeDisplay}
         />
         <Nav
           navListWidth={this.state.navWidth}

--- a/testplan/web_ui/testing/src/Report/EmptyReport.js
+++ b/testplan/web_ui/testing/src/Report/EmptyReport.js
@@ -3,13 +3,12 @@
  * Used as the default option when no other report URL filter is matched.
  */
 import React from 'react';
-import {StyleSheet, css} from 'aphrodite';
+import { StyleSheet, css } from 'aphrodite';
 
 import Message from '../Common/Message';
 import Toolbar from '../Toolbar/Toolbar';
-import {TimeButton} from '../Toolbar/Buttons';
 import Nav from '../Nav/Nav';
-import {COLUMN_WIDTH} from "../Common/defaults";
+import { COLUMN_WIDTH } from "../Common/defaults";
 
 const EmptyReport = (props) => {
   let message;
@@ -38,11 +37,8 @@ const EmptyReport = (props) => {
         updateEmptyDisplayFunc={noop}
         updateTreeViewFunc={noop}
         updateTagsDisplayFunc={noop}
-        extraButtons={[<TimeButton
-            key="time-button"
-            status={undefined}
-            updateTimeDisplayCbk={noop}
-          />]}
+        updateTimeDisplayFunc={noop}
+        extraButtons={[]}
       />
       <Nav
         report={null}

--- a/testplan/web_ui/testing/src/Report/InteractiveReport.js
+++ b/testplan/web_ui/testing/src/Report/InteractiveReport.js
@@ -636,6 +636,7 @@ class InteractiveReport extends React.Component {
           updateEmptyDisplayFunc={noop}
           updateTreeViewFunc={noop}
           updateTagsDisplayFunc={noop}
+          updateTimeDisplayFunc={noop}
           extraButtons={[
             <ReloadButton
               reloading={this.state.reloading}

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
@@ -6,14 +6,6 @@ exports[`BatchReport loads a more complex report 1`] = `
 >
   <Toolbar
     expandStatus="default"
-    extraButtons={
-      Array [
-        <TimeButton
-          status="failed"
-          updateTimeDisplayCbk={[Function]}
-        />,
-      ]
-    }
     filterBoxWidth="22em"
     filterText={null}
     handleNavFilter={[Function]}
@@ -462,7 +454,9 @@ exports[`BatchReport loads a more complex report 1`] = `
     updateEmptyDisplayFunc={[Function]}
     updateExpandStatusFunc={[Function]}
     updateFilterFunc={[Function]}
+    updatePathDisplayFunc={[Function]}
     updateTagsDisplayFunc={[Function]}
+    updateTimeDisplayFunc={[Function]}
     updateTreeViewFunc={[Function]}
   />
   <Nav
@@ -1386,14 +1380,6 @@ exports[`BatchReport loads a report with selection at Multitest level 1`] = `
 >
   <Toolbar
     expandStatus="default"
-    extraButtons={
-      Array [
-        <TimeButton
-          status="failed"
-          updateTimeDisplayCbk={[Function]}
-        />,
-      ]
-    }
     filterBoxWidth="22em"
     filterText={null}
     handleNavFilter={[Function]}
@@ -1842,7 +1828,9 @@ exports[`BatchReport loads a report with selection at Multitest level 1`] = `
     updateEmptyDisplayFunc={[Function]}
     updateExpandStatusFunc={[Function]}
     updateFilterFunc={[Function]}
+    updatePathDisplayFunc={[Function]}
     updateTagsDisplayFunc={[Function]}
+    updateTimeDisplayFunc={[Function]}
     updateTreeViewFunc={[Function]}
   />
   <Nav
@@ -3061,14 +3049,6 @@ exports[`BatchReport loads a report with selection at Testcase level 1`] = `
 >
   <Toolbar
     expandStatus="default"
-    extraButtons={
-      Array [
-        <TimeButton
-          status="failed"
-          updateTimeDisplayCbk={[Function]}
-        />,
-      ]
-    }
     filterBoxWidth="22em"
     filterText={null}
     handleNavFilter={[Function]}
@@ -3518,7 +3498,9 @@ exports[`BatchReport loads a report with selection at Testcase level 1`] = `
     updateEmptyDisplayFunc={[Function]}
     updateExpandStatusFunc={[Function]}
     updateFilterFunc={[Function]}
+    updatePathDisplayFunc={[Function]}
     updateTagsDisplayFunc={[Function]}
+    updateTimeDisplayFunc={[Function]}
     updateTreeViewFunc={[Function]}
   />
   <Nav
@@ -4680,6 +4662,7 @@ exports[`BatchReport loads a report with selection at Testcase level 1`] = `
         ]
       }
       descriptionEntries={Array []}
+      displayPath={false}
       filter={null}
       key="f73bd6ea-d378-437b-a5db-00d9e427f36a"
       left="22em"
@@ -4697,14 +4680,6 @@ exports[`BatchReport loads a report with selection at Testsuite level 1`] = `
 >
   <Toolbar
     expandStatus="default"
-    extraButtons={
-      Array [
-        <TimeButton
-          status="failed"
-          updateTimeDisplayCbk={[Function]}
-        />,
-      ]
-    }
     filterBoxWidth="22em"
     filterText={null}
     handleNavFilter={[Function]}
@@ -5153,7 +5128,9 @@ exports[`BatchReport loads a report with selection at Testsuite level 1`] = `
     updateEmptyDisplayFunc={[Function]}
     updateExpandStatusFunc={[Function]}
     updateFilterFunc={[Function]}
+    updatePathDisplayFunc={[Function]}
     updateTagsDisplayFunc={[Function]}
+    updateTimeDisplayFunc={[Function]}
     updateTreeViewFunc={[Function]}
   />
   <Nav
@@ -6527,14 +6504,6 @@ exports[`BatchReport loads a simple report 1`] = `
 >
   <Toolbar
     expandStatus="default"
-    extraButtons={
-      Array [
-        <TimeButton
-          status="failed"
-          updateTimeDisplayCbk={[Function]}
-        />,
-      ]
-    }
     filterBoxWidth="22em"
     filterText={null}
     handleNavFilter={[Function]}
@@ -6810,7 +6779,9 @@ exports[`BatchReport loads a simple report 1`] = `
     updateEmptyDisplayFunc={[Function]}
     updateExpandStatusFunc={[Function]}
     updateFilterFunc={[Function]}
+    updatePathDisplayFunc={[Function]}
     updateTagsDisplayFunc={[Function]}
+    updateTimeDisplayFunc={[Function]}
     updateTreeViewFunc={[Function]}
   />
   <Nav
@@ -7388,14 +7359,6 @@ exports[`BatchReport shallow renders the correct HTML structure when report load
 >
   <Toolbar
     expandStatus="default"
-    extraButtons={
-      Array [
-        <TimeButton
-          status="failed"
-          updateTimeDisplayCbk={[Function]}
-        />,
-      ]
-    }
     filterBoxWidth="22em"
     filterText={null}
     handleNavFilter={[Function]}
@@ -7844,7 +7807,9 @@ exports[`BatchReport shallow renders the correct HTML structure when report load
     updateEmptyDisplayFunc={[Function]}
     updateExpandStatusFunc={[Function]}
     updateFilterFunc={[Function]}
+    updatePathDisplayFunc={[Function]}
     updateTagsDisplayFunc={[Function]}
+    updateTimeDisplayFunc={[Function]}
     updateTreeViewFunc={[Function]}
   />
   <Nav
@@ -8779,14 +8744,6 @@ exports[`BatchReport shallow renders the correct HTML structure when report with
   >
     <Toolbar
       expandStatus="default"
-      extraButtons={
-        Array [
-          <TimeButton
-            status="error"
-            updateTimeDisplayCbk={[Function]}
-          />,
-        ]
-      }
       filterBoxWidth="22em"
       filterText={null}
       handleNavFilter={[Function]}
@@ -8832,7 +8789,9 @@ ZeroDivisionError: integer division or modulo by zero
       updateEmptyDisplayFunc={[Function]}
       updateExpandStatusFunc={[Function]}
       updateFilterFunc={[Function]}
+      updatePathDisplayFunc={[Function]}
       updateTagsDisplayFunc={[Function]}
+      updateTimeDisplayFunc={[Function]}
       updateTreeViewFunc={[Function]}
     >
       <div>
@@ -9308,80 +9267,199 @@ ZeroDivisionError: integer division or modulo by zero
                           </div>
                         </li>
                       </NavItem>
-                      <TimeButton
-                        key="time-button"
-                        status="error"
-                        updateTimeDisplayCbk={[Function]}
+                      <UncontrolledDropdown
+                        inNavbar={true}
+                        nav={true}
                       >
-                        <NavItem
-                          tag="li"
+                        <Dropdown
+                          active={false}
+                          addonType={false}
+                          direction="down"
+                          inNavbar={true}
+                          isOpen={false}
+                          nav={true}
+                          setActiveFromChild={false}
+                          toggle={[Function]}
                         >
-                          <li
-                            className="nav-item"
-                          >
-                            <div
-                              className="buttonsBar_6zsntc"
+                          <Manager>
+                            <li
+                              className="dropdown nav-item"
+                              onKeyDown={[Function]}
                             >
-                              <FontAwesomeIcon
-                                border={false}
-                                className="toolbarButton_1ueb7gu"
-                                fixedWidth={false}
-                                flip={null}
-                                icon={
-                                  Object {
-                                    "icon": Array [
-                                      512,
-                                      512,
-                                      Array [],
-                                      "f017",
-                                      "M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm57.1 350.1L224.9 294c-3.1-2.3-4.9-5.9-4.9-9.7V116c0-6.6 5.4-12 12-12h48c6.6 0 12 5.4 12 12v137.7l63.5 46.2c5.4 3.9 6.5 11.4 2.6 16.8l-28.2 38.8c-3.9 5.3-11.4 6.5-16.8 2.6z",
-                                    ],
-                                    "iconName": "clock",
-                                    "prefix": "fas",
-                                  }
-                                }
-                                inverse={false}
-                                key="toolbar-time"
-                                listItem={false}
-                                mask={null}
-                                onClick={[Function]}
-                                pull={null}
-                                pulse={false}
-                                rotation={null}
-                                size={null}
-                                spin={false}
-                                symbol={false}
-                                title="Display time information"
-                                transform={null}
+                              <div
+                                className="buttonsBar_6zsntc"
                               >
-                                <svg
-                                  aria-labelledby="svg-inline--fa-title-28"
-                                  className="svg-inline--fa fa-clock fa-w-16 toolbarButton_1ueb7gu"
-                                  data-icon="clock"
-                                  data-prefix="fas"
-                                  onClick={[Function]}
-                                  role="img"
-                                  style={Object {}}
-                                  viewBox="0 0 512 512"
-                                  xmlns="http://www.w3.org/2000/svg"
+                                <DropdownToggle
+                                  aria-haspopup={true}
+                                  className="toolbar_l6n5rs-o_O-toolbarFailed_1v5i7tx"
+                                  color="secondary"
+                                  nav={true}
                                 >
-                                  <title
-                                    id="svg-inline--fa-title-28"
-                                    style={Object {}}
+                                  <a
+                                    aria-expanded={false}
+                                    aria-haspopup={true}
+                                    className="toolbar_l6n5rs-o_O-toolbarFailed_1v5i7tx nav-link"
+                                    href="#"
+                                    onClick={[Function]}
                                   >
-                                    Display time information
-                                  </title>
-                                  <path
-                                    d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm57.1 350.1L224.9 294c-3.1-2.3-4.9-5.9-4.9-9.7V116c0-6.6 5.4-12 12-12h48c6.6 0 12 5.4 12 12v137.7l63.5 46.2c5.4 3.9 6.5 11.4 2.6 16.8l-28.2 38.8c-3.9 5.3-11.4 6.5-16.8 2.6z"
-                                    fill="currentColor"
-                                    style={Object {}}
-                                  />
-                                </svg>
-                              </FontAwesomeIcon>
-                            </div>
-                          </li>
-                        </NavItem>
-                      </TimeButton>
+                                    <FontAwesomeIcon
+                                      border={false}
+                                      className="toolbarButton_1ueb7gu"
+                                      fixedWidth={false}
+                                      flip={null}
+                                      icon="tasks"
+                                      inverse={false}
+                                      key="toolbar-details"
+                                      listItem={false}
+                                      mask={null}
+                                      pull={null}
+                                      pulse={false}
+                                      rotation={null}
+                                      size={null}
+                                      spin={false}
+                                      symbol={false}
+                                      title="Choose details"
+                                      transform={null}
+                                    >
+                                      <svg
+                                        aria-labelledby="svg-inline--fa-title-28"
+                                        className="svg-inline--fa fa-tasks fa-w-16 toolbarButton_1ueb7gu"
+                                        data-icon="tasks"
+                                        data-prefix="fas"
+                                        role="img"
+                                        style={Object {}}
+                                        viewBox="0 0 512 512"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <title
+                                          id="svg-inline--fa-title-28"
+                                          style={Object {}}
+                                        >
+                                          Choose details
+                                        </title>
+                                        <path
+                                          d="M208 132h288c8.8 0 16-7.2 16-16V76c0-8.8-7.2-16-16-16H208c-8.8 0-16 7.2-16 16v40c0 8.8 7.2 16 16 16zm0 160h288c8.8 0 16-7.2 16-16v-40c0-8.8-7.2-16-16-16H208c-8.8 0-16 7.2-16 16v40c0 8.8 7.2 16 16 16zm0 160h288c8.8 0 16-7.2 16-16v-40c0-8.8-7.2-16-16-16H208c-8.8 0-16 7.2-16 16v40c0 8.8 7.2 16 16 16zM64 368c-26.5 0-48.6 21.5-48.6 48s22.1 48 48.6 48 48-21.5 48-48-21.5-48-48-48zm92.5-299l-72.2 72.2-15.6 15.6c-4.7 4.7-12.9 4.7-17.6 0L3.5 109.4c-4.7-4.7-4.7-12.3 0-17l15.7-15.7c4.7-4.7 12.3-4.7 17 0l22.7 22.1 63.7-63.3c4.7-4.7 12.3-4.7 17 0l17 16.5c4.6 4.7 4.6 12.3-.1 17zm0 159.6l-72.2 72.2-15.7 15.7c-4.7 4.7-12.9 4.7-17.6 0L3.5 269c-4.7-4.7-4.7-12.3 0-17l15.7-15.7c4.7-4.7 12.3-4.7 17 0l22.7 22.1 63.7-63.7c4.7-4.7 12.3-4.7 17 0l17 17c4.6 4.6 4.6 12.2-.1 16.9z"
+                                          fill="currentColor"
+                                          style={Object {}}
+                                        />
+                                      </svg>
+                                    </FontAwesomeIcon>
+                                  </a>
+                                </DropdownToggle>
+                              </div>
+                              <DropdownMenu
+                                className="dropdown_biw13d"
+                                flip={true}
+                                tag="div"
+                              >
+                                <div
+                                  aria-hidden={true}
+                                  className="dropdown_biw13d dropdown-menu"
+                                  role="menu"
+                                  tabIndex="-1"
+                                >
+                                  <DropdownItem
+                                    className="dropdownItem_1bl0z5g"
+                                    tag="button"
+                                    toggle={false}
+                                  >
+                                    <button
+                                      className="dropdownItem_1bl0z5g dropdown-item"
+                                      onClick={[Function]}
+                                      role="menuitem"
+                                      tabIndex="0"
+                                    >
+                                      <Label
+                                        check={true}
+                                        className="filterLabel_17zzvy"
+                                        tag="label"
+                                        widths={
+                                          Array [
+                                            "xs",
+                                            "sm",
+                                            "md",
+                                            "lg",
+                                            "xl",
+                                          ]
+                                        }
+                                      >
+                                        <label
+                                          className="filterLabel_17zzvy form-check-label"
+                                        >
+                                          <Input
+                                            name="filter"
+                                            onChange={[Function]}
+                                            type="checkbox"
+                                            value="time"
+                                          >
+                                            <input
+                                              className="form-check-input"
+                                              name="filter"
+                                              onChange={[Function]}
+                                              type="checkbox"
+                                              value="time"
+                                            />
+                                          </Input>
+                                           
+                                          Time Information
+                                        </label>
+                                      </Label>
+                                    </button>
+                                  </DropdownItem>
+                                  <DropdownItem
+                                    className="dropdownItem_1bl0z5g"
+                                    tag="button"
+                                    toggle={false}
+                                  >
+                                    <button
+                                      className="dropdownItem_1bl0z5g dropdown-item"
+                                      onClick={[Function]}
+                                      role="menuitem"
+                                      tabIndex="0"
+                                    >
+                                      <Label
+                                        check={true}
+                                        className="filterLabel_17zzvy"
+                                        tag="label"
+                                        widths={
+                                          Array [
+                                            "xs",
+                                            "sm",
+                                            "md",
+                                            "lg",
+                                            "xl",
+                                          ]
+                                        }
+                                      >
+                                        <label
+                                          className="filterLabel_17zzvy form-check-label"
+                                        >
+                                          <Input
+                                            name="filter"
+                                            onChange={[Function]}
+                                            type="checkbox"
+                                            value="path"
+                                          >
+                                            <input
+                                              className="form-check-input"
+                                              name="filter"
+                                              onChange={[Function]}
+                                              type="checkbox"
+                                              value="path"
+                                            />
+                                          </Input>
+                                           
+                                          File Path
+                                        </label>
+                                      </Label>
+                                    </button>
+                                  </DropdownItem>
+                                </div>
+                              </DropdownMenu>
+                            </li>
+                          </Manager>
+                        </Dropdown>
+                      </UncontrolledDropdown>
                       <NavItem
                         tag="li"
                       >
@@ -9519,13 +9597,13 @@ ZeroDivisionError: integer division or modulo by zero
                                 </DropdownToggle>
                               </div>
                               <DropdownMenu
-                                className="filterDropdown_biw13d"
+                                className="dropdown_biw13d"
                                 flip={true}
                                 tag="div"
                               >
                                 <div
                                   aria-hidden={true}
-                                  className="filterDropdown_biw13d dropdown-menu"
+                                  className="dropdown_biw13d dropdown-menu"
                                   role="menu"
                                   tabIndex="-1"
                                 >

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/EmptyReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/EmptyReport.test.js.snap
@@ -5,18 +5,13 @@ exports[`EmptyReport renders a custom error message 1`] = `
   className="emptyReport_3hmsj"
 >
   <Toolbar
-    extraButtons={
-      Array [
-        <TimeButton
-          updateTimeDisplayCbk={[Function]}
-        />,
-      ]
-    }
+    extraButtons={Array []}
     filterBoxWidth="22em"
     handleNavFilter={[Function]}
     updateEmptyDisplayFunc={[Function]}
     updateFilterFunc={[Function]}
     updateTagsDisplayFunc={[Function]}
+    updateTimeDisplayFunc={[Function]}
     updateTreeViewFunc={[Function]}
   />
   <Nav
@@ -39,18 +34,13 @@ exports[`EmptyReport shallow renders and matches snapshot 1`] = `
   className="emptyReport_3hmsj"
 >
   <Toolbar
-    extraButtons={
-      Array [
-        <TimeButton
-          updateTimeDisplayCbk={[Function]}
-        />,
-      ]
-    }
+    extraButtons={Array []}
     filterBoxWidth="22em"
     handleNavFilter={[Function]}
     updateEmptyDisplayFunc={[Function]}
     updateFilterFunc={[Function]}
     updateTagsDisplayFunc={[Function]}
+    updateTimeDisplayFunc={[Function]}
     updateTreeViewFunc={[Function]}
   />
   <Nav

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/InteractiveReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/InteractiveReport.test.js.snap
@@ -26,6 +26,7 @@ exports[`InteractiveReport Handles environment being started 1`] = `
     updateExpandStatusFunc={[Function]}
     updateFilterFunc={[Function]}
     updateTagsDisplayFunc={[Function]}
+    updateTimeDisplayFunc={[Function]}
     updateTreeViewFunc={[Function]}
   />
   <InteractiveNav
@@ -507,6 +508,7 @@ exports[`InteractiveReport Parially refreshes the report on update. 1`] = `
     updateExpandStatusFunc={[Function]}
     updateFilterFunc={[Function]}
     updateTagsDisplayFunc={[Function]}
+    updateTimeDisplayFunc={[Function]}
     updateTreeViewFunc={[Function]}
   />
   <InteractiveNav
@@ -824,6 +826,7 @@ exports[`InteractiveReport Updates testcase state 1`] = `
     updateExpandStatusFunc={[Function]}
     updateFilterFunc={[Function]}
     updateTagsDisplayFunc={[Function]}
+    updateTimeDisplayFunc={[Function]}
     updateTreeViewFunc={[Function]}
   />
   <InteractiveNav
@@ -1151,6 +1154,7 @@ exports[`InteractiveReport handles individual parametrizations being run 1`] = `
     updateExpandStatusFunc={[Function]}
     updateFilterFunc={[Function]}
     updateTagsDisplayFunc={[Function]}
+    updateTimeDisplayFunc={[Function]}
     updateTreeViewFunc={[Function]}
   />
   <InteractiveNav
@@ -1634,6 +1638,7 @@ exports[`InteractiveReport handles individual test suites being run 1`] = `
     updateExpandStatusFunc={[Function]}
     updateFilterFunc={[Function]}
     updateTagsDisplayFunc={[Function]}
+    updateTimeDisplayFunc={[Function]}
     updateTreeViewFunc={[Function]}
   />
   <InteractiveNav
@@ -2113,6 +2118,7 @@ exports[`InteractiveReport handles individual testcases being run 1`] = `
     updateExpandStatusFunc={[Function]}
     updateFilterFunc={[Function]}
     updateTagsDisplayFunc={[Function]}
+    updateTimeDisplayFunc={[Function]}
     updateTreeViewFunc={[Function]}
   />
   <InteractiveNav
@@ -2592,6 +2598,7 @@ exports[`InteractiveReport handles tests being run 1`] = `
     updateExpandStatusFunc={[Function]}
     updateFilterFunc={[Function]}
     updateTagsDisplayFunc={[Function]}
+    updateTimeDisplayFunc={[Function]}
     updateTreeViewFunc={[Function]}
   />
   <InteractiveNav

--- a/testplan/web_ui/testing/src/Report/reportUtils.js
+++ b/testplan/web_ui/testing/src/Report/reportUtils.js
@@ -216,6 +216,7 @@ const GetCenterPane = (
         left={state.navWidth}
         testcaseUid={selectiedEntry.uid}
         filter={state.filter}
+        displayPath={state.displayPath}
         reportUid={reportUid}
       />
     );

--- a/testplan/web_ui/testing/src/Toolbar/Toolbar.js
+++ b/testplan/web_ui/testing/src/Toolbar/Toolbar.js
@@ -32,6 +32,7 @@ import {
   faBook,
   faPrint,
   faFilter,
+  faTasks,
   faTags,
   faBars,
   faQuestionCircle,
@@ -47,6 +48,7 @@ library.add(
   faBook,
   faPrint,
   faFilter,
+  faTasks,
   faTags,
   faBars,
   faQuestionCircle,
@@ -62,7 +64,9 @@ class Toolbar extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      treeView: true,
+      treeView: false,
+      displayTime: false,
+      displayPath: false,
       filterOpen: false,
       infoModal: false,
       filter: "all",
@@ -74,6 +78,8 @@ class Toolbar extends Component {
     this.filterOnClick = this.filterOnClick.bind(this);
     this.toggleInfoOnClick = this.toggleInfoOnClick.bind(this);
     this.toggleTreeView = this.toggleTreeView.bind(this);
+    this.toggleTimeDisplay = this.toggleTimeDisplay.bind(this);
+    this.togglePathDisplay = this.togglePathDisplay.bind(this);
     this.toggleEmptyDisplay = this.toggleEmptyDisplay.bind(this);
     this.toggleTagsDisplay = this.toggleTagsDisplay.bind(this);
     this.toggleFilterOnClick = this.toggleFilterOnClick.bind(this);
@@ -85,6 +91,20 @@ class Toolbar extends Component {
     this.props.updateTreeViewFunc(!this.state.treeView);
     this.setState(prevState => ({
       treeView: !prevState.treeView
+    }));
+  }
+
+  togglePathDisplay() {
+    this.props.updatePathDisplayFunc(!this.state.displayPath);
+    this.setState((prevState) => ({
+      displayPath: !prevState.displayPath,
+    }));
+  }
+
+  toggleTimeDisplay() {
+    this.props.updateTimeDisplayFunc(!this.state.displayTime);
+    this.setState((prevState) => ({
+      displayTime: !prevState.displayTime,
     }));
   }
 
@@ -173,9 +193,6 @@ class Toolbar extends Component {
     );
   }
 
-  /**
-   * Return the tree view toggle button.
-   */
   treeViewButton() {
     return (
       <NavItem>
@@ -192,9 +209,47 @@ class Toolbar extends Component {
     );
   }
 
-  /**
-   * Return the info button which toggles the info modal.
-   */
+  detailsButton(toolbarStyle) {
+    return (
+      <UncontrolledDropdown nav inNavbar>
+        <div className={css(styles.buttonsBar)}>
+          <DropdownToggle nav className={toolbarStyle}>
+            <FontAwesomeIcon
+              key="toolbar-details"
+              icon="tasks"
+              title="Choose details"
+              className={css(styles.toolbarButton)}
+            />
+          </DropdownToggle>
+        </div>
+        <DropdownMenu className={css(styles.dropdown)}>
+          <DropdownItem toggle={false} className={css(styles.dropdownItem)}>
+            <Label check className={css(styles.filterLabel)}>
+              <Input
+                type="checkbox"
+                name="filter"
+                value="time"
+                onChange={this.toggleTimeDisplay}
+              />{" "}
+              Time Information
+            </Label>
+          </DropdownItem>
+          <DropdownItem toggle={false} className={css(styles.dropdownItem)}>
+            <Label check className={css(styles.filterLabel)}>
+              <Input
+                type="checkbox"
+                name="filter"
+                value="path"
+                onChange={this.togglePathDisplay}
+              />{" "}
+              File Path
+            </Label>
+          </DropdownItem>
+        </DropdownMenu>
+      </UncontrolledDropdown>
+    );
+  }
+
   infoButton() {
     return (
       <NavItem>
@@ -211,9 +266,6 @@ class Toolbar extends Component {
     );
   }
 
-  /**
-   * Return the filter button which opens a drop-down menu.
-   */
   filterButton(toolbarStyle) {
     return (
       <UncontrolledDropdown nav inNavbar>
@@ -227,7 +279,7 @@ class Toolbar extends Component {
             />
           </DropdownToggle>
         </div>
-        <DropdownMenu className={css(styles.filterDropdown)}>
+        <DropdownMenu className={css(styles.dropdown)}>
           <DropdownItem toggle={false} className={css(styles.dropdownItem)}>
             <Label check className={css(styles.filterLabel)}>
               <Input
@@ -281,9 +333,6 @@ class Toolbar extends Component {
     );
   }
 
-  /**
-   * Return the button which prints the current testplan.
-   */
   printButton() {
     return (
       <NavItem>
@@ -300,9 +349,6 @@ class Toolbar extends Component {
     );
   }
 
-  /**
-   * Return the button which toggles the display of tags.
-   */
   tagsButton() {
     const toolbarButtonStyle = this.state.displayTags
       ? getToggledButtonStyle(this.props.status)
@@ -324,9 +370,6 @@ class Toolbar extends Component {
     );
   }
 
-  /**
-   * Return the button which links to the documentation.
-   */
   documentationButton() {
     return (
       <NavItem>
@@ -367,9 +410,6 @@ class Toolbar extends Component {
     );
   }
 
-  /**
-   * Return the navbar including all buttons.
-   */
   navbar() {
     const toolbarStyle = getToolbarStyle(this.props.status);
 
@@ -381,6 +421,7 @@ class Toolbar extends Component {
             {this.treeViewButton()}
             {this.expandButton()}
             {this.props.extraButtons}
+            {this.detailsButton(toolbarStyle)}
             {this.infoButton()}
             {this.filterButton(toolbarStyle)}
             {this.printButton()}
@@ -392,9 +433,6 @@ class Toolbar extends Component {
     );
   }
 
-  /**
-   * Return the information modal.
-   */
   infoModal() {
     return (
       <Modal

--- a/testplan/web_ui/testing/src/Toolbar/__tests__/__snapshots__/Toolbar.test.js.snap
+++ b/testplan/web_ui/testing/src/Toolbar/__tests__/__snapshots__/Toolbar.test.js.snap
@@ -171,6 +171,105 @@ exports[`Toolbar inserts extra buttons into the toolbar 1`] = `
             />
           </div>
         </NavItem>
+        <UncontrolledDropdown
+          inNavbar={true}
+          nav={true}
+        >
+          <div
+            className="buttonsBar_6zsntc"
+          >
+            <DropdownToggle
+              aria-haspopup={true}
+              className="toolbar_l6n5rs-o_O-toolbarPassed_1bjpgj2"
+              color="secondary"
+              nav={true}
+            >
+              <FontAwesomeIcon
+                border={false}
+                className="toolbarButton_1ueb7gu"
+                fixedWidth={false}
+                flip={null}
+                icon="tasks"
+                inverse={false}
+                key="toolbar-details"
+                listItem={false}
+                mask={null}
+                pull={null}
+                pulse={false}
+                rotation={null}
+                size={null}
+                spin={false}
+                symbol={false}
+                title="Choose details"
+                transform={null}
+              />
+            </DropdownToggle>
+          </div>
+          <DropdownMenu
+            className="dropdown_biw13d"
+            flip={true}
+            tag="div"
+          >
+            <DropdownItem
+              className="dropdownItem_1bl0z5g"
+              tag="button"
+              toggle={false}
+            >
+              <Label
+                check={true}
+                className="filterLabel_17zzvy"
+                tag="label"
+                widths={
+                  Array [
+                    "xs",
+                    "sm",
+                    "md",
+                    "lg",
+                    "xl",
+                  ]
+                }
+              >
+                <Input
+                  name="filter"
+                  onChange={[Function]}
+                  type="checkbox"
+                  value="time"
+                />
+                 
+                Time Information
+              </Label>
+            </DropdownItem>
+            <DropdownItem
+              className="dropdownItem_1bl0z5g"
+              tag="button"
+              toggle={false}
+            >
+              <Label
+                check={true}
+                className="filterLabel_17zzvy"
+                tag="label"
+                widths={
+                  Array [
+                    "xs",
+                    "sm",
+                    "md",
+                    "lg",
+                    "xl",
+                  ]
+                }
+              >
+                <Input
+                  name="filter"
+                  onChange={[Function]}
+                  type="checkbox"
+                  value="path"
+                />
+                 
+                File Path
+              </Label>
+            </DropdownItem>
+          </DropdownMenu>
+        </UncontrolledDropdown>
         <NavItem
           tag="li"
         >
@@ -234,7 +333,7 @@ exports[`Toolbar inserts extra buttons into the toolbar 1`] = `
             </DropdownToggle>
           </div>
           <DropdownMenu
-            className="filterDropdown_biw13d"
+            className="dropdown_biw13d"
             flip={true}
             tag="div"
           >
@@ -642,6 +741,105 @@ exports[`Toolbar shallow renders the correct HTML structure for batch mode 1`] =
             />
           </div>
         </NavItem>
+        <UncontrolledDropdown
+          inNavbar={true}
+          nav={true}
+        >
+          <div
+            className="buttonsBar_6zsntc"
+          >
+            <DropdownToggle
+              aria-haspopup={true}
+              className="toolbar_l6n5rs-o_O-toolbarPassed_1bjpgj2"
+              color="secondary"
+              nav={true}
+            >
+              <FontAwesomeIcon
+                border={false}
+                className="toolbarButton_1ueb7gu"
+                fixedWidth={false}
+                flip={null}
+                icon="tasks"
+                inverse={false}
+                key="toolbar-details"
+                listItem={false}
+                mask={null}
+                pull={null}
+                pulse={false}
+                rotation={null}
+                size={null}
+                spin={false}
+                symbol={false}
+                title="Choose details"
+                transform={null}
+              />
+            </DropdownToggle>
+          </div>
+          <DropdownMenu
+            className="dropdown_biw13d"
+            flip={true}
+            tag="div"
+          >
+            <DropdownItem
+              className="dropdownItem_1bl0z5g"
+              tag="button"
+              toggle={false}
+            >
+              <Label
+                check={true}
+                className="filterLabel_17zzvy"
+                tag="label"
+                widths={
+                  Array [
+                    "xs",
+                    "sm",
+                    "md",
+                    "lg",
+                    "xl",
+                  ]
+                }
+              >
+                <Input
+                  name="filter"
+                  onChange={[Function]}
+                  type="checkbox"
+                  value="time"
+                />
+                 
+                Time Information
+              </Label>
+            </DropdownItem>
+            <DropdownItem
+              className="dropdownItem_1bl0z5g"
+              tag="button"
+              toggle={false}
+            >
+              <Label
+                check={true}
+                className="filterLabel_17zzvy"
+                tag="label"
+                widths={
+                  Array [
+                    "xs",
+                    "sm",
+                    "md",
+                    "lg",
+                    "xl",
+                  ]
+                }
+              >
+                <Input
+                  name="filter"
+                  onChange={[Function]}
+                  type="checkbox"
+                  value="path"
+                />
+                 
+                File Path
+              </Label>
+            </DropdownItem>
+          </DropdownMenu>
+        </UncontrolledDropdown>
         <NavItem
           tag="li"
         >
@@ -705,7 +903,7 @@ exports[`Toolbar shallow renders the correct HTML structure for batch mode 1`] =
             </DropdownToggle>
           </div>
           <DropdownMenu
-            className="filterDropdown_biw13d"
+            className="dropdown_biw13d"
             flip={true}
             tag="div"
           >
@@ -1113,6 +1311,105 @@ exports[`Toolbar shallow renders the correct HTML structure for interactive mode
             />
           </div>
         </NavItem>
+        <UncontrolledDropdown
+          inNavbar={true}
+          nav={true}
+        >
+          <div
+            className="buttonsBar_6zsntc"
+          >
+            <DropdownToggle
+              aria-haspopup={true}
+              className="toolbar_l6n5rs-o_O-toolbarPassed_1bjpgj2"
+              color="secondary"
+              nav={true}
+            >
+              <FontAwesomeIcon
+                border={false}
+                className="toolbarButton_1ueb7gu"
+                fixedWidth={false}
+                flip={null}
+                icon="tasks"
+                inverse={false}
+                key="toolbar-details"
+                listItem={false}
+                mask={null}
+                pull={null}
+                pulse={false}
+                rotation={null}
+                size={null}
+                spin={false}
+                symbol={false}
+                title="Choose details"
+                transform={null}
+              />
+            </DropdownToggle>
+          </div>
+          <DropdownMenu
+            className="dropdown_biw13d"
+            flip={true}
+            tag="div"
+          >
+            <DropdownItem
+              className="dropdownItem_1bl0z5g"
+              tag="button"
+              toggle={false}
+            >
+              <Label
+                check={true}
+                className="filterLabel_17zzvy"
+                tag="label"
+                widths={
+                  Array [
+                    "xs",
+                    "sm",
+                    "md",
+                    "lg",
+                    "xl",
+                  ]
+                }
+              >
+                <Input
+                  name="filter"
+                  onChange={[Function]}
+                  type="checkbox"
+                  value="time"
+                />
+                 
+                Time Information
+              </Label>
+            </DropdownItem>
+            <DropdownItem
+              className="dropdownItem_1bl0z5g"
+              tag="button"
+              toggle={false}
+            >
+              <Label
+                check={true}
+                className="filterLabel_17zzvy"
+                tag="label"
+                widths={
+                  Array [
+                    "xs",
+                    "sm",
+                    "md",
+                    "lg",
+                    "xl",
+                  ]
+                }
+              >
+                <Input
+                  name="filter"
+                  onChange={[Function]}
+                  type="checkbox"
+                  value="path"
+                />
+                 
+                File Path
+              </Label>
+            </DropdownItem>
+          </DropdownMenu>
+        </UncontrolledDropdown>
         <NavItem
           tag="li"
         >
@@ -1176,7 +1473,7 @@ exports[`Toolbar shallow renders the correct HTML structure for interactive mode
             </DropdownToggle>
           </div>
           <DropdownMenu
-            className="filterDropdown_biw13d"
+            className="dropdown_biw13d"
             flip={true}
             tag="div"
           >

--- a/testplan/web_ui/testing/src/Toolbar/navStyles.js
+++ b/testplan/web_ui/testing/src/Toolbar/navStyles.js
@@ -84,7 +84,7 @@ const styles = StyleSheet.create({
     backgroundColor: DARK_RED,
     color: 'white'
   },
-  filterDropdown: {
+  dropdown: {
     'margin-top': '-0.3em'
   },
   infoTable: {


### PR DESCRIPTION
## Bug / Requirement Description
Display the line number and path to the file for assertions.

## Solution description
Added file path to the examples as the line number was already present and displayed it on the ui.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
