### PR TITLE
`task_target` can be used without parentheses

### DIFF
--- a/doc/en/pools.rst
+++ b/doc/en/pools.rst
@@ -327,49 +327,50 @@ to do task discovery.
     )
 
 In the code above, testplan will go look for @task_target decorated functions
-in modules that matches the name_pattern under current working directory.
+in modules that matches the ``name_pattern`` under current working directory.
 
 .. code-block:: python
 
-    @task_target()
-    def make_multitest1():
-        # a test target shall only return 1 runnable object
-        test = MultiTest(name="Proj2-Suite1", suites=[Suite1()])
+    @task_target
+    def make_multitest():
+        # A test target shall only return 1 runnable object
+        test = MultiTest(name="MTest", suites=[Suite()])
         return test
 
 Once found, task object will be created from the target, and scheduled to pool.
-It is also possible to create multiple task objects out of one target:
+It is possible to create multiple task objects out of one target with
+`parameters` specified:
 
 .. code-block:: python
 
     @task_target(
         parameters=(
             # positional args to be passed to target, as a tuple or list
-            ("Proj1-Suite2", None, [sub_proj1.suites.Suite2]),
+            ("MTest1", None, [SimpleSuite1, SimpleSuite2]),
             # keyword args to be passed to target, as a dict
             dict(
-                name="Proj1-Suite1",
+                name="MTest2-1",
                 part_tuple=(0, 2),
-                suites=[sub_proj1.suites.Suite1],
+                suites=[ComplicatedSuite],
             ),
             dict(
-                name="Proj1-Suite1",
+                name="MTest2-2",
                 part_tuple=(1, 2),
-                suites=[sub_proj1.suites.Suite1],
+                suites=[ComplicatedSuite],
             ),
         ),
-        # additional args of Task class
+        # additional arguments of Task class
         rerun=1,
         weight=1,
     )
     def make_multitest(name, part_tuple=None, suites=None):
-        # a test target shall only return 1 runnable object
+        # A test target shall only return 1 runnable object
         test = MultiTest(
             name=name, suites=[cls() for cls in suites], part=part_tuple
         )
         return test
 
-The code above specifies a collections of parameters in @task_target, and each
+The code above specifies a collections of parameters in `@task_target`, and each
 entry will be used create one task - thus 3 tasks will be created from the target.
 
 For a complete and downloadable example, see :ref:`here <example_discover>`.

--- a/examples/ExecutionPools/Discover/sub_proj2/tasks.py
+++ b/examples/ExecutionPools/Discover/sub_proj2/tasks.py
@@ -4,14 +4,14 @@ from testplan.testing.multitest import MultiTest
 from sub_proj2.suites import Suite1, Suite2
 
 
-@task_target()
+@task_target
 def make_multitest1():
     # a test target shall only return 1 runnable object
     test = MultiTest(name="Proj2-Suite1", suites=[Suite1()])
     return test
 
 
-@task_target()
+@task_target
 def make_multitest2():
     # a test target shall only return 1 runnable object
     test = MultiTest(name="Proj2-Suite2", suites=[Suite2()])

--- a/examples/ExecutionPools/Discover/test_plan.py
+++ b/examples/ExecutionPools/Discover/test_plan.py
@@ -39,9 +39,7 @@ def main(plan):
     # to MyPool.
 
     plan.schedule_all(
-        path=".",
-        name_pattern=r".*tasks\.py$",
-        resource="MyPool",
+        path=".", name_pattern=r".*tasks\.py$", resource="MyPool"
     )
 
 

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -474,19 +474,23 @@ class TestRunner(Runnable):
         :type resource: :py:class:`~testplan.runners.pools.base.Pool`
         """
 
+        def schedule_task(task_kwargs, resource):
+            self.logger.debug("Task created with arguments: %s", task_kwargs)
+            self.add(Task(**task_kwargs), resource=resource)
+
         self.logger.test_info(
             "Discovering task target with file name pattern '%s' under '%s'",
             name_pattern,
             path,
         )
         regex = re.compile(name_pattern)
-        created_tasks = []
 
         for root, dirs, files in os.walk(path or "."):
             for filename in files:
                 if not regex.match(filename):
                     continue
 
+                filepath = os.path.join(root, filename)
                 module = filename.split(".")[0]
 
                 with import_tmp_module(module, root) as mod:
@@ -495,41 +499,35 @@ class TestRunner(Runnable):
                         if not is_task_target(target):
                             continue
 
-                        self.logger.test_info(
-                            "Discovered task target %s::%s",
-                            os.path.join(root, filename),
-                            attr,
+                        self.logger.debug(
+                            "Discovered task target %s::%s", filepath, attr
                         )
-                        parameters = target.__target_params__ or [{}]
+                        task_arguments = dict(
+                            target=attr,
+                            module=module,
+                            path=root,
+                            **target.__task_kwargs__,
+                        )
 
-                        for param in parameters:
-                            if isinstance(param, dict):
-                                args = None
-                                kwargs = param
-                            elif isinstance(param, (tuple, list)):
-                                args = param
-                                kwargs = None
-                            else:
-                                raise TypeError(
-                                    "task_target's parameters can only contain"
-                                    f" dict/tuple/list, but received: {param}"
+                        if target.__target_params__:
+                            for param in target.__target_params__:
+                                if isinstance(param, dict):
+                                    task_arguments["args"] = None
+                                    task_arguments["kwargs"] = param
+                                elif isinstance(param, (tuple, list)):
+                                    task_arguments["args"] = param
+                                    task_arguments["kwargs"] = None
+                                else:
+                                    raise TypeError(
+                                        "task_target's parameters can only"
+                                        " contain dict/tuple/list, but"
+                                        " received: {param}"
+                                    )
+                                schedule_task(
+                                    task_arguments, resource=resource
                                 )
-
-                            task_args = dict(
-                                target=attr,
-                                module=module,
-                                path=root,
-                                args=args,
-                                kwargs=kwargs,
-                                **target.__task_kwargs__,
-                            )
-                            self.logger.debug(
-                                "Create task with param %s", task_args
-                            )
-                            created_tasks.append((Task(**task_args), resource))
-
-        for task, resource in created_tasks:
-            self.add(task, resource=resource)
+                        else:
+                            schedule_task(task_arguments, resource=resource)
 
     def add(self, target, resource=None):
         """


### PR DESCRIPTION
* Allow the decorator `task_target` used without parentheses following.
* When `schedule_all` is used to discover task targets, once a target
  is found then should be added to executor, rather adding all targets
  after directory traversed, so the log of 'Discovered task target' and
  'Task created' can match for easy tracing, also the exception can be
  raised in advance if there's Test instances with duplicate name.
* Update document and examples.

## Checklist:
- [ ] Test
- [x] Example (both test_plan.py and .rst)
- [x] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
