### PR TITLE
TESTPLAN-1698: add clean_remote option to RemoteResource.

### DIFF
--- a/examples/ExecutionPools/Remote/test_plan.py
+++ b/examples/ExecutionPools/Remote/test_plan.py
@@ -103,6 +103,7 @@ def main(plan):
         # explicit source and destination locations defined above.
         push=push_files,
         workspace=workspace,
+        clean_remote=True,
     )
 
     plan.add_resource(pool)

--- a/examples/RemoteDriver/Basic/test_plan.py
+++ b/examples/RemoteDriver/Basic/test_plan.py
@@ -62,6 +62,7 @@ def main(plan):
     remote_service = RemoteService(
         "rmt_svc",
         REMOTE_HOST,
+        clean_remote=True,
     )
 
     # add the remote_service to plan so that it gets started,

--- a/testplan/common/remote/remote_resource.py
+++ b/testplan/common/remote/remote_resource.py
@@ -71,6 +71,7 @@ class RemoteResourceConfig(EntityConfig):
             ConfigOption("remote_runpath", default=None): str,
             ConfigOption("testplan_path", default=None): str,
             ConfigOption("remote_workspace", default=None): str,
+            ConfigOption("clean_remote", default=False): bool,
             ConfigOption("push", default=[]): Or(list, None),
             ConfigOption("push_exclude", default=[]): Or(list, None),
             ConfigOption("delete_pushed", default=False): bool,
@@ -112,6 +113,8 @@ class RemoteResource(Entity):
     :param remote_workspace: The path of the workspace on remote host,
       default is fetched_workspace under remote_runpath
     :type remote_workspace: ``str``
+    :param clean_remote: Deleted root runpath on remote at exit.
+    :type clean_remote: ``bool``
 
     :param push: Files and directories to push to the remote.
     :type push: ``list`` that contains ``str`` or ``tuple``:
@@ -153,6 +156,7 @@ class RemoteResource(Entity):
         remote_runpath=None,
         testplan_path=None,
         remote_workspace=None,
+        clean_remote=False,
         push=None,
         push_exclude=None,
         delete_pushed=False,
@@ -523,6 +527,17 @@ class RemoteResource(Entity):
         except Exception as exc:
             self.logger.exception(
                 "While fetching result from worker [%s]: %s", self, exc
+            )
+
+    def _clean_remote(self):
+        if self.cfg.clean_remote:
+            self.logger.debug(
+                "Clean root runpath on remote host - %s", self.cfg.remote_host
+            )
+
+            self._execute_cmd_remote(
+                cmd=f"/bin/rm -rf {self._remote_plan_runpath}",
+                label="Clean remote root runpath",
             )
 
     def _pull_files(self):

--- a/testplan/common/remote/remote_service.py
+++ b/testplan/common/remote/remote_service.py
@@ -177,6 +177,9 @@ class RemoteService(Resource, RemoteResource):
         """Before stopping the service"""
         self._fetch_results()
 
+    def post_stop(self):
+        self._clean_remote()
+
     def stopping(self):
         """Stop remote rpyc process"""
         remote_pid = self.rpyc_connection.modules.os.getpid()

--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -80,7 +80,9 @@ class ProcessWorker(Worker):
     def _write_syspath(self, sys_path=None):
         """Write out our current sys.path to a file and return the filename."""
         sys_path = sys_path or sys.path
-        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            mode="w", dir=self.parent.runpath, delete=False
+        ) as f:
             f.write("\n".join(sys_path))
             self.logger.debug("Written sys.path to file: %s", f.name)
             self._syspath_file = f.name

--- a/testplan/runners/pools/remote.py
+++ b/testplan/runners/pools/remote.py
@@ -136,6 +136,9 @@ class RemoteWorker(ProcessWorker, RemoteResource):
         """Stop child process worker."""
         self._fetch_results()
 
+    def post_stop(self):
+        self._clean_remote()
+
     def _wait_stopped(self, timeout=None):
         sleeper = get_sleeper(1, timeout)
         while next(sleeper):
@@ -234,6 +237,9 @@ class RemotePool(Pool):
     :param remote_workspace: The path of the workspace on remote host,
       default is fetched_workspace under remote_runpath
     :type remote_workspace: ``str``
+    :param clean_remote: Deleted root runpath on remote at exit.
+    :type clean_remote: ``bool``
+
     :param push: Files and directories to push to the remote.
     :type push: ``list`` that contains ``str`` or ``tuple``:
         - ``str``: Name of the file or directory
@@ -283,6 +289,7 @@ class RemotePool(Pool):
         remote_runpath=None,
         testplan_path=None,
         remote_workspace=None,
+        clean_remote=False,
         push=None,
         push_exclude=None,
         delete_pushed=False,

--- a/tests/unit/testplan/common/remote/test_remote_resource.py
+++ b/tests/unit/testplan/common/remote/test_remote_resource.py
@@ -106,6 +106,7 @@ def remote_resource(runpath_module, workspace, push_dir):
         pull_exclude=["file2"],
         env={"LOCAL_USER": getpass.getuser()},
         setup_script=["remote_setup.py"],
+        clean_remote=True,
     )
     remote_resource.parent = mockplan.runnable
     remote_resource.cfg.parent = mockplan.runnable.cfg


### PR DESCRIPTION
## Bug / Requirement Description
Add new clean_remote option to RemoteResource, which will be available to RemotePool and RemoteService.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
