### PR TITLE
Fix an issue that DictMatch items cannot be filtered on WebUI

### DIFF
--- a/testplan/common/utils/reporting.py
+++ b/testplan/common/utils/reporting.py
@@ -3,6 +3,7 @@ This module contains utilities that are mostly used
 to make assertion comparison data report friendly.
 """
 
+import re
 from collections.abc import Mapping, Iterable
 
 NATIVE_TYPES = (str, int, float, bool, memoryview, bytes, bytearray)
@@ -82,6 +83,8 @@ def fmt(obj):
             )
         elif issubclass(obj_t, Iterable):
             ret = (1, [render(value) for value in obj])
+        elif issubclass(obj_t, re.Pattern):
+            ret = (0, "REGEX", obj.pattern)
         else:
             ret = (0, obj_t.__name__, str(obj))
         if key:


### PR DESCRIPTION
* Filter options 'Failures only' and 'Hide ignored items' does not
  work for nested items, because only the top-level item has the
  result marked as "failed" or "ignored", should apply this flag
  to descendants. `FixMatch` also has this issue like `DictMatch`.
* `re.Pattern` instance is marked as type "REGEX" after formatted.
* Add testcases.