### PR TITLE
Fix fetch_runpath_exclude not be used issue.

### DIFF
--- a/testplan/common/remote/remote_resource.py
+++ b/testplan/common/remote/remote_resource.py
@@ -515,12 +515,18 @@ class RemoteResource(Entity):
 
     def _fetch_results(self):
         """Fetch back to local host the results generated remotely."""
+        if not self.cfg.fetch_runpath:
+            self.logger.debug(
+                "Skip fetch results stage - %s", self.cfg.remote_host
+            )
+            return
         self.logger.debug("Fetch results stage - %s", self.cfg.remote_host)
         try:
             self._transfer_data(
                 source=self._remote_resource_runpath,
                 remote_source=True,
                 target=self.parent.runpath,
+                exclude=self.cfg.fetch_runpath_exclude,
             )
             if self.cfg.pull:
                 self._pull_files()


### PR DESCRIPTION
## Bug / Requirement Description
`fetch_runpath_exclude`  arg is missed in transfer data from remote to local in remote resource

## Solution description
Add fetch_runpath_exclud when calling transfer_data method

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
