### PR TITLE
Warn if `schedule_all` retrive task target from modules with same name

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -92,7 +92,7 @@ jobs:
           sudo apt-get -y install zookeeper zookeeper-bin zookeeperd
       - name: Set up Kafka for tests
         run: |
-          wget https://downloads.apache.org/kafka/2.6.2/kafka_2.12-2.6.2.tgz -O kafka.tgz
+          wget https://downloads.apache.org/kafka/2.6.3/kafka_2.12-2.6.3.tgz -O kafka.tgz
           sudo mkdir /opt/kafka
           sudo chown -R $USER:$USER /opt/kafka
           tar zxf kafka.tgz -C /opt/kafka --strip-components 1

--- a/testplan/common/utils/package.py
+++ b/testplan/common/utils/package.py
@@ -1,33 +1,54 @@
-import importlib
 import sys
+import importlib
 import threading
+import warnings
 from contextlib import contextmanager
-
-from testplan.common.utils.path import pwd
 
 MOD_LOCK = threading.Lock()
 
 
 @contextmanager
-def import_tmp_module(module, path=None):
-    module_imported = False
+def import_tmp_module(module_name, path=None, delete=True, warn_if_exist=True):
+    """
+    Temporarily import a module by name and later remove all imported modules.
+
+    :param module_name: Module name.
+    :type module_name: ``str``
+    :param path: Where the module can be imported.
+    :type path: ``str`` or ``NoneType``
+    :param delete: If delete imported modules from `sys.modules` after use.
+    :type delete: ``bool``
+    :param warn_if_exist: Warn if module name already exists in `sys.modules`.
+    :type warn_if_exist: ``bool``
+    """
+    module = None
+    modules_imported = []  # Names of imported modules
 
     with MOD_LOCK:
         if path is not None:
-            # note: avoid adding "." to sys.path, mod won't have correct __file__
-            # add "" to sys.path instead
+            if path == ".":
+                path = ""
             sys.path.insert(0, path)
 
-        if module not in sys.modules:
-            module_imported = True
+        mod_name = ""
+        for element in module_name.split("."):
+            mod_name = f"{mod_name}.{element}" if mod_name else element
+            if mod_name in sys.modules:
+                if warn_if_exist:
+                    warnings.warn(
+                        f'Importing module: "{mod_name}" already loaded',
+                    )
+            else:
+                modules_imported.append(mod_name)
+            module = importlib.import_module(mod_name)
 
-        mod = importlib.import_module(module)
-
-    yield mod
+    yield module
 
     with MOD_LOCK:
-        if module_imported:
-            del sys.modules[module]
+        if delete:
+            for mod_name in reversed(modules_imported):
+                if mod_name in sys.modules:
+                    del sys.modules[mod_name]
 
         if path is not None:
             sys.path.remove(path)


### PR DESCRIPTION
* `schedule_all` can search for test target and it needs to import
  modules at first, but the module with same name might be already
  loaded, so needs to print warnings for this.
* The test targes found can be collected and then added into runner
  at last, thus avoid calling `import_tmp_module` in itself. Because
  during materializing a task this function is called again.
* Update kafka version needed for test.