### PR TITLE
Make custom_wrapper apply for non-parametrized case.

### DIFF
--- a/testplan/common/utils/callable.py
+++ b/testplan/common/utils/callable.py
@@ -7,7 +7,6 @@ from collections import namedtuple
 WRAPPER_ASSIGNMENTS = functools.WRAPPER_ASSIGNMENTS + (
     "__tags__",
     "__tags_index__",
-    "wrapper_of",
     "summarize",
     "summarize_num_passing",
     "summarize_num_failing",
@@ -72,70 +71,20 @@ def getargspec(callable_):
     )
 
 
-# backport from python 3.6, 2.7 version does not catch AttributeError
-def update_wrapper(
-    wrapper,
-    wrapped,
-    assigned=WRAPPER_ASSIGNMENTS,
-    updated=functools.WRAPPER_UPDATES,
-):
-    """
-    Update a wrapper function to look like the wrapped function.
-
-    :param wrapper: Function to be updated.
-    :type wrapper: ``func``
-    :param wrapped: Original function.
-    :type wrapped: ``func``
-    :param assigned: Tuple naming the attributes assigned directly from the
-                     wrapped function to the wrapper function (defaults to
-                     functools.WRAPPER_ASSIGNMENTS)
-    :type assigned: ``tuple``
-    :param updated: tuple naming the attributes of the wrapper that are updated
-                    with the corresponding attribute from the wrapped function
-                    (defaults to functools.WRAPPER_UPDATES)
-    :type updated: ``tuple``
-    :return: Wrapper function.
-    :rtype: ``func``
-    """
-    for attr in assigned:
-        try:
-            value = getattr(wrapped, attr)
-        except AttributeError:
-            pass
-        else:
-            setattr(wrapper, attr, value)
-    for attr in updated:
-        getattr(wrapper, attr).update(getattr(wrapped, attr, {}))
-    # Issue #17482: set __wrapped__ last so we don't inadvertently copy it
-    # from the wrapped function when updating __dict__
-    wrapper.__wrapped__ = wrapped
-    # Return the wrapper so this can be used as a decorator via partial()
-    return wrapper
-
-
 def wraps(
     wrapped, assigned=WRAPPER_ASSIGNMENTS, updated=functools.WRAPPER_UPDATES
 ):
     """
-    Custom wraps function that uses the backported ``update_wrapper``.
-
-    Also sets ``wrapper_of`` attribute for code highlighting, for methods that
-    are decorated for the first time.
+    Custom wraps function that copies some additional attr than default.
     """
 
     def _inner(wrapper):
-        wrapper = update_wrapper(
+        wrapper = functools.update_wrapper(
             wrapper=wrapper,
             wrapped=wrapped,
             assigned=assigned,
             updated=updated,
         )
-
-        # When a method is decorated for the first time it will not have
-        # `wrapper_of` attribute set, so `update_wrapper` won't be able to copy
-        # it over. That's why we have to explicitly assign it here.
-        if not hasattr(wrapped, "wrapper_of"):
-            wrapper.wrapper_of = wrapped
         return wrapper
 
     return _inner

--- a/testplan/testing/multitest/suite.py
+++ b/testplan/testing/multitest/suite.py
@@ -572,6 +572,7 @@ def _testcase_meta(
     @functools.wraps(_testcase)
     def wrapper(function):
         """Meta logic for test case goes here."""
+        global __TESTCASES__
         global __GENERATED_TESTCASES__
         global __PARAMETRIZATION_TEMPLATE__
 
@@ -580,6 +581,7 @@ def _testcase_meta(
 
         tag_dict = tagging.validate_tag_value(tags) if tags else {}
         function.__tags__ = copy.deepcopy(tag_dict)
+        function.__tags_index__ = copy.deepcopy(tag_dict)
 
         if parameters is not None:  # Empty tuple / dict checks happen later
             function.__parametrization_template__ = True
@@ -626,23 +628,35 @@ def _testcase_meta(
                 for wrapper_func in wrappers:
                     func = wrapper_func(func)
 
-                # so that CodeDetails gets the correct line number
-                func.wrapper_of = function
-
                 __GENERATED_TESTCASES__.append(func)
 
             return function
 
         else:
+
+            _validate_testcase(function)
+            _mark_function_as_testcase(function)
+
+            function.__seq_number__ = _number_of_testcases()
+            function.__skip__ = []
+
             function.summarize = summarize
             function.summarize_num_passing = num_passing
             function.summarize_num_failing = num_failing
             function.summarize_key_combs_limit = key_combs_limit
             function.execution_group = execution_group
             function.timeout = timeout
-            function.__tags_index__ = copy.deepcopy(tag_dict)
 
-            return _testcase(function)
+            wrappers = custom_wrappers or []
+
+            if not isinstance(wrappers, (list, tuple)):
+                wrappers = [wrappers]
+
+            for wrapper_func in wrappers:
+                function = wrapper_func(function)
+
+            __TESTCASES__.append(function.__name__)
+            return function
 
     return wrapper
 

--- a/tests/functional/testplan/testing/multitest/test_parametrization.py
+++ b/tests/functional/testplan/testing/multitest/test_parametrization.py
@@ -503,8 +503,14 @@ def test_custom_wrapper():
         def adder_test(self, env, result, a, b, expected):
             result.equal(actual=a + b, expected=expected)
 
+        # custom_wrappers should work for non-parametrized case as well
+        @testcase(custom_wrappers=add_label("bar"))
+        def non_param_case(self, env, result):
+            result.equal(actual=1, expected=1)
+
     assert MySuite.adder_test__a_1__b_2__expected_3.label == "foo"
     assert MySuite.adder_test__a_3__b_3__expected_6.label == "foo"
+    assert MySuite.non_param_case.label == "bar"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Bug / Requirement Description
@testcase(custom_wrappers=) without parameters is not working.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
