### PR TITLE
Fix several bugs of WebUI about displaying time information

### DIFF
--- a/testplan/web_ui/testing/src/Common/utils.js
+++ b/testplan/web_ui/testing/src/Common/utils.js
@@ -141,7 +141,7 @@ function formatMilliseconds(durationInMilliseconds) {
 
   return [hoursDisplay, minutesDisplay, secondsDisplay, millisecondsDisplay]
     .filter(Boolean)
-    .join(" ");
+    .join(" ") || "0ms";
 }
 
 export {

--- a/testplan/web_ui/testing/src/Nav/NavEntry.js
+++ b/testplan/web_ui/testing/src/Nav/NavEntry.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Badge } from 'reactstrap';
 import { StyleSheet, css } from 'aphrodite';
-import { formatSeconds } from './../Common/utils';
+import { formatMilliseconds } from './../Common/utils';
 import _ from 'lodash';
 
 import {
@@ -29,7 +29,7 @@ const NavEntry = (props) => {
     props.displayTime && _.isNumber(props.executionTime) ? (
       <i className={css(styles.entryIcon)} title='Execution time'>
         <span className={css(styles[STATUS_CATEGORY[props.status]])}>
-          {formatSeconds(props.executionTime)}
+          {formatMilliseconds(props.executionTime)}
         </span>
       </i>
     ) : null

--- a/testplan/web_ui/testing/src/Nav/NavList.js
+++ b/testplan/web_ui/testing/src/Nav/NavList.js
@@ -14,7 +14,7 @@ const NavList = (props) => {
     (entry) => {
       const executionTime = (entry.timer && entry.timer.run) ? (
         (new Date(entry.timer.run.end)).getTime() -
-        (new Date(entry.timer.run.start)).getTime()) / 1000 : null;
+        (new Date(entry.timer.run.start)).getTime()) : null;  // In millisecond
 
       return (
         <NavEntry

--- a/testplan/web_ui/testing/src/Report/reportUtils.js
+++ b/testplan/web_ui/testing/src/Report/reportUtils.js
@@ -280,7 +280,7 @@ const getAssertions = (selectedEntries, displayTime) => {
       }
       if (links.length > 0) {
         let duration = "Unknown";
-        if (selectedEntry.timer && selectedEntry.timer.run.end &&
+        if (selectedEntry.timer && selectedEntry.timer.run?.end &&
           links[links.length - 1].utc_time) {
           const nextEntryTime =
             (new Date(selectedEntry.timer.run.end)).getTime();


### PR DESCRIPTION
* For non-MultiTest instance, its testcases have not time delta
  information and no need to calculate duration of assertions, or
  exception raised.
* Duration is formatted as "h m s mm" but sometimes there can be
  a long string like "1.89999999ms" which looks ugly. It's better
  avoid floating point conversion and from the very beginning value
  in milliseconds is passed as argument.
* for empty case (or setup/teardown methods) the duration is very
  small and not displayed, should still mark it as "0ms" In order
  to distinguish those entries who have no time information.
