### PR TITLE
fix sphinx version <2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 
 REQUIRED = [
-    "sphinx",
+    "sphinx<2",
     "sphinx_rtd_theme",
     "setuptools",
     "pytest",


### PR DESCRIPTION
readthedocs using that with the old config

## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
