### PR TITLE
Make AbsentType class real singleton.

### DIFF
--- a/doc/en/download/Execution Pools.rst
+++ b/doc/en/download/Execution Pools.rst
@@ -91,7 +91,7 @@ test_plan.py
 .. literalinclude:: ../../../examples/ExecutionPools/Parts/test_plan.py
 
 tasks.py
-+++++++++
+++++++++
 .. literalinclude:: ../../../examples/ExecutionPools/Parts/tasks.py
 
 .. _example_discover:

--- a/testplan/common/utils/reporting.py
+++ b/testplan/common/utils/reporting.py
@@ -9,14 +9,20 @@ from collections.abc import Mapping, Iterable
 NATIVE_TYPES = (str, int, float, bool, memoryview, bytes, bytearray)
 
 
-class AbsentType(object):
+class AbsentType:
     """
     A singleton to represent the lack of a value in a comparison.
     None is not used to avoid the situation where a key may be
     present and it's value is ``None``.
     """
 
+    __instance = None
     descr = "ABSENT"
+
+    def __new__(cls):
+        if not isinstance(cls.__instance, cls):
+            cls.__instance = object.__new__(cls)
+        return cls.__instance
 
     def __str__(self):
         return self.descr

--- a/tests/unit/testplan/common/utils/test_comparison.py
+++ b/tests/unit/testplan/common/utils/test_comparison.py
@@ -1,6 +1,13 @@
 import pytest
 from testplan.common.utils import comparison as cmp
 
+from testplan.common.utils.reporting import Absent
+import copy
+
+
+def test_absent():
+    assert id(Absent) == id(copy.deepcopy(Absent))
+
 
 @pytest.mark.parametrize(
     "callable_kls,reference,value,expected,description",


### PR DESCRIPTION
## Bug / Requirement Description
When user deepcopy a msg with Absent, the new Absent object is not Absent.

## Solution description
Make AbsentType class singleton.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
