### PR TITLE
Fix an issue that FixMatch assertion may break web UI

### DIFF
--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/FixCellRenderer.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/FixCellRenderer.js
@@ -43,14 +43,14 @@ export default function FixCellRenderer(props) {
         <FixTagTooltip names={tagInfo.names} descr={tagInfo.descr} />
       );
     } else if (tagInfo.enum_type) {
-      if (colField === "value") {
+      if (colField === "value" && props.data.value) {
         toolTipComp = (
           <FixTagValueTooltip
             num={tagInfo.num}
             value={props.data.value.value}
           />
         );
-      } else if (colField === "expected") {
+      } else if (colField === "expected" && props.data.expected) {
         toolTipComp = (
           <FixTagValueTooltip
             num={tagInfo.num}


### PR DESCRIPTION
* The expected value for comparing can be `None` in test report, while
  in JS this field is undefined, should add a check and will not make
  a tooltip component for agGrid.