### PR TITLE
Tree view navigation refinements

### DIFF
--- a/testplan/web_ui/testing/src/Common/defaults.js
+++ b/testplan/web_ui/testing/src/Common/defaults.js
@@ -11,6 +11,7 @@ const LIGHT_GREY = "#F3F3F3";
 const MEDIUM_GREY = "#D0D0D0";
 const DARK_GREY = "#ADADAD";
 const BLACK = "#404040";
+const NAV_DEFAULT_COLOR = "#6a95c3";
 
 export const BOTTOMMOST_ENTRY_CATEGORY = "testcase";
 const COLUMN_WIDTH = 22; // unit: em
@@ -241,6 +242,7 @@ export {
   MEDIUM_GREY,
   DARK_GREY,
   BLACK,
+  NAV_DEFAULT_COLOR,
   COLUMN_WIDTH,
   MIN_COLUMN_WIDTH,
   INTERACTIVE_COL_WIDTH,

--- a/testplan/web_ui/testing/src/Nav/InteractiveNavEntry.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNavEntry.js
@@ -59,10 +59,7 @@ const InteractiveNavEntry = (props) => {
       className='d-flex justify-content-between align-items-center'
       style={{
         height: "1.5em",
-        webkitUserSelect: "text",
-        MozUserSelect: "text",
-        MsUserSelect: "text",
-        UserSelect: "text",
+        userSelect: "text"
       }}
     >
       <Badge

--- a/testplan/web_ui/testing/src/Nav/InteractiveNavEntry.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNavEntry.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Badge} from 'reactstrap';
-import {StyleSheet, css} from "aphrodite";
-import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import { Badge } from 'reactstrap';
+import { StyleSheet, css } from "aphrodite";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faPlay,
   faRedo,
@@ -57,7 +57,13 @@ const InteractiveNavEntry = (props) => {
   return (
     <div
       className='d-flex justify-content-between align-items-center'
-      style={{height: "1.5em"}}
+      style={{
+        height: "1.5em",
+        webkitUserSelect: "text",
+        MozUserSelect: "text",
+        MsUserSelect: "text",
+        UserSelect: "text",
+      }}
     >
       <Badge
         className={css(styles.entryIcon, styles[badgeStyle])}
@@ -209,64 +215,64 @@ const getStatusIcon = (
  */
 const getEnvStatusIcon = (entryStatus, envStatus, envCtrlCallback) => {
   switch (envStatus) {
-      case 'STOPPED':
-        return (
-          <FontAwesomeIcon
-            className={
-              testInProgress(entryStatus)
-                ? css(styles.inactiveEntryButton)
-                : css(styles.entryButton)
-            }
-            icon={faToggleOff}
-            title='Start environment'
-            onClick={
-              testInProgress(entryStatus)
-                ? ignoreClickEvent
-                : (e) => envCtrlCallback(e, "start")
-            }
-          />
-        );
+    case 'STOPPED':
+      return (
+        <FontAwesomeIcon
+          className={
+            testInProgress(entryStatus)
+              ? css(styles.inactiveEntryButton)
+              : css(styles.entryButton)
+          }
+          icon={faToggleOff}
+          title='Start environment'
+          onClick={
+            testInProgress(entryStatus)
+              ? ignoreClickEvent
+              : (e) => envCtrlCallback(e, "start")
+          }
+        />
+      );
 
-      case 'STOPPING':
-        return (
-          <FontAwesomeIcon
-            className={css(styles.inactiveEntryButton)}
-            icon={faToggleOn}
-            title='Environment stopping...'
-            onClick={ignoreClickEvent}
-          />
-        );
+    case 'STOPPING':
+      return (
+        <FontAwesomeIcon
+          className={css(styles.inactiveEntryButton)}
+          icon={faToggleOn}
+          title='Environment stopping...'
+          onClick={ignoreClickEvent}
+        />
+      );
 
-      case 'STARTED':
-        return (
-          <FontAwesomeIcon
-            className={
-              testInProgress(entryStatus)
-                ? css(styles.inactiveEntryButton)
-                : css(styles.entryButton)
-            }
-            icon={faToggleOn}
-            title='Stop environment'
-            onClick={
-              testInProgress(entryStatus)
-                ? ignoreClickEvent
-                : (e) => envCtrlCallback(e, "stop")
-            }
-          />
-        );
+    case 'STARTED':
+      return (
+        <FontAwesomeIcon
+          className={
+            testInProgress(entryStatus)
+              ? css(styles.inactiveEntryButton)
+              : css(styles.entryButton)
+          }
+          icon={faToggleOn}
+          title='Stop environment'
+          onClick={
+            testInProgress(entryStatus)
+              ? ignoreClickEvent
+              : (e) => envCtrlCallback(e, "stop")
+          }
+        />
+      );
 
-      case 'STARTING':
-        return (
-          <FontAwesomeIcon
-            className={css(styles.inactiveEntryButton)}
-            icon={faToggleOff}
-            title='Environment starting...'
-            onClick={ignoreClickEvent}
-          />
-        );
+    case 'STARTING':
+      return (
+        <FontAwesomeIcon
+          className={css(styles.inactiveEntryButton)}
+          icon={faToggleOff}
+          title='Environment starting...'
+          onClick={ignoreClickEvent}
+        />
+      );
 
-      default:
-          return null;
+    default:
+      return null;
   }
 };
 
@@ -275,8 +281,7 @@ const getEnvStatusIcon = (entryStatus, envStatus, envCtrlCallback) => {
  * instance. Returns null for suite entries and case entries.
  */
 const getResetReportIcon = (
-  entryStatus, envStatus, handleResetClick, entryType) =>
-{
+  entryStatus, envStatus, handleResetClick, entryType) => {
   if (
     entryType === 'multitest' || entryType === "unittest" ||
     entryType === "gtest" || entryType === "cppunit" ||
@@ -379,7 +384,7 @@ const styles = StyleSheet.create({
     padding: '0.7em 0em 0.7em 0em',
     transition: 'all 0.3s ease-out 0s',
     ':hover': {
-        color: LIGHT_GREY
+      color: LIGHT_GREY
     }
   },
   inactiveEntryButton: {

--- a/testplan/web_ui/testing/src/Nav/NavBreadcrumbs.js
+++ b/testplan/web_ui/testing/src/Nav/NavBreadcrumbs.js
@@ -55,6 +55,8 @@ const useStyles = makeStyles({
     height: "32px",
     fontSize: "small",
     paddingLeft: "30px",
+    paddingTop: "5px",
+    paddingBottom: "5px",
     textDecoration: "none",
     textTransform: "none",
     borderRadius: 0,

--- a/testplan/web_ui/testing/src/Nav/NavEntry.js
+++ b/testplan/web_ui/testing/src/Nav/NavEntry.js
@@ -39,10 +39,7 @@ const NavEntry = (props) => {
       className='d-flex justify-content-between align-items-center'
       style={{
         height: "1.5em",
-        webkitUserSelect: "text",
-        MozUserSelect: "text",
-        MsUserSelect: "text",
-        UserSelect: "text",
+        userSelect: "text"
       }}
     >
       <Badge

--- a/testplan/web_ui/testing/src/Nav/NavEntry.js
+++ b/testplan/web_ui/testing/src/Nav/NavEntry.js
@@ -37,7 +37,13 @@ const NavEntry = (props) => {
   return (
     <div
       className='d-flex justify-content-between align-items-center'
-      style={{ height: "1.5em" }}
+      style={{
+        height: "1.5em",
+        webkitUserSelect: "text",
+        MozUserSelect: "text",
+        MsUserSelect: "text",
+        UserSelect: "text",
+      }}
     >
       <Badge
         className={css(styles.entryIcon, styles[badgeStyle], styles.badge)}

--- a/testplan/web_ui/testing/src/Nav/TagList.js
+++ b/testplan/web_ui/testing/src/Nav/TagList.js
@@ -1,7 +1,8 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {Badge} from 'reactstrap';
-import {StyleSheet, css} from 'aphrodite';
+import { Badge } from 'reactstrap';
+import { StyleSheet, css } from 'aphrodite';
+import { NAV_DEFAULT_COLOR } from '../Common/defaults';
 
 
 class TagList extends Component {
@@ -14,7 +15,7 @@ class TagList extends Component {
       for (let tag of tags.simple) {
         labels.push(
           <Badge
-            key={this.props.entryName+tag}
+            key={this.props.entryName + tag}
             className={css(styles.tags)}
             color='primary'>
             {tag}
@@ -28,7 +29,7 @@ class TagList extends Component {
       for (let tagValue of tags[tagKey]) {
         labels.push(
           <Badge
-            key={this.props.entryName+tagKey+tagValue}
+            key={this.props.entryName + tagKey + tagValue}
             className={css(styles.tags)}
             color='primary'>
             {tagKey}={tagValue}
@@ -53,7 +54,7 @@ TagList.propTypes = {
 const styles = StyleSheet.create({
   tags: {
     'margin-right': '.4em',
-    'background-color': '#6a95c3'
+    'background-color': NAV_DEFAULT_COLOR
   },
 });
 

--- a/testplan/web_ui/testing/src/Nav/TagList.js
+++ b/testplan/web_ui/testing/src/Nav/TagList.js
@@ -53,6 +53,7 @@ TagList.propTypes = {
 const styles = StyleSheet.create({
   tags: {
     'margin-right': '.4em',
+    'background-color': '#6a95c3'
   },
 });
 

--- a/testplan/web_ui/testing/src/Nav/TreeView.js
+++ b/testplan/web_ui/testing/src/Nav/TreeView.js
@@ -27,7 +27,14 @@ const TreeViewNav = (props) => {
           disableSelection={true}
           defaultCollapseIcon={<ExpandMoreIcon />}
           defaultExpandIcon={<ChevronRightIcon />}>
-          {createTree(props)}
+          {<Tree
+            entries={props.entries}
+            displayEmpty={props.displayEmpty}
+            filter={props.filter}
+            url={props.url}
+            displayTags={props.displayTags}
+            displayTime={props.displayTime}
+          />}
         </TreeView>
       </Column >
     </>
@@ -67,22 +74,26 @@ TreeViewNav.propTypes = {
 
 export default TreeViewNav;
 
-const createTree = (props) => {
+const Tree = (props) => {
   let entries = applyAllFilters(props, props.entries);
   return Array.isArray(entries) ?
-    entries.map((entry) => createNode(props, entry)) : null;
+    entries.map((entry) =>
+      <CreateNode
+        props={props}
+        entry={entry}
+      />) : null;
 };
 
-const createNode = (props, entry) => {
-  let [reportuid, ...selectionuids] = entry.uids;
+const CreateNode = (props) => {
+  let [reportuid, ...selectionuids] = props.entry.uids;
   const linkTo = generatePath(props.url,
     {
       uid: reportuid,
       selection: selectionuids
     });
   const tags = (
-    (props.displayTags && entry.tags)
-      ? <TagList entryName={entry.name} tags={entry.tags} />
+    (props.displayTags && props.entry.tags)
+      ? <TagList entryName={props.entry.name} tags={props.entry.tags} />
       : null
   );
   const treeViewClasses = createTreeViewStyles();
@@ -96,29 +107,33 @@ const createNode = (props, entry) => {
         iconContainer: treeViewClasses.iconContainer,
         label: treeViewClasses.label
       }}
-      nodeId={entry.uid || entry.hash}
-      key={entry.uid || entry.hash}
+      nodeId={props.entry.uid || props.entry.hash}
+      key={props.entry.uid || props.entry.hash}
       onLabelClick={event => {
         event.preventDefault();
       }}
       label={
         <NavLink
           className={css(styles.leafNode)}
-          key={entry.hash || entry.uid}
+          key={props.entry.hash || props.entry.uid}
           to={linkTo}>
           {tags}
-          {createNavEntry(props, entry)}
+          {createNavEntry(props, props.entry)}
         </NavLink>
       }>
-      {entry.category === CATEGORIES['testcase'] ?
-        null : continueTreeBranch(props, entry)}
+      {props.entry.category === CATEGORIES['testcase'] ?
+        null : continueTreeBranch(props, props.entry)}
     </TreeItem>
   );
 };
 
 const continueTreeBranch = (props, entry) => {
   return Array.isArray(entry.entries) ?
-    entry.entries.map((entry) => createNode(props, entry)) : null;
+    entry.entries.map((entry) =>
+      <CreateNode
+        props={props}
+        entry={entry}
+      />) : null;
 };
 
 const createNavEntry = (props, entry) => {

--- a/testplan/web_ui/testing/src/Nav/TreeView.js
+++ b/testplan/web_ui/testing/src/Nav/TreeView.js
@@ -15,24 +15,6 @@ import { NavLink } from 'react-router-dom';
 import TagList from './TagList';
 import { makeStyles } from '@material-ui/core/styles';
 
-const createTreeViewStyles = makeStyles({
-  treeItemLabel: {
-    padding: '5px 0px',
-    overflow: 'hidden',
-    '&:hover': {
-      backgroundColor: MEDIUM_GREY
-    },
-  },
-
-  parentTreeItem: {
-    cursor: 'default'
-  },
-
-  iconContainer: {
-    cursor: 'pointer'
-  }
-});
-
 /**
  * Render a vertical list of all the currently selected entries children.
  */
@@ -87,19 +69,13 @@ TreeViewNav.propTypes = {
 
 export default TreeViewNav;
 
-
 const createTree = (props) => {
   let entries = applyAllFilters(props, props.entries);
   return Array.isArray(entries) ?
-    entries.map((entry) => createTreeHelper(props, entry)) : null;
+    entries.map((entry) => createNode(props, entry)) : null;
 };
 
-const createTreeHelper = (props, entry) => {
-  return entry.category === CATEGORIES['testcase'] ?
-    createLeafNode(props, entry) : createNode(props, entry);
-};
-
-const createLeafNode = (props, entry) => {
+const createNode = (props, entry) => {
   let [reportuid, ...selectionuids] = entry.uids;
   const linkTo = generatePath(props.url,
     {
@@ -116,9 +92,13 @@ const createLeafNode = (props, entry) => {
     <TreeItem
       classes={{
         label: treeViewClasses.treeItemLabel,
+        iconContainer: treeViewClasses.iconContainer
       }}
       nodeId={entry.uid || entry.hash}
       key={entry.uid || entry.hash}
+      onLabelClick={event => {
+        event.preventDefault();
+      }}
       label={
         <NavLink
           className={css(styles.leafNode)}
@@ -127,30 +107,17 @@ const createLeafNode = (props, entry) => {
           {tags}
           {createNavEntry(props, entry)}
         </NavLink>
-      }></TreeItem>
-  );
-};
-
-const createNode = (props, entry) => {
-  const treeViewClasses = createTreeViewStyles();
-  return (
-    <TreeItem
-      classes={{
-        label: treeViewClasses.treeItemLabel,
-        content: treeViewClasses.parentTreeItem,
-        iconContainer: treeViewClasses.iconContainer
-      }}
-      nodeId={entry.uid || entry.hash}
-      key={entry.uid || entry.hash}
-      onLabelClick={event => {
-        event.preventDefault();
-      }}
-      label={createNavEntry(props, entry)}>
-      {Array.isArray(entry.entries) ?
-        entry.entries.map((entry) => createTreeHelper(props, entry)) : null}
+      }>
+      {entry.category === CATEGORIES['testcase'] ?
+        null : continueTreeBranch(props, entry)}
     </TreeItem>
   );
 };
+
+const continueTreeBranch = (props, entry) => {
+  return Array.isArray(entry.entries) ?
+    entry.entries.map((entry) => createNode(props, entry)) : null
+}
 
 const createNavEntry = (props, entry) => {
   return (
@@ -167,6 +134,20 @@ const createNavEntry = (props, entry) => {
       displayTime={props.displayTime} />
   );
 };
+
+const createTreeViewStyles = makeStyles({
+  treeItemLabel: {
+    padding: '5px 0px',
+    overflow: 'hidden',
+    '&:hover': {
+      backgroundColor: MEDIUM_GREY
+    },
+  },
+
+  iconContainer: {
+    cursor: 'pointer'
+  }
+});
 
 const styles = StyleSheet.create({
   treeView: {

--- a/testplan/web_ui/testing/src/Nav/TreeView.js
+++ b/testplan/web_ui/testing/src/Nav/TreeView.js
@@ -4,15 +4,37 @@ import TreeView from '@material-ui/lab/TreeView';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import TreeItem from '@material-ui/lab/TreeItem';
+import { css, StyleSheet } from 'aphrodite';
 import Column from './Column';
 import NavEntry from './NavEntry';
 import { applyAllFilters } from './navUtils';
-import { STATUS } from "../Common/defaults";
+import { STATUS, MEDIUM_GREY } from "../Common/defaults";
 import { CATEGORIES } from "../Common/defaults";
 import { generatePath } from 'react-router';
 import { NavLink } from 'react-router-dom';
 import TagList from './TagList';
+import { makeStyles } from '@material-ui/core/styles';
 
+const createTreeViewStyles = makeStyles({
+  treeItemLabel: {
+    padding: '5px 0px',
+    '&:hover': {
+      backgroundColor: MEDIUM_GREY
+    },
+    // WORKAROUND:
+    // if display: flex (default) then entry icons get cut off in case a long test case name
+    // if display: block then expand / collapse icons get rendered in a seperate row
+    width: '90%',
+  },
+
+  parentTreeItem: {
+    cursor: 'default'
+  },
+
+  iconContainer: {
+    cursor: 'pointer'
+  }
+});
 
 /**
  * Render a vertical list of all the currently selected entries children.
@@ -24,6 +46,7 @@ const TreeViewNav = (props) => {
         width={props.width}
         handleColumnResizing={props.handleColumnResizing}>
         <TreeView
+          className={css(styles.treeView)}
           disableSelection={true}
           defaultCollapseIcon={<ExpandMoreIcon />}
           defaultExpandIcon={<ChevronRightIcon />}>
@@ -67,13 +90,6 @@ TreeViewNav.propTypes = {
 
 export default TreeViewNav;
 
-const LeafNodeStyle = {
-  webkitUserSelect: "text",
-  MozUserSelect: "text",
-  MsUserSelect: "text",
-  UserSelect: "text",
-  textDecoration: 'none'
-};
 
 const createTree = (props) => {
   let entries = applyAllFilters(props, props.entries);
@@ -98,13 +114,17 @@ const createLeafNode = (props, entry) => {
       ? <TagList entryName={entry.name} tags={entry.tags} />
       : null
   );
+  const treeViewClasses = createTreeViewStyles();
   return (
     <TreeItem
+      classes={{
+        label: treeViewClasses.treeItemLabel,
+      }}
       nodeId={entry.uid || entry.hash}
       key={entry.uid || entry.hash}
       label={
         <NavLink
-          style={LeafNodeStyle}
+          className={css(styles.leafNode)}
           key={entry.hash || entry.uid}
           to={linkTo}>
           {tags}
@@ -115,10 +135,19 @@ const createLeafNode = (props, entry) => {
 };
 
 const createNode = (props, entry) => {
+  const treeViewClasses = createTreeViewStyles();
   return (
     <TreeItem
+      classes={{
+        label: treeViewClasses.treeItemLabel,
+        content: treeViewClasses.parentTreeItem,
+        iconContainer: treeViewClasses.iconContainer
+      }}
       nodeId={entry.uid || entry.hash}
       key={entry.uid || entry.hash}
+      onLabelClick={event => {
+        event.preventDefault();
+      }}
       label={createNavEntry(props, entry)}>
       {Array.isArray(entry.entries) ?
         entry.entries.map((entry) => createTreeHelper(props, entry)) : null}
@@ -141,3 +170,16 @@ const createNavEntry = (props, entry) => {
       displayTime={props.displayTime} />
   );
 };
+
+const styles = StyleSheet.create({
+  treeView: {
+    'overflow-y': 'auto',
+    'overflow-x': 'hidden',
+    'height': '100%',
+  },
+
+  leafNode: {
+    textDecoration: 'none',
+    color: '#495057'
+  }
+});

--- a/testplan/web_ui/testing/src/Nav/TreeView.js
+++ b/testplan/web_ui/testing/src/Nav/TreeView.js
@@ -79,7 +79,12 @@ const Tree = (props) => {
   return Array.isArray(entries) ?
     entries.map((entry) =>
       <CreateNode
-        props={props}
+        displayEmpty
+        displayTags={props.displayTags}
+        displayTime={props.displayTime}
+        entries={props.entries}
+        filter={props.filter}
+        url={props.url}
         entry={entry}
       />) : null;
 };
@@ -131,7 +136,12 @@ const continueTreeBranch = (props, entry) => {
   return Array.isArray(entry.entries) ?
     entry.entries.map((entry) =>
       <CreateNode
-        props={props}
+        displayEmpty
+        displayTags={props.displayTags}
+        displayTime={props.displayTime}
+        entries={props.entries}
+        filter={props.filter}
+        url={props.url}
         entry={entry}
       />) : null;
 };

--- a/testplan/web_ui/testing/src/Nav/TreeView.js
+++ b/testplan/web_ui/testing/src/Nav/TreeView.js
@@ -75,7 +75,7 @@ TreeViewNav.propTypes = {
 export default TreeViewNav;
 
 const Tree = (props) => {
-  let entries = applyAllFilters(props, props.entries);
+  let entries = filterEntries(props.filter, props.entries, props.displayEmpty);
   return Array.isArray(entries) ?
     entries.map((entry) =>
       <CreateNode
@@ -87,6 +87,20 @@ const Tree = (props) => {
         url={props.url}
         entry={entry}
       />) : null;
+};
+
+const filterEntries = (filter, entries, displayEmpty) => {
+  let filteredEntries = applyAllFilters(filter, entries, displayEmpty);
+  return filteredEntries.map(
+    (entry) => filterEntriesOfEntry(entry, filter, displayEmpty));
+};
+
+const filterEntriesOfEntry = (entry, filter, displayEmpty) => {
+  if (Array.isArray(entry.entries)) {
+    let tmp = { entries: filterEntries(filter, entry.entries, displayEmpty) };
+    return { ...entry, ...tmp };
+  }
+  return entry;
 };
 
 const CreateNode = (props) => {

--- a/testplan/web_ui/testing/src/Nav/TreeView.js
+++ b/testplan/web_ui/testing/src/Nav/TreeView.js
@@ -78,7 +78,7 @@ const Tree = (props) => {
   let entries = filterEntries(props.filter, props.entries, props.displayEmpty);
   return Array.isArray(entries) ?
     entries.map((entry) =>
-      <CreateNode
+      <Node
         displayEmpty
         displayTags={props.displayTags}
         displayTime={props.displayTime}
@@ -103,7 +103,7 @@ const filterEntriesOfEntry = (entry, filter, displayEmpty) => {
   return entry;
 };
 
-const CreateNode = (props) => {
+const Node = (props) => {
   let [reportuid, ...selectionuids] = props.entry.uids;
   const linkTo = generatePath(props.url,
     {
@@ -149,7 +149,7 @@ const CreateNode = (props) => {
 const continueTreeBranch = (props, entry) => {
   return Array.isArray(entry.entries) ?
     entry.entries.map((entry) =>
-      <CreateNode
+      <Node
         displayEmpty
         displayTags={props.displayTags}
         displayTime={props.displayTime}

--- a/testplan/web_ui/testing/src/Nav/TreeView.js
+++ b/testplan/web_ui/testing/src/Nav/TreeView.js
@@ -118,8 +118,8 @@ const createNode = (props, entry) => {
 
 const continueTreeBranch = (props, entry) => {
   return Array.isArray(entry.entries) ?
-    entry.entries.map((entry) => createNode(props, entry)) : null
-}
+    entry.entries.map((entry) => createNode(props, entry)) : null;
+};
 
 const createNavEntry = (props, entry) => {
   return (
@@ -148,13 +148,13 @@ const createTreeViewStyles = makeStyles({
     "&.Mui-selected > .MuiTreeItem-content:hover > .MuiTreeItem-label": {
       background: "transparent"
     },
-    "&.Mui-selected > .MuiTreeItem-content .MuiTreeItem-label:hover, .MuiTreeItem-root.Mui-selected:focus > .MuiTreeItem-content .MuiTreeItem-label": {
+    "&.Mui-selected > .MuiTreeItem-content .MuiTreeItem-label:hover, .MuiTreeItem-root.Mui-selected:focus > .MuiTreeItem-content .MuiTreeItem-label": { // eslint-disable-line max-len
       background: "transparent"
     }
   },
 
   group: {
-    marginLeft: '10px'
+    marginLeft: '0px'
   },
 
   content: {

--- a/testplan/web_ui/testing/src/Nav/TreeView.js
+++ b/testplan/web_ui/testing/src/Nav/TreeView.js
@@ -115,7 +115,7 @@ const Node = (props) => {
       ? <TagList entryName={props.entry.name} tags={props.entry.tags} />
       : null
   );
-  const treeViewClasses = createTreeViewStyles();
+  const treeViewClasses = getTreeViewStyles();
   return (
     <TreeItem
       classes={{
@@ -176,7 +176,7 @@ const createNavEntry = (props, entry) => {
   );
 };
 
-const createTreeViewStyles = makeStyles({
+const getTreeViewStyles = makeStyles({
   root: {
     "&.Mui-selected > .MuiTreeItem-content": {
       background: "transparent"

--- a/testplan/web_ui/testing/src/Nav/TreeView.js
+++ b/testplan/web_ui/testing/src/Nav/TreeView.js
@@ -15,9 +15,6 @@ import { NavLink } from 'react-router-dom';
 import TagList from './TagList';
 import { makeStyles } from '@material-ui/core/styles';
 
-/**
- * Render a vertical list of all the currently selected entries children.
- */
 const TreeViewNav = (props) => {
   return (
     <>
@@ -25,6 +22,7 @@ const TreeViewNav = (props) => {
         width={props.width}
         handleColumnResizing={props.handleColumnResizing}>
         <TreeView
+          selected={props.selectedUid}
           className={css(styles.treeView)}
           disableSelection={true}
           defaultCollapseIcon={<ExpandMoreIcon />}
@@ -91,8 +89,12 @@ const createNode = (props, entry) => {
   return (
     <TreeItem
       classes={{
-        label: treeViewClasses.treeItemLabel,
-        iconContainer: treeViewClasses.iconContainer
+        root: treeViewClasses.root,
+        group: treeViewClasses.group,
+        content: treeViewClasses.content,
+        selected: treeViewClasses.selected,
+        iconContainer: treeViewClasses.iconContainer,
+        label: treeViewClasses.label
       }}
       nodeId={entry.uid || entry.hash}
       key={entry.uid || entry.hash}
@@ -136,24 +138,53 @@ const createNavEntry = (props, entry) => {
 };
 
 const createTreeViewStyles = makeStyles({
-  treeItemLabel: {
-    padding: '5px 0px',
-    overflow: 'hidden',
+  root: {
+    "&.Mui-selected > .MuiTreeItem-content": {
+      background: "transparent"
+    },
+    "&.Mui-selected > .MuiTreeItem-content > .MuiTreeItem-label": {
+      background: "transparent"
+    },
+    "&.Mui-selected > .MuiTreeItem-content:hover > .MuiTreeItem-label": {
+      background: "transparent"
+    },
+    "&.Mui-selected > .MuiTreeItem-content .MuiTreeItem-label:hover, .MuiTreeItem-root.Mui-selected:focus > .MuiTreeItem-content .MuiTreeItem-label": {
+      background: "transparent"
+    }
+  },
+
+  group: {
+    marginLeft: '10px'
+  },
+
+  content: {
     '&:hover': {
       backgroundColor: MEDIUM_GREY
-    },
+    }
   },
 
   iconContainer: {
     cursor: 'pointer'
-  }
+  },
+
+  selected: {
+    '&:focus': {
+      backgroundColor: MEDIUM_GREY
+    },
+    backgroundColor: MEDIUM_GREY
+  },
+
+  label: {
+    padding: '5px 0px',
+    overflow: 'hidden'
+  },
 });
 
 const styles = StyleSheet.create({
   treeView: {
     'overflow-y': 'auto',
     'overflow-x': 'hidden',
-    'height': '100%',
+    'height': '100%'
   },
 
   leafNode: {

--- a/testplan/web_ui/testing/src/Nav/TreeView.js
+++ b/testplan/web_ui/testing/src/Nav/TreeView.js
@@ -18,13 +18,10 @@ import { makeStyles } from '@material-ui/core/styles';
 const createTreeViewStyles = makeStyles({
   treeItemLabel: {
     padding: '5px 0px',
+    overflow: 'hidden',
     '&:hover': {
       backgroundColor: MEDIUM_GREY
     },
-    // WORKAROUND:
-    // if display: flex (default) then entry icons get cut off in case a long test case name
-    // if display: block then expand / collapse icons get rendered in a seperate row
-    width: '90%',
   },
 
   parentTreeItem: {

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
@@ -5,11 +5,8 @@ exports[`InteractiveNavEntry renders a testcase in "failed" state 1`] = `
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
-      "MozUserSelect": "text",
-      "MsUserSelect": "text",
-      "UserSelect": "text",
       "height": "1.5em",
-      "webkitUserSelect": "text",
+      "userSelect": "text",
     }
   }
 >
@@ -87,11 +84,8 @@ exports[`InteractiveNavEntry renders a testcase in "not_run" state 1`] = `
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
-      "MozUserSelect": "text",
-      "MsUserSelect": "text",
-      "UserSelect": "text",
       "height": "1.5em",
-      "webkitUserSelect": "text",
+      "userSelect": "text",
     }
   }
 >
@@ -169,11 +163,8 @@ exports[`InteractiveNavEntry renders a testcase in "passed" state 1`] = `
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
-      "MozUserSelect": "text",
-      "MsUserSelect": "text",
-      "UserSelect": "text",
       "height": "1.5em",
-      "webkitUserSelect": "text",
+      "userSelect": "text",
     }
   }
 >
@@ -251,11 +242,8 @@ exports[`InteractiveNavEntry renders a testcase in "ready" state 1`] = `
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
-      "MozUserSelect": "text",
-      "MsUserSelect": "text",
-      "UserSelect": "text",
       "height": "1.5em",
-      "webkitUserSelect": "text",
+      "userSelect": "text",
     }
   }
 >
@@ -333,11 +321,8 @@ exports[`InteractiveNavEntry renders a testcase in "resetting" state 1`] = `
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
-      "MozUserSelect": "text",
-      "MsUserSelect": "text",
-      "UserSelect": "text",
       "height": "1.5em",
-      "webkitUserSelect": "text",
+      "userSelect": "text",
     }
   }
 >
@@ -415,11 +400,8 @@ exports[`InteractiveNavEntry renders a testcase in "running" state 1`] = `
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
-      "MozUserSelect": "text",
-      "MsUserSelect": "text",
-      "UserSelect": "text",
       "height": "1.5em",
-      "webkitUserSelect": "text",
+      "userSelect": "text",
     }
   }
 >
@@ -497,11 +479,8 @@ exports[`InteractiveNavEntry renders a testcase in "waiting" state 1`] = `
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
-      "MozUserSelect": "text",
-      "MsUserSelect": "text",
-      "UserSelect": "text",
       "height": "1.5em",
-      "webkitUserSelect": "text",
+      "userSelect": "text",
     }
   }
 >
@@ -579,11 +558,8 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTED 1`
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
-      "MozUserSelect": "text",
-      "MsUserSelect": "text",
-      "UserSelect": "text",
       "height": "1.5em",
-      "webkitUserSelect": "text",
+      "userSelect": "text",
     }
   }
 >
@@ -722,11 +698,8 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTING 1
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
-      "MozUserSelect": "text",
-      "MsUserSelect": "text",
-      "UserSelect": "text",
       "height": "1.5em",
-      "webkitUserSelect": "text",
+      "userSelect": "text",
     }
   }
 >
@@ -866,11 +839,8 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPED 1`
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
-      "MozUserSelect": "text",
-      "MsUserSelect": "text",
-      "UserSelect": "text",
       "height": "1.5em",
-      "webkitUserSelect": "text",
+      "userSelect": "text",
     }
   }
 >
@@ -1009,11 +979,8 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPING 1
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
-      "MozUserSelect": "text",
-      "MsUserSelect": "text",
-      "UserSelect": "text",
       "height": "1.5em",
-      "webkitUserSelect": "text",
+      "userSelect": "text",
     }
   }
 >

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
@@ -5,7 +5,11 @@ exports[`InteractiveNavEntry renders a testcase in "failed" state 1`] = `
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
+      "MozUserSelect": "text",
+      "MsUserSelect": "text",
+      "UserSelect": "text",
       "height": "1.5em",
+      "webkitUserSelect": "text",
     }
   }
 >
@@ -83,7 +87,11 @@ exports[`InteractiveNavEntry renders a testcase in "not_run" state 1`] = `
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
+      "MozUserSelect": "text",
+      "MsUserSelect": "text",
+      "UserSelect": "text",
       "height": "1.5em",
+      "webkitUserSelect": "text",
     }
   }
 >
@@ -161,7 +169,11 @@ exports[`InteractiveNavEntry renders a testcase in "passed" state 1`] = `
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
+      "MozUserSelect": "text",
+      "MsUserSelect": "text",
+      "UserSelect": "text",
       "height": "1.5em",
+      "webkitUserSelect": "text",
     }
   }
 >
@@ -239,7 +251,11 @@ exports[`InteractiveNavEntry renders a testcase in "ready" state 1`] = `
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
+      "MozUserSelect": "text",
+      "MsUserSelect": "text",
+      "UserSelect": "text",
       "height": "1.5em",
+      "webkitUserSelect": "text",
     }
   }
 >
@@ -317,7 +333,11 @@ exports[`InteractiveNavEntry renders a testcase in "resetting" state 1`] = `
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
+      "MozUserSelect": "text",
+      "MsUserSelect": "text",
+      "UserSelect": "text",
       "height": "1.5em",
+      "webkitUserSelect": "text",
     }
   }
 >
@@ -395,7 +415,11 @@ exports[`InteractiveNavEntry renders a testcase in "running" state 1`] = `
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
+      "MozUserSelect": "text",
+      "MsUserSelect": "text",
+      "UserSelect": "text",
       "height": "1.5em",
+      "webkitUserSelect": "text",
     }
   }
 >
@@ -473,7 +497,11 @@ exports[`InteractiveNavEntry renders a testcase in "waiting" state 1`] = `
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
+      "MozUserSelect": "text",
+      "MsUserSelect": "text",
+      "UserSelect": "text",
       "height": "1.5em",
+      "webkitUserSelect": "text",
     }
   }
 >
@@ -551,7 +579,11 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTED 1`
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
+      "MozUserSelect": "text",
+      "MsUserSelect": "text",
+      "UserSelect": "text",
       "height": "1.5em",
+      "webkitUserSelect": "text",
     }
   }
 >
@@ -690,7 +722,11 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTING 1
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
+      "MozUserSelect": "text",
+      "MsUserSelect": "text",
+      "UserSelect": "text",
       "height": "1.5em",
+      "webkitUserSelect": "text",
     }
   }
 >
@@ -830,7 +866,11 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPED 1`
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
+      "MozUserSelect": "text",
+      "MsUserSelect": "text",
+      "UserSelect": "text",
       "height": "1.5em",
+      "webkitUserSelect": "text",
     }
   }
 >
@@ -969,7 +1009,11 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPING 1
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
+      "MozUserSelect": "text",
+      "MsUserSelect": "text",
+      "UserSelect": "text",
       "height": "1.5em",
+      "webkitUserSelect": "text",
     }
   }
 >

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavEntry.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavEntry.test.js.snap
@@ -5,11 +5,8 @@ exports[`NavEntry shallow renders the correct HTML structure 1`] = `
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
-      "MozUserSelect": "text",
-      "MsUserSelect": "text",
-      "UserSelect": "text",
       "height": "1.5em",
-      "webkitUserSelect": "text",
+      "userSelect": "text",
     }
   }
 >
@@ -56,11 +53,8 @@ exports[`NavEntry when prop status="failed" name div and Badge have correct styl
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
-      "MozUserSelect": "text",
-      "MsUserSelect": "text",
-      "UserSelect": "text",
       "height": "1.5em",
-      "webkitUserSelect": "text",
+      "userSelect": "text",
     }
   }
 >
@@ -107,11 +101,8 @@ exports[`NavEntry when prop status="xfail" name div and Badge have correct style
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
-      "MozUserSelect": "text",
-      "MsUserSelect": "text",
-      "UserSelect": "text",
       "height": "1.5em",
-      "webkitUserSelect": "text",
+      "userSelect": "text",
     }
   }
 >

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavEntry.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavEntry.test.js.snap
@@ -5,7 +5,11 @@ exports[`NavEntry shallow renders the correct HTML structure 1`] = `
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
+      "MozUserSelect": "text",
+      "MsUserSelect": "text",
+      "UserSelect": "text",
       "height": "1.5em",
+      "webkitUserSelect": "text",
     }
   }
 >
@@ -52,7 +56,11 @@ exports[`NavEntry when prop status="failed" name div and Badge have correct styl
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
+      "MozUserSelect": "text",
+      "MsUserSelect": "text",
+      "UserSelect": "text",
       "height": "1.5em",
+      "webkitUserSelect": "text",
     }
   }
 >
@@ -99,7 +107,11 @@ exports[`NavEntry when prop status="xfail" name div and Badge have correct style
   className="d-flex justify-content-between align-items-center"
   style={
     Object {
+      "MozUserSelect": "text",
+      "MsUserSelect": "text",
+      "UserSelect": "text",
       "height": "1.5em",
+      "webkitUserSelect": "text",
     }
   }
 >

--- a/testplan/web_ui/testing/src/Nav/navUtils.js
+++ b/testplan/web_ui/testing/src/Nav/navUtils.js
@@ -26,7 +26,8 @@ const CreateNavButtons = (
 ) => {
 
   // Apply all filters to the entries.
-  const filteredEntries = applyAllFilters(props);
+  const filteredEntries =
+    applyAllFilters(props.filter, props.entries, props.displayEmpty);
 
   // Create buttons for each of the filtered entries.
   const navButtons = filteredEntries.map((entry, entryIndex) => {
@@ -85,15 +86,15 @@ const CreateNavButtons = (
  *    entries).
  *  * Filter out empty testcases if required.
  */
-const applyAllFilters = (props) => {
-  if (props.displayEmpty) {
-    return applyNamedFilter(props.entries, props.filter);
+const applyAllFilters = (filter, entries, displayEmpty) => {
+  if (displayEmpty) {
+    return applyNamedFilter(entries, filter);
   } else {
-    return applyNamedFilter(props.entries, props.filter).filter((entry) => {
+    return applyNamedFilter(entries, filter).filter((entry) => {
       if (entry.category === 'testcase') {
         return (entry.entries !== null && entry.entries.length > 0);
       } else {
-        return (entry.counter.total > 0);
+        return (entry.counter && entry.counter.total > 0);
       }
     });
   }
@@ -109,12 +110,14 @@ const applyNamedFilter = (entries, filter) => {
   switch (filter) {
     case 'pass':
       return entries.filter(
-        (entry) => (entry.counter.passed | 0) > 0
+        (entry) =>
+          (entry.counter ? (entry.counter.passed | 0) : 0) > 0
       );
-
     case 'fail':
       return entries.filter(
-        (entry) => (entry.counter.failed | 0) + (entry.counter.error | 0) > 0
+        (entry) =>
+          (entry.counter ? (entry.counter.failed | 0) : 0) +
+          (entry.counter ? (entry.counter.error | 0) : 0) > 0
       );
 
     default:

--- a/testplan/web_ui/testing/src/Report/BatchReport.js
+++ b/testplan/web_ui/testing/src/Report/BatchReport.js
@@ -57,7 +57,7 @@ class BatchReport extends React.Component {
       loading: false,
       error: null,
       filter: null,
-      treeView: false,
+      treeView: true,
       displayTags: false,
       displayTime: false,
       displayEmpty: true,

--- a/testplan/web_ui/testing/src/Report/BatchReport.js
+++ b/testplan/web_ui/testing/src/Report/BatchReport.js
@@ -80,8 +80,8 @@ class BatchReport extends React.Component {
     const redirectPath = this.props.match.params.selection
       ? null
       : generateSelectionPath(this.props.match.path, [
-          filteredReport.report.uid,
-        ]);
+        filteredReport.report.uid,
+      ]);
 
     this.setState(
       {
@@ -134,7 +134,7 @@ class BatchReport extends React.Component {
                   if (!assertionsRes.data) {
                     alert(
                       "Failed to parse assertion datails!\n" +
-                        "Please report this issue to the Testplan team."
+                      "Please report this issue to the Testplan team."
                     );
                     console.error(assertionsRes);
                   }
@@ -249,7 +249,7 @@ class BatchReport extends React.Component {
    * @param {boolean} treeView.
    * @public
    */
-   updateTreeView(treeView) {
+  updateTreeView(treeView) {
     this.setState({ treeView: treeView });
   }
 
@@ -322,8 +322,8 @@ class BatchReport extends React.Component {
     if (selectedEntries.length) {
       window.document.title = `${_.last(selectedEntries).name} | \
                                ${selectedEntries.slice(0, -1)
-                                                .map(entry => entry.name)
-                                                .join(" > ")}`;
+          .map(entry => entry.name)
+          .join(" > ")}`;
     }
 
     const centerPane = GetCenterPane(

--- a/testplan/web_ui/testing/src/Report/EmptyReport.js
+++ b/testplan/web_ui/testing/src/Report/EmptyReport.js
@@ -48,7 +48,7 @@ const EmptyReport = (props) => {
         report={null}
         saveAssertions={noop}
         filter={undefined}
-        treeView={false}
+        treeView={true}
         displayEmpty={true}
         displayTags={false}
         displayTime={false}

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
@@ -1356,7 +1356,7 @@ exports[`BatchReport loads a more complex report 1`] = `
         },
       ]
     }
-    treeView={false}
+    treeView={true}
     url="/testplan/:uid/:selection*"
   />
   <ContextProvider
@@ -3031,7 +3031,7 @@ exports[`BatchReport loads a report with selection at Multitest level 1`] = `
         },
       ]
     }
-    treeView={false}
+    treeView={true}
     url="/testplan/:uid/:selection*"
   />
   <ContextProvider
@@ -4644,7 +4644,7 @@ exports[`BatchReport loads a report with selection at Testcase level 1`] = `
         },
       ]
     }
-    treeView={false}
+    treeView={true}
     url="/testplan/:uid/:selection*"
   />
   <ContextProvider
@@ -6497,7 +6497,7 @@ exports[`BatchReport loads a report with selection at Testsuite level 1`] = `
         },
       ]
     }
-    treeView={false}
+    treeView={true}
     url="/testplan/:uid/:selection*"
   />
   <ContextProvider
@@ -7358,7 +7358,7 @@ exports[`BatchReport loads a simple report 1`] = `
         },
       ]
     }
-    treeView={false}
+    treeView={true}
     url="/testplan/:uid/:selection*"
   />
   <ContextProvider
@@ -8738,7 +8738,7 @@ exports[`BatchReport shallow renders the correct HTML structure when report load
         },
       ]
     }
-    treeView={false}
+    treeView={true}
     url="/testplan/:uid/:selection*"
   />
   <ContextProvider
@@ -9960,7 +9960,7 @@ ZeroDivisionError: integer division or modulo by zero
       navListWidth="22em"
       report={null}
       selected={Array []}
-      treeView={false}
+      treeView={true}
       url="/testplan/:uid/:selection*"
     >
       <NavBreadcrumbs
@@ -9975,7 +9975,7 @@ ZeroDivisionError: integer division or modulo by zero
           />
         </div>
       </NavBreadcrumbs>
-      <NavList
+      <TreeViewNav
         breadcrumbLength={0}
         displayEmpty={true}
         displayTags={false}
@@ -9983,6 +9983,7 @@ ZeroDivisionError: integer division or modulo by zero
         entries={Array []}
         filter={null}
         handleColumnResizing={[Function]}
+        selected={Array []}
         selectedUid={null}
         url="/testplan/:uid/:selection*"
         width="22em"
@@ -9994,25 +9995,41 @@ ZeroDivisionError: integer division or modulo by zero
           <div
             className="column_1e6n0oe-o_O-leftColumn_lzxz1z"
           >
-            <ListGroup
-              className="buttonList_mjw45f"
-              tag="ul"
+            <WithStyles(ForwardRef(TreeView))
+              className="treeView_sdm2vq"
+              defaultCollapseIcon={<UNDEFINED />}
+              defaultExpandIcon={<UNDEFINED />}
+              disableSelection={true}
+              selected={null}
             >
-              <ul
-                className="buttonList_mjw45f list-group"
+              <ForwardRef(TreeView)
+                className="treeView_sdm2vq"
+                classes={
+                  Object {
+                    "root": "MuiTreeView-root",
+                  }
+                }
+                defaultCollapseIcon={<UNDEFINED />}
+                defaultExpandIcon={<UNDEFINED />}
+                disableSelection={true}
+                selected={null}
               >
-                <ListGroupItem
-                  className="navButton_1x055n9"
-                  tag="li"
+                <ul
+                  aria-multiselectable={false}
+                  className="MuiTreeView-root treeView_sdm2vq"
+                  role="tree"
                 >
-                  <li
-                    className="navButton_1x055n9 list-group-item"
-                  >
-                    No entries to display...
-                  </li>
-                </ListGroupItem>
-              </ul>
-            </ListGroup>
+                  <Tree
+                    displayEmpty={true}
+                    displayTags={false}
+                    displayTime={false}
+                    entries={Array []}
+                    filter={null}
+                    url="/testplan/:uid/:selection*"
+                  />
+                </ul>
+              </ForwardRef(TreeView)>
+            </WithStyles(ForwardRef(TreeView))>
           </div>
           <div
             className="column_1e6n0oe-o_O-rightColumn_a8e8l5"
@@ -10023,7 +10040,7 @@ ZeroDivisionError: integer division or modulo by zero
             />
           </div>
         </Column>
-      </NavList>
+      </TreeViewNav>
     </Nav>
     <Message
       left="22em"

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/EmptyReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/EmptyReport.test.js.snap
@@ -25,7 +25,7 @@ exports[`EmptyReport renders a custom error message 1`] = `
     displayTime={false}
     report={null}
     saveAssertions={[Function]}
-    treeView={false}
+    treeView={true}
   />
   <Message
     left="22em"
@@ -59,7 +59,7 @@ exports[`EmptyReport shallow renders and matches snapshot 1`] = `
     displayTime={false}
     report={null}
     saveAssertions={[Function]}
-    treeView={false}
+    treeView={true}
   />
   <Message
     left="22em"

--- a/testplan/web_ui/testing/src/Toolbar/Toolbar.js
+++ b/testplan/web_ui/testing/src/Toolbar/Toolbar.js
@@ -62,7 +62,7 @@ class Toolbar extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      treeView: false,
+      treeView: true,
       filterOpen: false,
       infoModal: false,
       filter: "all",


### PR DESCRIPTION
## Bug / Requirement Description
The tree view navigation needed some refinements.

## Solution description
Made the tree view navigation scrollable.
Desatured tags color.
Fixed padding.
Expand / collapse works only with icon click not label.
Reset color of the slashes in the entry icons.
Entry icon cut off workaround fix.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
