### PR TITLE
pin the docutils version for rtd

### DIFF
--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -1,2 +1,3 @@
+docutils<0.18
 -r ./requirements.txt
 ./releaseherald


### PR DESCRIPTION


## Bug / Requirement Description
new version of docutils not compatible with sphynx<2 that we are using
ref: https://blog.readthedocs.com/build-errors-docutils-0-18/

## Solution description
pin the version of docutils<0.18

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
