### PR TITLE
Time data should be recorded in report

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -770,7 +770,9 @@ class Runnable(Entity):
         self.pre_resource_steps()
         self._add_step(self.resources.start)
 
+        self.pre_main_steps()
         self.main_batch_steps()
+        self.post_main_steps()
 
         self._add_step(self.resources.stop, reversed=True)
         self.post_resource_steps()
@@ -845,15 +847,23 @@ class Runnable(Entity):
             self.status.update_metadata(**{str(step): res})
 
     def pre_resource_steps(self):
-        """Steps to run before environment started."""
+        """Runnable steps to run before environment started."""
+        pass
+
+    def pre_main_steps(self):
+        """Runnable steps to run after environment started."""
         pass
 
     def main_batch_steps(self):
-        """Steps to run after environment started."""
+        """Runnable steps to be executed while environment is running."""
+        pass
+
+    def post_main_steps(self):
+        """Runnable steps to run before environment stopped."""
         pass
 
     def post_resource_steps(self):
-        """Steps to run after environment stopped."""
+        """Runnable steps to run after environment stopped."""
         pass
 
     def pausing(self):

--- a/testplan/common/serialization/fields.py
+++ b/testplan/common/serialization/fields.py
@@ -362,14 +362,19 @@ class UTCDateTime(fields.DateTime):
     """
 
     def _serialize(self, value, attr, obj, **kwargs):
-        dt = (
+        if value is None:
+            return None
+
+        return (
             value.replace(tzinfo=pytz.UTC)
             if value.tzinfo is None
             else value.astimezone(tz=pytz.UTC)
-        )
-        return dt.isoformat()
+        ).isoformat()
 
     def _deserialize(self, value, attr, data, **kwargs):
+        if value is None:
+            return None
+
         dt = parser.parse(value)
         return (
             dt.replace(tzinfo=pytz.UTC)
@@ -389,10 +394,10 @@ class LocalDateTime(fields.DateTime):
     """
 
     def _serialize(self, value, attr, obj, **kwargs):
-        return value.astimezone().isoformat()
+        return None if value is None else value.astimezone().isoformat()
 
     def _deserialize(self, value, attr, data, **kwargs):
-        return parser.parse(value).astimezone()
+        return None if value is None else parser.parse(value).astimezone()
 
 
 class ExceptionField(fields.Field):

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -665,17 +665,18 @@ class TestRunner(Runnable):
             pass
 
     def pre_resource_steps(self):
-        """Steps to be executed before resources started."""
+        """Runnable steps to be executed before resources started."""
+        super(TestRunner, self).pre_resource_steps()
         self._add_step(self._record_start)
         self._add_step(self.make_runpath_dirs)
         self._add_step(self._configure_file_logger)
 
     def main_batch_steps(self):
-        """Steps to be executed while resources are running."""
+        """Runnable steps to be executed while resources are running."""
         self._add_step(self._wait_ongoing)
 
     def post_resource_steps(self):
-        """Steps to be executed after resources stopped."""
+        """Runnable steps to be executed after resources stopped."""
         self._add_step(self._stop_remote_services)
         self._add_step(self._create_result)
         self._add_step(self._log_test_status)
@@ -683,6 +684,7 @@ class TestRunner(Runnable):
         self._add_step(self._invoke_exporters)
         self._add_step(self._post_exporters)
         self._add_step(self._close_file_logger)
+        super(TestRunner, self).post_resource_steps()
 
     def _wait_ongoing(self):
         # TODO: if a pool fails to initialize we could reschedule the tasks.

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -467,6 +467,7 @@ class MultiTest(testing_base.Test):
 
     def pre_resource_steps(self):
         """Runnable steps to be executed before environment starts."""
+        super(MultiTest, self).pre_resource_steps()
         self._add_step(self.make_runpath_dirs)
         if self.cfg.before_start:
             self._add_step(
@@ -475,18 +476,24 @@ class MultiTest(testing_base.Test):
                 )
             )
 
-    def main_batch_steps(self):
-        """Runnable steps to be executed while environment is running."""
+    def pre_main_steps(self):
+        """Runnable steps to be executed after environment starts."""
         if self.cfg.after_start:
             self._add_step(
                 self._wrap_run_step(
                     label="after_start", func=self.cfg.after_start
                 )
             )
+        super(MultiTest, self).pre_main_steps()
 
+    def main_batch_steps(self):
+        """Runnable steps to be executed while environment is running."""
         self._add_step(self.run_tests)
         self._add_step(self.propagate_tag_indices)
 
+    def post_main_steps(self):
+        """Runnable steps to run before environment stopped."""
+        super(MultiTest, self).post_main_steps()
         if self.cfg.before_stop:
             self._add_step(
                 self._wrap_run_step(
@@ -502,8 +509,8 @@ class MultiTest(testing_base.Test):
                     label="after_stop", func=self.cfg.after_stop
                 )
             )
-
         self._add_step(self.append_pre_post_step_report)
+        super(MultiTest, self).post_resource_steps()
 
     def should_run(self):
         """

--- a/testplan/testing/py_test.py
+++ b/testplan/testing/py_test.py
@@ -116,17 +116,19 @@ class PyTest(testing.Test):
     def run_tests(self):
         """Run pytest and wait for it to terminate."""
         # Execute pytest with self as a plugin for hook support
+        with self.report.timer.record("run"):
+            return_code = pytest.main(
+                self._pytest_args, plugins=[self._pytest_plugin]
+            )
 
-        return_code = pytest.main(
-            self._pytest_args, plugins=[self._pytest_plugin]
-        )
-
-        if return_code == 5:
-            self.result.report.status_override = Status.UNSTABLE
-            self.logger.warning("No tests were run")
-        elif return_code != 0:
-            self.result.report.status_override = Status.FAILED
-            self.logger.error("pytest exited with return code %d", return_code)
+            if return_code == 5:
+                self.result.report.status_override = Status.UNSTABLE
+                self.logger.warning("No tests were run")
+            elif return_code != 0:
+                self.result.report.status_override = Status.FAILED
+                self.logger.error(
+                    "pytest exited with return code %d", return_code
+                )
 
     def _collect_tests(self):
         """Collect test items but do not run any."""

--- a/testplan/testing/pyunit.py
+++ b/testplan/testing/pyunit.py
@@ -57,7 +57,8 @@ class PyUnit(testing.Test):
 
     def run_tests(self):
         """Run PyUnit and wait for it to terminate."""
-        self.result.report.extend(self._run_tests())
+        with self.report.timer.record("run"):
+            self.result.report.extend(self._run_tests())
 
     def get_test_context(self):
         """

--- a/tests/unit/testplan/test_plan_base.py
+++ b/tests/unit/testplan/test_plan_base.py
@@ -14,9 +14,9 @@ from testplan.common.entity import (
 from testplan.common.utils.exceptions import should_raise
 from testplan.common.utils.path import default_runpath
 from testplan.common.utils.testing import argv_overridden
-from testplan.report import TestGroupReport, ReportCategories
 from testplan.runnable import TestRunnerStatus, TestRunner
 from testplan.runners.local import LocalRunner
+from testplan.report import TestGroupReport, ReportCategories
 
 
 class DummyDriver(Resource):

--- a/tests/unit/testplan/testing/test_base.py
+++ b/tests/unit/testplan/testing/test_base.py
@@ -1,0 +1,117 @@
+"""TODO."""
+
+import time
+
+from testplan import TestplanMock
+from testplan.common.entity import Resource, Runnable
+from testplan.testing.base import Test, TestResult
+from testplan.runnable import TestRunnerStatus
+from testplan.runners.local import LocalRunner
+from testplan.report import Status, TestGroupReport, ReportCategories
+
+
+class DummyDriver(Resource):
+    def start(self):
+        self.status.change(self.STATUS.STARTING)
+        self.starting()
+
+    def stop(self):
+        if self.status.tag is self.STATUS.STOPPED:
+            return
+        self.status.change(self.STATUS.STOPPING)
+        if self.active:
+            self.stopping()
+
+    def starting(self):
+        time.sleep(0.2)  # 200ms for startup
+
+    def stopping(self):
+        time.sleep(0.1)  # 100ms for teardown
+
+    def aborting(self):
+        pass
+
+
+class DummyTest(Test):
+    def __init__(self, name, **options):
+        super(DummyTest, self).__init__(name=name, **options)
+        self.resources.add(DummyDriver(), uid="drv1")
+        self.resources.add(DummyDriver(), uid="drv2")
+
+    def run_tests(self):
+        with self._result.report.timer.record("run"):
+            time.sleep(0.5)  # 500ms for execution
+            self._result.report.status_override = Status.PASSED
+
+    def pre_resource_steps(self):
+        self._add_step(lambda: self.result.report.timer.start("flag1"))
+        super(DummyTest, self).pre_resource_steps()
+
+    def pre_main_steps(self):
+        super(DummyTest, self).pre_main_steps()
+        self._add_step(lambda: self.result.report.timer.start("flag2"))
+
+    def main_batch_steps(self):
+        self._add_step(self.run_tests)
+
+    def post_main_steps(self):
+        self._add_step(lambda: self.result.report.timer.end("flag2"))
+        super(DummyTest, self).post_main_steps()
+
+    def post_resource_steps(self):
+        super(DummyTest, self).post_resource_steps()
+        self._add_step(lambda: self.result.report.timer.end("flag1"))
+
+
+class MyRunner(LocalRunner):  # Start is async
+    def __init__(self, name=None):
+        super(MyRunner, self).__init__()
+        self.name = name
+
+    def uid(self):
+        return self.name or super(MyRunner, self).uid()
+
+    def _execute(self, uid):
+        runnable = self._input[uid]
+        assert isinstance(runnable, Runnable)
+
+        if not runnable.parent:
+            runnable.parent = self
+        if not runnable.cfg.parent:
+            runnable.cfg.parent = self.cfg
+
+        runnable.run()
+        self._results[uid] = runnable.result
+        assert isinstance(self._results[uid], TestResult)
+
+    def aborting(self):
+        pass
+
+
+def test_time_information():
+    """TODO."""
+    plan = TestplanMock(name="MyPlan")
+    assert isinstance(plan.status, TestRunnerStatus)
+
+    plan.add_resource(MyRunner(name="runner"))
+    assert "runner" in plan.resources
+
+    task_uid = plan.schedule(DummyTest("Dummy"), resource="runner")
+    assert task_uid == "Dummy"
+    assert len(plan.resources["runner"]._input) == 1
+    resources = plan.resources["runner"]._input[task_uid].resources
+    assert len(resources) == 2 and "drv1" in resources and "drv2" in resources
+
+    res = plan.run()
+    assert res.run is True
+
+    test_report = res.report["Dummy"]
+    assert test_report.name == "Dummy" and test_report.category == "dummytest"
+    assert test_report.timer["setup"].elapsed > 0.4  # 2 drivers startup
+    assert test_report.timer["teardown"].elapsed > 0.2  # 2 drivers teardown
+    assert (
+        test_report.timer["flag1"].elapsed
+        > test_report.timer["flag2"].elapsed
+        > test_report.timer["run"].elapsed
+        > 0.5
+    )


### PR DESCRIPTION
* Now only time information of running tests for Multitest is recorded
  but time of setup/teardown (start/stop resources) is missing. For
  other type of tests (ProcessRunnerTest, PyUnit, PyTest) all of the
  time information is not recorded. We should add it.
* Add a new testcase.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
