### PR TITLE
refine pool related tests

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -1084,11 +1084,21 @@ class Resource(Entity):
         method.
         """
 
+        if self._aborted:
+            self.logger.debug("%r already aborted, skip stopping", self)
+            return
+
+        if self.status.tag in (self.STATUS.STOPPING, self.STATUS.STOPPED):
+            self.logger.debug(
+                "stop() has been called on %r, skip stopping", self
+            )
+            return
+
         self.logger.debug("Stopping %r", self)
+
         self.status.change(self.STATUS.STOPPING)
         self.pre_stop()
-        if self.active:
-            self.stopping()
+        self.stopping()
 
         if not self.cfg.async_start:
             self.wait(self.STATUS.STOPPED)

--- a/testplan/common/remote/remote_resource.py
+++ b/testplan/common/remote/remote_resource.py
@@ -532,10 +532,10 @@ class RemoteResource(Entity):
         """Fetch back to local host the results generated remotely."""
         if not self.cfg.fetch_runpath:
             self.logger.debug(
-                "Skip fetch results stage - %s", self.cfg.remote_host
+                "Skip fetch results stage - %s", self.ssh_cfg["host"]
             )
             return
-        self.logger.debug("Fetch results stage - %s", self.cfg.remote_host)
+        self.logger.debug("Fetch results stage - %s", self.ssh_cfg["host"])
         try:
             self._transfer_data(
                 source=self._remote_resource_runpath,
@@ -553,7 +553,7 @@ class RemoteResource(Entity):
     def _clean_remote(self):
         if self.cfg.clean_remote:
             self.logger.debug(
-                "Clean root runpath on remote host - %s", self.cfg.remote_host
+                "Clean root runpath on remote host - %s", self.ssh_cfg["host"]
             )
 
             self._execute_cmd_remote(
@@ -625,7 +625,7 @@ class RemoteResource(Entity):
         suitable for use in a copy command such as `scp`.
         """
         return "{user}@{host}:{path}".format(
-            user=self._user, host=self.cfg.remote_host, path=path
+            user=self._user, host=self.ssh_cfg["host"], path=path
         )
 
     def _transfer_data(

--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -150,7 +150,8 @@ class ProcessWorker(Worker):
 
     def stopping(self):
         """Stop child process worker."""
-        if self._handler:
+
+        if hasattr(self, "_handler") and self._handler:
             kill_process(self._handler)
             self._handler.wait()
         self.status.change(self.STATUS.STOPPED)
@@ -158,10 +159,7 @@ class ProcessWorker(Worker):
     def aborting(self):
         """Process worker abort logic."""
         self._transport.disconnect()
-        if hasattr(self, "_handler") and self._handler:
-            kill_process(self._handler)
-            self._handler.wait()
-            self._handler = None
+        self.stop()
 
 
 class ProcessPoolConfig(PoolConfig):

--- a/testplan/runners/pools/remote.py
+++ b/testplan/runners/pools/remote.py
@@ -151,15 +151,6 @@ class RemoteWorker(ProcessWorker, RemoteResource):
             self.logger.error(msg)
             raise RuntimeError(msg)
 
-    def aborting(self):
-        """Abort child process worker."""
-        try:
-            self._fetch_results()
-        except Exception as exc:
-            self.logger.error("Could not fetch results, {}".format(exc))
-        super(RemoteWorker, self).aborting()
-        self.status.change(self.STATUS.STOPPED)
-
 
 class RemotePoolConfig(PoolConfig):
     """

--- a/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
+++ b/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
@@ -76,12 +76,25 @@ class SimpleSuite(object):
         pass
 
 
-def multitest_kills_worker(parent_pid):
+def multitest_kill_workers(parent_pid):
     """To kill all child workers."""
     if os.getpid() != parent_pid:  # Main process should not be killed
         os.kill(os.getpid(), 9)
     else:
         return MultiTest(name="MTestKiller", suites=[SimpleSuite()])
+
+
+@testsuite
+class SuiteKillRemoteWorker:
+    @testcase
+    def kill_remote_worker(self, env, result):
+        os.kill(os.getpid(), 9)
+
+
+def multitest_kill_remote_workers():
+    return MultiTest(
+        name="MTestKillRemoteWorker", suites=[SuiteKillRemoteWorker()]
+    )
 
 
 def schedule_tests_to_pool(plan, pool, schedule_path=None, **pool_cfg):

--- a/tests/functional/testplan/runners/pools/test_pool_process.py
+++ b/tests/functional/testplan/runners/pools/test_pool_process.py
@@ -100,7 +100,7 @@ def test_kill_all_workers(mockplan):
     dirname = os.path.dirname(os.path.abspath(__file__))
 
     uid = mockplan.schedule(
-        target="multitest_kills_worker",
+        target="multitest_kill_workers",
         module="func_pool_base_tasks",
         path=dirname,
         args=(os.getpid(),),
@@ -146,7 +146,7 @@ def test_reassign_times_limit(mockplan):
     dirname = os.path.dirname(os.path.abspath(__file__))
 
     uid = mockplan.schedule(
-        target="multitest_kills_worker",
+        target="multitest_kill_workers",
         module="func_pool_base_tasks",
         path=dirname,
         args=(os.getpid(),),
@@ -304,7 +304,7 @@ def test_restart_worker(mockplan):
     dirname = os.path.dirname(os.path.abspath(__file__))
 
     mockplan.schedule(
-        target="multitest_kills_worker",
+        target="multitest_kill_workers",
         module="func_pool_base_tasks",
         path=dirname,
         args=(os.getpid(),),


### PR DESCRIPTION
## Bug / Requirement Description
This mainly for internal enhancement for treadmill pool.

## Solution description
De-dup the code between pool's stopping and aborting.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
