### PR TITLE
Fix tests

### DIFF
--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -13,6 +13,7 @@ import threading
 import platform
 
 from testplan import defaults
+from testplan.common.utils.package import MOD_LOCK
 from testplan.defaults import STDOUT_STYLE
 from testplan.common.utils import comparison
 from testplan.common.utils import strings
@@ -78,7 +79,10 @@ class ExceptionCapture(object):
             description=self.description,
         )
 
-        caller_frame = inspect.stack()[1]
+        with MOD_LOCK:
+            # TODO: see https://github.com/python/cpython/commit/85cf1d514b84dc9a4bcb40e20a12e1d82ff19f20
+            caller_frame = inspect.stack()[1]
+
         exc_assertion.file_path = os.path.abspath(caller_frame[1])
         exc_assertion.line_no = caller_frame[2]
 
@@ -109,7 +113,9 @@ def assertion(func):
             entry = func(result, *args, **kwargs)
             if top_assertion:
                 # Second element is the caller
-                caller_frame = inspect.stack()[1]
+                with MOD_LOCK:
+                    # TODO: see https://github.com/python/cpython/commit/85cf1d514b84dc9a4bcb40e20a12e1d82ff19f20
+                    caller_frame = inspect.stack()[1]
                 entry.file_path = os.path.abspath(caller_frame.filename)
                 entry.line_no = caller_frame.lineno
 

--- a/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
+++ b/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
@@ -25,12 +25,12 @@ class MySuite(object):
     @testcase
     def test_attach(self, env, result):
         with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".txt", delete=True
+            mode="w", suffix=".txt", delete=False
         ) as tmpfile:
             tmpfile.write("testplan\n")
-            result.attach(
-                tmpfile.name, description=os.path.basename(tmpfile.name)
-            )
+
+        result.attach(tmpfile.name, description=os.path.basename(tmpfile.name))
+        os.remove(tmpfile.name)
 
 
 def get_mtest(name):


### PR DESCRIPTION
## Bug / Requirement Description
1) inspect.stack would iterate sys.modules which has chance to be modified by another thread
2) make test_attach work for windows

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
