### PR TITLE
Backend logic to include the line number and file path of a failing test case

### DIFF
--- a/examples/Assertions/Basic/test_plan_basic.py
+++ b/examples/Assertions/Basic/test_plan_basic.py
@@ -22,6 +22,18 @@ import matplotlib.pyplot as plot
 @testsuite
 class SampleSuite(object):
     @testcase
+    def test_tkerr(self, env, result):
+        result.log_html(
+            """
+<div style="font-size:80px;font-family:Arial;font-weight:bold;">
+    <i class="fa fa-check-square" style="color:green;padding-right:5px;"></i>
+    Testplan
+</div>
+        """,
+            description="HTML example",
+        )
+
+    @testcase
     def test_basic_assertions(self, env, result):
         # Basic assertions contain equality, comparison, membership checks:
         result.equal("foo", "foo")  # The most basic syntax

--- a/testplan/testing/multitest/entries/schemas/base.py
+++ b/testplan/testing/multitest/entries/schemas/base.py
@@ -32,6 +32,7 @@ class BaseSchema(Schema):
     line_no = fields.Integer()
     category = fields.String()
     flag = fields.String()
+    file_path = fields.String()
 
     def load(self, *args, **kwargs):
         raise NotImplementedError("Only serialization is supported.")

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -10,6 +10,7 @@ import inspect
 import os
 import re
 import json
+from pathlib import Path
 
 from testplan import defaults
 from testplan.defaults import STDOUT_STYLE
@@ -94,7 +95,13 @@ def _bind_entry(entry, result_obj):
     ``entries`` list.
     """
     # Second element is the caller
-    caller_frame = inspect.stack()[2]
+    frame1, frame2, caller_frame, *_ = inspect.stack()
+
+    # Test that frame1.filename and frame2.filename == result.py. Also that caller_frame.filename != result.py
+    if not(Path(frame1.filename).name == Path(__file__).name and Path(frame2.filename).name == Path(__file__).name and
+           Path(caller_frame.filename).name != Path(__file__).name):
+        raise AssertionError('Location of _bind_entry function call breaks established pattern')
+
     entry.file_path = os.path.abspath(caller_frame[1])
     entry.line_no = caller_frame[2]
 

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -94,17 +94,21 @@ assertion_state = threading.local()
 
 def assertion(func):
     def wrapper(result_obj, *args, **kwargs):
-        entry = func(result_obj, *args, **kwargs)        
+        entry = func(result_obj, *args, **kwargs)
         # Second element is the caller
-        if not hasattr(assertion_state.in_progress) or not assertion_state.in_progress:
+        if (
+            not hasattr(assertion_state.in_progress)
+            or not assertion_state.in_progress
+        ):
             assertion_state.in_progress = True
 
             caller_frame = inspect.stack()[1]
             entry.file_path = os.path.abspath(caller_frame.filename)
             entry.line_no = caller_frame.lineno
 
-            assert isinstance(result_obj, AssertionNamespace) or isinstance(result_obj, Result),\
-                "Incorrect usage of assertion decorator"
+            assert isinstance(result_obj, AssertionNamespace) or isinstance(
+                result_obj, Result
+            ), "Incorrect usage of assertion decorator"
 
             if isinstance(result_obj, AssertionNamespace):
                 result_obj = result_obj.result
@@ -112,7 +116,7 @@ def assertion(func):
             result_obj.entries.append(entry)
             stdout_registry.log_entry(
                 entry=entry, stdout_style=result_obj.stdout_style
-                )
+            )
 
             if not entry and not result_obj.continue_on_failure:
                 raise AssertionError(entry)
@@ -166,7 +170,7 @@ class RegexNamespace(AssertionNamespace):
             flags=flags,
             description=description,
             category=category,
-        )        
+        )
         return entry
 
     @assertion
@@ -205,7 +209,7 @@ class RegexNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        
+
         return entry
 
     @assertion
@@ -241,7 +245,7 @@ class RegexNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        
+
         return entry
 
     @assertion
@@ -282,7 +286,7 @@ class RegexNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        
+
         return entry
 
     @assertion
@@ -316,7 +320,7 @@ class RegexNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        
+
         return entry
 
     @assertion
@@ -352,7 +356,7 @@ class RegexNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        
+
         return entry
 
     @assertion
@@ -403,7 +407,7 @@ class RegexNamespace(AssertionNamespace):
             condition=condition,
             category=category,
         )
-        
+
         return entry
 
     @assertion
@@ -446,7 +450,7 @@ class RegexNamespace(AssertionNamespace):
             flags=flags,
             category=category,
         )
-        
+
         return entry
 
 
@@ -511,7 +515,7 @@ class TableNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        
+
         return entry
 
     @assertion
@@ -600,7 +604,7 @@ class TableNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        
+
         return entry
 
     @assertion
@@ -691,7 +695,7 @@ class TableNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        
+
         return entry
 
     def log(self, table, display_index=False, description=None):
@@ -721,7 +725,6 @@ class TableNamespace(AssertionNamespace):
         entry = base.TableLog(
             table=table, display_index=display_index, description=description
         )
-        
 
 
 class XMLNamespace(AssertionNamespace):
@@ -794,7 +797,7 @@ class XMLNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        
+
         return entry
 
 
@@ -844,7 +847,7 @@ class DictNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        
+
         return entry
 
     @assertion
@@ -939,7 +942,7 @@ class DictNamespace(AssertionNamespace):
             category=category,
             value_cmp_func=value_cmp_func,
         )
-        
+
         return entry
 
     @assertion
@@ -1003,7 +1006,7 @@ class DictNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        
+
         return entry
 
     def log(self, dictionary, description=None):
@@ -1029,7 +1032,7 @@ class DictNamespace(AssertionNamespace):
         :rtype: ``bool``
         """
         entry = base.DictLog(dictionary=dictionary, description=description)
-        
+
         return entry
 
 
@@ -1083,7 +1086,7 @@ class FixNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        
+
         return entry
 
     @assertion
@@ -1161,7 +1164,7 @@ class FixNamespace(AssertionNamespace):
             expected_description=expected_description,
             actual_description=actual_description,
         )
-        
+
         return entry
 
     @assertion
@@ -1228,7 +1231,7 @@ class FixNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        
+
         return entry
 
     def log(self, msg, description=None):
@@ -1256,7 +1259,7 @@ class FixNamespace(AssertionNamespace):
         :rtype: ``bool``
         """
         entry = base.FixLog(msg=msg, description=description)
-        
+
         return entry
 
 
@@ -1448,7 +1451,7 @@ class Result(object):
         :rtype: ``bool``
         """
         entry = base.Log(message=message, description=description, flag=flag)
-        
+
         return entry
 
     @assertion
@@ -1477,7 +1480,7 @@ class Result(object):
         entry = base.Markdown(
             message=message, description=description, escape=escape
         )
-        
+
         return entry
 
     @assertion
@@ -1513,7 +1516,7 @@ class Result(object):
         entry = base.CodeLog(
             code=code, language=language, description=description
         )
-        
+
         return
 
     @assertion
@@ -1539,7 +1542,7 @@ class Result(object):
         :rtype: ``bool``
         """
         entry = assertions.Fail(description, category=category, flag=flag)
-        
+
         return entry
 
     def conditional_log(
@@ -1617,7 +1620,7 @@ class Result(object):
         entry = assertions.IsTrue(
             value, description=description, category=category
         )
-        
+
         return entry
 
     @assertion
@@ -1641,7 +1644,7 @@ class Result(object):
         entry = assertions.IsFalse(
             value, description=description, category=category
         )
-        
+
         return entry
 
     @assertion
@@ -1668,7 +1671,7 @@ class Result(object):
         entry = assertions.Equal(
             actual, expected, description=description, category=category
         )
-        # 
+        #
         return entry
 
     @assertion
@@ -1695,7 +1698,7 @@ class Result(object):
         entry = assertions.NotEqual(
             actual, expected, description=description, category=category
         )
-        
+
         return entry
 
     @assertion
@@ -1722,7 +1725,7 @@ class Result(object):
         entry = assertions.Less(
             first, second, description=description, category=category
         )
-        
+
         return entry
 
     @assertion
@@ -1749,7 +1752,7 @@ class Result(object):
         entry = assertions.Greater(
             first, second, description=description, category=category
         )
-        
+
         return entry
 
     @assertion
@@ -1776,7 +1779,7 @@ class Result(object):
         entry = assertions.LessEqual(
             first, second, description=description, category=category
         )
-        
+
         return entry
 
     def greater_equal(self, first, second, description=None, category=None):
@@ -1802,7 +1805,7 @@ class Result(object):
         entry = assertions.GreaterEqual(
             first, second, description=description, category=category
         )
-        
+
         return entry
 
     # Shortcut aliases for basic comparators
@@ -1849,7 +1852,7 @@ class Result(object):
             description=description,
             category=category,
         )
-        
+
         return entry
 
     @assertion
@@ -1876,7 +1879,7 @@ class Result(object):
         entry = assertions.Contain(
             member, container, description=description, category=category
         )
-        
+
         return entry
 
     @assertion
@@ -1903,7 +1906,7 @@ class Result(object):
         entry = assertions.NotContain(
             member, container, description=description, category=category
         )
-        
+
         return entry
 
     @assertion
@@ -1943,7 +1946,7 @@ class Result(object):
             description=description,
             category=category,
         )
-        
+
         return entry
 
     @assertion
@@ -1984,7 +1987,7 @@ class Result(object):
             description=description,
             category=category,
         )
-        
+
         return entry
 
     def raises(
@@ -2153,7 +2156,7 @@ class Result(object):
             description=description,
             category=category,
         )
-        
+
         return entry
 
     def graph(
@@ -2207,7 +2210,7 @@ class Result(object):
             series_options=series_options,
             graph_options=graph_options,
         )
-        
+
         return entry
 
     @assertion
@@ -2256,7 +2259,7 @@ class Result(object):
             description=description,
         )
         self.attachments.append(matplot)
-        
+
         return matplot
 
     def plotly(self, fig, description=None, style=None):
@@ -2269,7 +2272,7 @@ class Result(object):
             description=description,
         )
         self.attachments.append(chart)
-        
+
         return chart
 
     @property

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -113,6 +113,7 @@ def assertion(func):
         entry.file_path = os.path.abspath(caller_frame.filename)
         entry.line_no = caller_frame.lineno
         return entry
+
     return wrapper
 
 

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -704,6 +704,7 @@ class TableNamespace(AssertionNamespace):
 
         return entry
 
+    @assertion
     def log(self, table, display_index=False, description=None):
         """
         Logs a table to the report.
@@ -731,6 +732,7 @@ class TableNamespace(AssertionNamespace):
         entry = base.TableLog(
             table=table, display_index=display_index, description=description
         )
+        return entry
 
 
 class XMLNamespace(AssertionNamespace):
@@ -1015,6 +1017,7 @@ class DictNamespace(AssertionNamespace):
 
         return entry
 
+    @assertion
     def log(self, dictionary, description=None):
         """
         Logs a dictionary to the report.
@@ -1240,6 +1243,7 @@ class FixNamespace(AssertionNamespace):
 
         return entry
 
+    @assertion
     def log(self, msg, description=None):
         """
         Logs a fix message to the report.
@@ -2165,6 +2169,7 @@ class Result(object):
 
         return entry
 
+    @assertion
     def graph(
         self,
         graph_type,
@@ -2268,6 +2273,7 @@ class Result(object):
 
         return matplot
 
+    @assertion
     def plotly(self, fig, description=None, style=None):
         filename = "{0}.json".format(strings.uuid4())
         data_file_path = os.path.join(self._scratch, filename)

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -106,12 +106,23 @@ def _bind_entry(entry, result_obj):
 
 
 def assertion(func):
-    def wrapper(*args, **kwargs):
-        entry = func(*args, **kwargs)
+    def wrapper(result_obj, *args, **kwargs):
+        entry = func(result_obj, *args, **kwargs)        
         # Second element is the caller
         caller_frame = inspect.stack()[1]
         entry.file_path = os.path.abspath(caller_frame.filename)
         entry.line_no = caller_frame.lineno
+
+        if not isinstance(result_obj, Result):
+            result_obj = result_obj.result
+
+        result_obj.entries.append(entry)
+        stdout_registry.log_entry(
+            entry=entry, stdout_style=result_obj.stdout_style
+            )
+        
+        if not entry and not result_obj.continue_on_failure:
+            raise AssertionError(entry)
         return entry
 
     return wrapper
@@ -160,8 +171,7 @@ class RegexNamespace(AssertionNamespace):
             flags=flags,
             description=description,
             category=category,
-        )
-        _bind_entry(entry, self.result)
+        )        
         return entry
 
     @assertion
@@ -200,7 +210,7 @@ class RegexNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        _bind_entry(entry, self.result)
+        
         return entry
 
     @assertion
@@ -236,7 +246,7 @@ class RegexNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        _bind_entry(entry, self.result)
+        
         return entry
 
     @assertion
@@ -277,7 +287,7 @@ class RegexNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        _bind_entry(entry, self.result)
+        
         return entry
 
     @assertion
@@ -311,7 +321,7 @@ class RegexNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        _bind_entry(entry, self.result)
+        
         return entry
 
     @assertion
@@ -347,7 +357,7 @@ class RegexNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        _bind_entry(entry, self.result)
+        
         return entry
 
     @assertion
@@ -398,7 +408,7 @@ class RegexNamespace(AssertionNamespace):
             condition=condition,
             category=category,
         )
-        _bind_entry(entry, self.result)
+        
         return entry
 
     @assertion
@@ -441,7 +451,7 @@ class RegexNamespace(AssertionNamespace):
             flags=flags,
             category=category,
         )
-        _bind_entry(entry, self.result)
+        
         return entry
 
 
@@ -506,7 +516,7 @@ class TableNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        _bind_entry(entry, self.result)
+        
         return entry
 
     @assertion
@@ -595,7 +605,7 @@ class TableNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        _bind_entry(entry, self.result)
+        
         return entry
 
     @assertion
@@ -686,7 +696,7 @@ class TableNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        _bind_entry(entry, self.result)
+        
         return entry
 
     def log(self, table, display_index=False, description=None):
@@ -716,7 +726,7 @@ class TableNamespace(AssertionNamespace):
         entry = base.TableLog(
             table=table, display_index=display_index, description=description
         )
-        _bind_entry(entry, self.result)
+        
 
 
 class XMLNamespace(AssertionNamespace):
@@ -789,7 +799,7 @@ class XMLNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        _bind_entry(entry, self.result)
+        
         return entry
 
 
@@ -839,7 +849,7 @@ class DictNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        _bind_entry(entry, self.result)
+        
         return entry
 
     @assertion
@@ -934,7 +944,7 @@ class DictNamespace(AssertionNamespace):
             category=category,
             value_cmp_func=value_cmp_func,
         )
-        _bind_entry(entry, self.result)
+        
         return entry
 
     @assertion
@@ -998,7 +1008,7 @@ class DictNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        _bind_entry(entry, self.result)
+        
         return entry
 
     def log(self, dictionary, description=None):
@@ -1024,7 +1034,7 @@ class DictNamespace(AssertionNamespace):
         :rtype: ``bool``
         """
         entry = base.DictLog(dictionary=dictionary, description=description)
-        _bind_entry(entry, self.result)
+        
         return entry
 
 
@@ -1078,7 +1088,7 @@ class FixNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        _bind_entry(entry, self.result)
+        
         return entry
 
     @assertion
@@ -1156,7 +1166,7 @@ class FixNamespace(AssertionNamespace):
             expected_description=expected_description,
             actual_description=actual_description,
         )
-        _bind_entry(entry, self.result)
+        
         return entry
 
     @assertion
@@ -1223,7 +1233,7 @@ class FixNamespace(AssertionNamespace):
             description=description,
             category=category,
         )
-        _bind_entry(entry, self.result)
+        
         return entry
 
     def log(self, msg, description=None):
@@ -1251,7 +1261,7 @@ class FixNamespace(AssertionNamespace):
         :rtype: ``bool``
         """
         entry = base.FixLog(msg=msg, description=description)
-        _bind_entry(entry, self.result)
+        
         return entry
 
 
@@ -1443,7 +1453,7 @@ class Result(object):
         :rtype: ``bool``
         """
         entry = base.Log(message=message, description=description, flag=flag)
-        _bind_entry(entry, self)
+        
         return entry
 
     @assertion
@@ -1472,7 +1482,7 @@ class Result(object):
         entry = base.Markdown(
             message=message, description=description, escape=escape
         )
-        _bind_entry(entry, self)
+        
         return entry
 
     @assertion
@@ -1508,7 +1518,7 @@ class Result(object):
         entry = base.CodeLog(
             code=code, language=language, description=description
         )
-        _bind_entry(entry, self)
+        
         return
 
     @assertion
@@ -1534,7 +1544,7 @@ class Result(object):
         :rtype: ``bool``
         """
         entry = assertions.Fail(description, category=category, flag=flag)
-        _bind_entry(entry, self)
+        
         return entry
 
     def conditional_log(
@@ -1612,7 +1622,7 @@ class Result(object):
         entry = assertions.IsTrue(
             value, description=description, category=category
         )
-        _bind_entry(entry, self)
+        
         return entry
 
     @assertion
@@ -1636,7 +1646,7 @@ class Result(object):
         entry = assertions.IsFalse(
             value, description=description, category=category
         )
-        _bind_entry(entry, self)
+        
         return entry
 
     @assertion
@@ -1663,7 +1673,7 @@ class Result(object):
         entry = assertions.Equal(
             actual, expected, description=description, category=category
         )
-        _bind_entry(entry, self)
+        # 
         return entry
 
     @assertion
@@ -1690,7 +1700,7 @@ class Result(object):
         entry = assertions.NotEqual(
             actual, expected, description=description, category=category
         )
-        _bind_entry(entry, self)
+        
         return entry
 
     @assertion
@@ -1717,7 +1727,7 @@ class Result(object):
         entry = assertions.Less(
             first, second, description=description, category=category
         )
-        _bind_entry(entry, self)
+        
         return entry
 
     @assertion
@@ -1744,7 +1754,7 @@ class Result(object):
         entry = assertions.Greater(
             first, second, description=description, category=category
         )
-        _bind_entry(entry, self)
+        
         return entry
 
     @assertion
@@ -1771,7 +1781,7 @@ class Result(object):
         entry = assertions.LessEqual(
             first, second, description=description, category=category
         )
-        _bind_entry(entry, self)
+        
         return entry
 
     def greater_equal(self, first, second, description=None, category=None):
@@ -1797,7 +1807,7 @@ class Result(object):
         entry = assertions.GreaterEqual(
             first, second, description=description, category=category
         )
-        _bind_entry(entry, self)
+        
         return entry
 
     # Shortcut aliases for basic comparators
@@ -1844,7 +1854,7 @@ class Result(object):
             description=description,
             category=category,
         )
-        _bind_entry(entry, self)
+        
         return entry
 
     @assertion
@@ -1871,7 +1881,7 @@ class Result(object):
         entry = assertions.Contain(
             member, container, description=description, category=category
         )
-        _bind_entry(entry, self)
+        
         return entry
 
     @assertion
@@ -1898,7 +1908,7 @@ class Result(object):
         entry = assertions.NotContain(
             member, container, description=description, category=category
         )
-        _bind_entry(entry, self)
+        
         return entry
 
     @assertion
@@ -1938,7 +1948,7 @@ class Result(object):
             description=description,
             category=category,
         )
-        _bind_entry(entry, self)
+        
         return entry
 
     @assertion
@@ -1979,7 +1989,7 @@ class Result(object):
             description=description,
             category=category,
         )
-        _bind_entry(entry, self)
+        
         return entry
 
     def raises(
@@ -2148,7 +2158,7 @@ class Result(object):
             description=description,
             category=category,
         )
-        _bind_entry(entry, self)
+        
         return entry
 
     def graph(
@@ -2202,7 +2212,7 @@ class Result(object):
             series_options=series_options,
             graph_options=graph_options,
         )
-        _bind_entry(entry, self)
+        
         return entry
 
     def attach(self, filepath, description=None):
@@ -2251,7 +2261,7 @@ class Result(object):
             description=description,
         )
         self.attachments.append(matplot)
-        _bind_entry(matplot, self)
+        
         return matplot
 
     def plotly(self, fig, description=None, style=None):
@@ -2264,7 +2274,7 @@ class Result(object):
             description=description,
         )
         self.attachments.append(chart)
-        _bind_entry(chart, self)
+        
         return chart
 
     @property

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -1792,6 +1792,7 @@ class Result(object):
 
         return entry
 
+    @assertion
     def greater_equal(self, first, second, description=None, category=None):
         """
         Checks if ``first >= second``.

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -94,11 +94,6 @@ def _bind_entry(entry, result_obj):
     Appends return value of a assertion / log method to the ``Result`` object's
     ``entries`` list.
     """
-    # Second element is the caller
-    frame1, frame2, caller_frame, *_ = inspect.stack()
-
-    entry.file_path = os.path.abspath(caller_frame.filename)
-    entry.line_no = caller_frame.lineno
 
     result_obj.entries.append(entry)
 
@@ -108,6 +103,17 @@ def _bind_entry(entry, result_obj):
 
     if not entry and not result_obj.continue_on_failure:
         raise AssertionError(entry)
+
+
+def assertion(func):
+    def wrapper(*args, **kwargs):
+        entry = func(*args, **kwargs)
+        # Second element is the caller
+        caller_frame = inspect.stack()[1]
+        entry.file_path = os.path.abspath(caller_frame.filename)
+        entry.line_no = caller_frame.lineno
+        return entry
+    return wrapper
 
 
 class AssertionNamespace(object):
@@ -123,6 +129,7 @@ class AssertionNamespace(object):
 class RegexNamespace(AssertionNamespace):
     """Contains logic for regular expression assertions."""
 
+    @assertion
     def match(self, regexp, value, description=None, category=None, flags=0):
         """
         Checks if the given ``regexp`` matches the ``value``
@@ -156,6 +163,7 @@ class RegexNamespace(AssertionNamespace):
         _bind_entry(entry, self.result)
         return entry
 
+    @assertion
     def multiline_match(self, regexp, value, description=None, category=None):
         """
         Checks if the given ``regexp`` matches the ``value``
@@ -194,6 +202,7 @@ class RegexNamespace(AssertionNamespace):
         _bind_entry(entry, self.result)
         return entry
 
+    @assertion
     def not_match(
         self, regexp, value, description=None, category=None, flags=0
     ):
@@ -229,6 +238,7 @@ class RegexNamespace(AssertionNamespace):
         _bind_entry(entry, self.result)
         return entry
 
+    @assertion
     def multiline_not_match(
         self, regexp, value, description=None, category=None
     ):
@@ -269,6 +279,7 @@ class RegexNamespace(AssertionNamespace):
         _bind_entry(entry, self.result)
         return entry
 
+    @assertion
     def search(self, regexp, value, description=None, category=None, flags=0):
         """
         Checks if the given ``regexp`` exists in the ``value``
@@ -302,6 +313,7 @@ class RegexNamespace(AssertionNamespace):
         _bind_entry(entry, self.result)
         return entry
 
+    @assertion
     def search_empty(
         self, regexp, value, description=None, category=None, flags=0
     ):
@@ -337,6 +349,7 @@ class RegexNamespace(AssertionNamespace):
         _bind_entry(entry, self.result)
         return entry
 
+    @assertion
     def findall(
         self,
         regexp,
@@ -387,6 +400,7 @@ class RegexNamespace(AssertionNamespace):
         _bind_entry(entry, self.result)
         return entry
 
+    @assertion
     def matchline(
         self, regexp, value, description=None, category=None, flags=0
     ):
@@ -433,6 +447,7 @@ class RegexNamespace(AssertionNamespace):
 class TableNamespace(AssertionNamespace):
     """Contains logic for regular expression assertions."""
 
+    @assertion
     def column_contain(
         self,
         table,
@@ -493,6 +508,7 @@ class TableNamespace(AssertionNamespace):
         _bind_entry(entry, self.result)
         return entry
 
+    @assertion
     def match(
         self,
         actual,
@@ -581,6 +597,7 @@ class TableNamespace(AssertionNamespace):
         _bind_entry(entry, self.result)
         return entry
 
+    @assertion
     def diff(
         self,
         actual,
@@ -704,6 +721,7 @@ class TableNamespace(AssertionNamespace):
 class XMLNamespace(AssertionNamespace):
     """Contains logic for XML related assertions."""
 
+    @assertion
     def check(
         self,
         element,
@@ -777,6 +795,7 @@ class XMLNamespace(AssertionNamespace):
 class DictNamespace(AssertionNamespace):
     """Contains logic for Dictionary related assertions."""
 
+    @assertion
     def check(
         self,
         dictionary,
@@ -822,6 +841,7 @@ class DictNamespace(AssertionNamespace):
         _bind_entry(entry, self.result)
         return entry
 
+    @assertion
     def match(
         self,
         actual,
@@ -916,6 +936,7 @@ class DictNamespace(AssertionNamespace):
         _bind_entry(entry, self.result)
         return entry
 
+    @assertion
     def match_all(
         self,
         values,
@@ -1009,6 +1030,7 @@ class DictNamespace(AssertionNamespace):
 class FixNamespace(AssertionNamespace):
     """Contains assertion logic that operates on fix messages."""
 
+    @assertion
     def check(
         self,
         msg,
@@ -1058,6 +1080,7 @@ class FixNamespace(AssertionNamespace):
         _bind_entry(entry, self.result)
         return entry
 
+    @assertion
     def match(
         self,
         actual,
@@ -1135,6 +1158,7 @@ class FixNamespace(AssertionNamespace):
         _bind_entry(entry, self.result)
         return entry
 
+    @assertion
     def match_all(
         self,
         values,
@@ -1396,6 +1420,7 @@ class Result(object):
         """Entries stored passed status."""
         return all(getattr(entry, "passed", True) for entry in self.entries)
 
+    @assertion
     def log(self, message, description=None, flag=None):
         """
         Create a string message entry, can be used for providing additional
@@ -1420,6 +1445,7 @@ class Result(object):
         _bind_entry(entry, self)
         return entry
 
+    @assertion
     def markdown(self, message, description=None, escape=True):
         """
         Create a markdown message entry, can be used for providing additional
@@ -1448,6 +1474,7 @@ class Result(object):
         _bind_entry(entry, self)
         return entry
 
+    @assertion
     def log_html(self, code, description="Embedded HTML"):
         """
         Create a markdown message entry without escape, can be used for
@@ -1483,6 +1510,7 @@ class Result(object):
         _bind_entry(entry, self)
         return
 
+    @assertion
     def fail(self, description, category=None, flag=None):
         """
         Failure assertion, can be used for explicitly failing a testcase.
@@ -1562,6 +1590,7 @@ class Result(object):
         else:
             return self.fail(fail_description, flag=flag)
 
+    @assertion
     def true(self, value, description=None, category=None):
         """
         Boolean assertion, checks if ``value`` is truthy.
@@ -1585,6 +1614,7 @@ class Result(object):
         _bind_entry(entry, self)
         return entry
 
+    @assertion
     def false(self, value, description=None, category=None):
         """
         Boolean assertion, checks if ``value`` is falsy.
@@ -1608,6 +1638,7 @@ class Result(object):
         _bind_entry(entry, self)
         return entry
 
+    @assertion
     def equal(self, actual, expected, description=None, category=None):
         """
         Equality assertion, checks if ``actual == expected``.
@@ -1634,6 +1665,7 @@ class Result(object):
         _bind_entry(entry, self)
         return entry
 
+    @assertion
     def not_equal(self, actual, expected, description=None, category=None):
         """
         Inequality assertion, checks if ``actual != expected``.
@@ -1660,6 +1692,7 @@ class Result(object):
         _bind_entry(entry, self)
         return entry
 
+    @assertion
     def less(self, first, second, description=None, category=None):
         """
         Checks if ``first < second``.
@@ -1686,6 +1719,7 @@ class Result(object):
         _bind_entry(entry, self)
         return entry
 
+    @assertion
     def greater(self, first, second, description=None, category=None):
         """
         Checks if ``first > second``.
@@ -1712,6 +1746,7 @@ class Result(object):
         _bind_entry(entry, self)
         return entry
 
+    @assertion
     def less_equal(self, first, second, description=None, category=None):
         """
         Checks if ``first <= second``.
@@ -1772,6 +1807,7 @@ class Result(object):
     le = less_equal
     ge = greater_equal
 
+    @assertion
     def isclose(
         self,
         first,
@@ -1810,6 +1846,7 @@ class Result(object):
         _bind_entry(entry, self)
         return entry
 
+    @assertion
     def contain(self, member, container, description=None, category=None):
         """
         Checks if ``member in container``.
@@ -1836,6 +1873,7 @@ class Result(object):
         _bind_entry(entry, self)
         return entry
 
+    @assertion
     def not_contain(self, member, container, description=None, category=None):
         """
         Checks if ``member not in container``.
@@ -1862,6 +1900,7 @@ class Result(object):
         _bind_entry(entry, self)
         return entry
 
+    @assertion
     def equal_slices(
         self, actual, expected, slices, description=None, category=None
     ):
@@ -1901,6 +1940,7 @@ class Result(object):
         _bind_entry(entry, self)
         return entry
 
+    @assertion
     def equal_exclude_slices(
         self, actual, expected, slices, description=None, category=None
     ):
@@ -2051,6 +2091,7 @@ class Result(object):
             pattern=pattern,
         )
 
+    @assertion
     def diff(
         self,
         first,
@@ -2182,6 +2223,7 @@ class Result(object):
         _bind_entry(attachment, self)
         return attachment
 
+    @assertion
     def matplot(self, pyplot, width=None, height=None, description=None):
         """
         Displays a Matplotlib plot in the report.

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -97,13 +97,8 @@ def _bind_entry(entry, result_obj):
     # Second element is the caller
     frame1, frame2, caller_frame, *_ = inspect.stack()
 
-    # Test that frame1.filename and frame2.filename == result.py. Also that caller_frame.filename != result.py
-    if not(Path(frame1.filename).name == Path(__file__).name and Path(frame2.filename).name == Path(__file__).name and
-           Path(caller_frame.filename).name != Path(__file__).name):
-        raise AssertionError('Location of _bind_entry function call breaks established pattern')
-
-    entry.file_path = os.path.abspath(caller_frame[1])
-    entry.line_no = caller_frame[2]
+    entry.file_path = os.path.abspath(caller_frame.filename)
+    entry.line_no = caller_frame.lineno
 
     result_obj.entries.append(entry)
 

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -95,7 +95,10 @@ assertion_state = threading.local()
 def assertion(func):
     def wrapper(result, *args, **kwargs):
         top_assertion = False
-        if not hasattr(assertion_state, 'in_progress') or not assertion_state.in_progress:
+        if (
+            not hasattr(assertion_state, "in_progress")
+            or not assertion_state.in_progress
+        ):
             assertion_state.in_progress = True
             top_assertion = True
 
@@ -126,6 +129,7 @@ def assertion(func):
         finally:
             if top_assertion:
                 assertion_state.in_progress = False
+
     return wrapper
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,35 +98,3 @@ def root_directory(pytestconfig):
     Return the root directory of pyTest config as a string.
     """
     return str(pytestconfig.rootdir)
-
-
-def get_hook():
-    reference = result_py._bind_entry
-
-    def validation_wrapper(entry, result_obj):
-        frame1, frame2, caller_frame, *_ = inspect.stack()
-        """
-            Usage of _bind_entry function should follow an established pattern where the first 3 entries in the
-            stack trace are result.py, result.py and some_calling_test_file.py( generic test file name). 
-            The code below aims to validate this established pattern. Here The first 3 entries in the stack trace will
-            be a little different though. Expected entries are conftest.py, result.py and some_calling_test_file.py
-        """
-        if not (
-            Path(frame1.filename).name == Path(__file__).name
-            and Path(frame2.filename).name == Path(result_py.__file__).name
-            and Path(caller_frame.filename).name[:5] == "test_"
-        ):
-            raise AssertionError(
-                "Location of _bind_entry function call breaks established pattern"
-            )
-        return reference(entry, result_obj)
-
-    return validation_wrapper
-
-
-def patch_bind_entry():
-    patcher = patch.object(result_py, "_bind_entry", get_hook())
-    patcher.start()
-
-
-patch_bind_entry()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,6 @@
 import os
 import sys
 import tempfile
-from pathlib import Path
-import inspect
-from unittest.mock import patch
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
 
@@ -13,8 +10,6 @@ import pytest
 
 from testplan import TestplanMock
 from testplan.common.utils.path import VAR_TMP
-
-import testplan.testing.multitest.result as result_py
 
 
 # Testplan and various drivers have a `runpath` attribute in their config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,7 @@ def repo_root_path():
     for building paths to specific files/directories in the repo without
     relying on the current working directory or building a relative path from
     a different known filepath.
-    """   
+    """
     # This file is at tests/conftest.py. It should not be moved, since it
     # defines global pytest fixtures for all tests.
     return os.path.join(os.path.dirname(__file__), os.pardir)
@@ -105,22 +105,27 @@ def get_hook():
 
     def validation_wrapper(entry, result_obj):
         frame1, frame2, caller_frame, *_ = inspect.stack()
-        '''
+        """
             Usage of _bind_entry function should follow an established pattern where the first 3 entries in the
             stack trace are result.py, result.py and some_calling_test_file.py( generic test file name). 
             The code below aims to validate this established pattern. Here The first 3 entries in the stack trace will
             be a little different though. Expected entries are conftest.py, result.py and some_calling_test_file.py
-        '''
-        if not (Path(frame1.filename).name == Path(__file__).name and
-                Path(frame2.filename).name == Path(result_py.__file__).name and
-                Path(caller_frame.filename).name[:5] == 'test_'):
-            raise AssertionError('Location of _bind_entry function call breaks established pattern')
+        """
+        if not (
+            Path(frame1.filename).name == Path(__file__).name
+            and Path(frame2.filename).name == Path(result_py.__file__).name
+            and Path(caller_frame.filename).name[:5] == "test_"
+        ):
+            raise AssertionError(
+                "Location of _bind_entry function call breaks established pattern"
+            )
         return reference(entry, result_obj)
+
     return validation_wrapper
 
 
 def patch_bind_entry():
-    patcher = patch.object(result_py, '_bind_entry', get_hook())
+    patcher = patch.object(result_py, "_bind_entry", get_hook())
     patcher.start()
 
 


### PR DESCRIPTION
## Bug / Requirement Description
For a failing test case, it was not explicitly stated which file contained the failing test case or its corresponding line number

## Solution description
Replace bind_entry function with a decorator called assertion. Then decorate any function that is meant to be an assertion

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
