### PR TITLE
Hot fix 2 bugs: rsync missing '-l', and dup opt.

### DIFF
--- a/testplan/common/utils/remote.py
+++ b/testplan/common/utils/remote.py
@@ -82,7 +82,8 @@ def copy_cmd(source, target, exclude=None, port=None, deref_links=False):
             )
 
     if binary:
-        full_cmd = [binary, "-r"]
+        full_cmd = [binary, "-r", "-L" if deref_links else "-l"]
+
         if exclude is not None:
             for item in exclude:
                 full_cmd.extend(["--exclude", item])

--- a/testplan/runners/pools/remote.py
+++ b/testplan/runners/pools/remote.py
@@ -323,7 +323,6 @@ class RemotePool(Pool):
             worker = self.cfg.worker_type(
                 index=instance["host"],
                 remote_host=instance["host"],
-                restart_count=self.cfg.restart_count,
                 workers=instance["number_of_workers"],
                 **self._options,
             )

--- a/tests/functional/testplan/runners/pools/test_pool_remote.py
+++ b/tests/functional/testplan/runners/pools/test_pool_remote.py
@@ -69,6 +69,7 @@ def test_pool_basic(mockplan, remote_pool_type):
             workspace=workspace,
             pool_type=remote_pool_type,
             schedule_path=schedule_path,
+            restart_count=0,
         )
     finally:
         os.chdir(orig_dir)

--- a/tests/unit/testplan/common/remote/test_remote_resource.py
+++ b/tests/unit/testplan/common/remote/test_remote_resource.py
@@ -7,7 +7,8 @@ import pytest
 
 from testplan import TestplanMock
 from testplan.common.utils.path import rebase_path
-from testplan.common.utils.remote import filepath_exist_cmd
+from testplan.common.utils.process import execute_cmd
+from testplan.common.utils.remote import filepath_exist_cmd, link_cmd
 
 REMOTE_HOST = os.environ.get("TESTPLAN_REMOTE_HOST")
 pytestmark = pytest.mark.skipif(
@@ -63,6 +64,10 @@ def push_dir():
         path = os.path.join(push_dir, filename)
         with open(path, "w") as fobj:
             fobj.write(path)
+
+    import subprocess
+
+    subprocess.check_output(["ln", "-sfn", "file1", "file1_ln"], cwd=push_dir)
 
     yield push_dir
 
@@ -136,6 +141,7 @@ def test_prepare_remote(remote_resource, workspace, push_dir):
         remote_resource._remote_runid_file,
         "/".join([remote_resource._workspace_paths.remote, "tests", "unit"]),
         "/".join([push_dir, "file1"]),
+        "/".join([push_dir, "file1_ln"]),
         "/".join([remote_resource._working_dirs.remote, "file1"]),
         "/".join([workspace, "file2"]),
     ]:


### PR DESCRIPTION
## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
