### PR TITLE
Allow ProcessRunnerTest based tests to take extra arguments

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -22,6 +22,7 @@ jobs:
             testplan/*
             tests/*
             scripts/*
+            releaseherald/releaseherald/*
             pytest.ini
             pyproject.toml
             setup.py

--- a/doc/newsfragments/extra_args.feature.rst
+++ b/doc/newsfragments/extra_args.feature.rst
@@ -1,0 +1,1 @@
+* ProcessRunnerTest based tests are able to take extra args.

--- a/doc/newsfragments/extra_args.rst
+++ b/doc/newsfragments/extra_args.rst
@@ -1,0 +1,1 @@
+* Logfile, stdout and stderr is rotated on restart.

--- a/doc/newsfragments/extra_args.rst
+++ b/doc/newsfragments/extra_args.rst
@@ -1,1 +1,0 @@
-* Logfile, stdout and stderr is rotated on restart.

--- a/releaseherald/releaseherald/configuration.py
+++ b/releaseherald/releaseherald/configuration.py
@@ -29,7 +29,9 @@ class Configuration(BaseModel):
     config_path: Path
     version_tag_pattern: Pattern = DEFAULT_VERSION_TAG_PATTERN
     news_fragments_directory: Path = DEFAULT_FRAGMENTS_DIR
-    insert_marker: Pattern = re.compile(r"^(\s)*\.\. releaseherald_insert(\s)*$")
+    insert_marker: Pattern = re.compile(
+        r"^(\s)*\.\. releaseherald_insert(\s)*$"
+    )
     template: Path = str(Path(templates.__path__[0]) / "news.rst")
     unreleased: bool = False
     news_file: Path = "news.rst"
@@ -59,6 +61,8 @@ class Configuration(BaseModel):
         values = values.copy()
         for path_config in cls.__config__.paths_to_resolve:
             path = Path(values[path_config])
-            values[path_config] = str(path if path.is_absolute() else root / path)
+            values[path_config] = str(
+                path if path.is_absolute() else root / path
+            )
 
         return values

--- a/releaseherald/releaseherald/main.py
+++ b/releaseherald/releaseherald/main.py
@@ -142,7 +142,9 @@ class CommitInfo:
         )
 
 
-def get_commits(repo: Repo, tags, include_head, include_root) -> List[CommitInfo]:
+def get_commits(
+    repo: Repo, tags, include_head, include_root
+) -> List[CommitInfo]:
     commits = [CommitInfo(tag=tag, commit=tag.commit) for tag in tags]
     if include_head and (
         not commits or (commits and repo.head.commit != commits[0].commit)
@@ -194,7 +196,9 @@ def get_submodule_news(
 
         commits = [submodule_to, *tag_commits, submodule_from]
 
-        snews = SubmoduleNews(name=submodule.name, display_name=submodule.display_name)
+        snews = SubmoduleNews(
+            name=submodule.name, display_name=submodule.display_name
+        )
 
         for c_to, c_from in pairwise(commits):
             snews.news.extend(
@@ -222,7 +226,9 @@ def collect_news_fragments(
         tags = list(takewhile(lambda tag: tag != last_tag, tags))
         tags.append(last_tag)
 
-    commits = get_commits(repo, tags, include_unreleased, include_root=not last_tag)
+    commits = get_commits(
+        repo, tags, include_unreleased, include_root=not last_tag
+    )
 
     result = [
         VersionNews(

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -474,6 +474,12 @@ class ProcessRunnerTest(Test):
                     This can be disabled by providing a list of
                     numbers to ignore.
     :type ignore_exit_codes: ``list`` of ``int``
+    :param pre_args: List of arguments to be prepended before the
+        arguments of the test runnable.
+    :type pre_args: ``list``
+    :param post_args: List of arguments to be appended before the
+        arguments of the test runnable.
+    :type post_args: ``list``
 
     Also inherits all
     :py:class:`~testplan.testing.base.Test` options.

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -476,10 +476,10 @@ class ProcessRunnerTest(Test):
     :type ignore_exit_codes: ``list`` of ``int``
     :param pre_args: List of arguments to be prepended before the
         arguments of the test runnable.
-    :type pre_args: ``list``
+    :type pre_args: ``list`` of ``str``
     :param post_args: List of arguments to be appended before the
         arguments of the test runnable.
-    :type post_args: ``list``
+    :type post_args: ``list`` of ``str``
 
     Also inherits all
     :py:class:`~testplan.testing.base.Test` options.
@@ -532,20 +532,40 @@ class ProcessRunnerTest(Test):
 
     def test_command(self):
         """
+        Add custom arguments before and after the executable if they are defined.
+        :return: List of commands to run before and after the test process, as well as the test executable itself.
+        :rtype:  ``list`` of ``str``
+        """
+        cmd = self._test_command()
+
+        if self.cfg.pre_args:
+            return self.cfg.pre_args + cmd
+        if self.cfg.post_args:
+            return cmd + self.cfg.post_args
+
+    def _test_command(self):
+        """
         Override this to add extra options to the test command.
 
         :return: Command to run test process
         :rtype: ``list`` of ``str``
         """
-        if self.cfg.pre_args:
-            cmd = [*self.cfg.pre_args, self.cfg.binary]
-        else:
-            cmd = [self.cfg.binary]
-        if self.cfg.post_args:
-            cmd.extend(self.cfg.post_args)
-        return cmd
+        return [self.cfg.binary]
 
     def list_command(self):
+        """
+        List custom arguments before and after the executable if they are defined.
+        :return: List of commands to run before and after the test process, as well as the test executable itself.
+        :rtype:  ``list`` of ``str`` or ``NoneType``
+        """
+        cmd = self._list_command()
+        if self.cfg.pre_args:
+            cmd = self.cfg.pre_args + cmd
+        if self.cfg.post_args:
+            cmd = cmd + self.cfg.post_args
+        return cmd
+
+    def _list_command(self):
         """
         Override this to generate the shell command that will cause the
         testing framework to list the tests available on stdout.

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -539,9 +539,10 @@ class ProcessRunnerTest(Test):
         cmd = self._test_command()
 
         if self.cfg.pre_args:
-            return self.cfg.pre_args + cmd
+            cmd = self.cfg.pre_args + cmd
         if self.cfg.post_args:
-            return cmd + self.cfg.post_args
+            cmd = cmd + self.cfg.post_args
+        return cmd
 
     def _test_command(self):
         """

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -490,15 +490,13 @@ class ProcessRunnerTest(Test):
     _VERIFICATION_TESTCASE_NAME = "ExitCodeCheck"
     _MAX_RETAINED_LOG_SIZE = 4096
 
-    def __init__(self, pre_args=[], post_args=[], **options):
+    def __init__(self, pre_args=None, post_args=None, **options):
         proc_env = os.environ.copy()
         if options.get("proc_env"):
             proc_env.update(options["proc_env"])
         options["proc_env"] = proc_env
-        if pre_args:
-            options["pre_args"] = pre_args
-        if post_args:
-            options["post_args"] = post_args
+        options["pre_args"] = pre_args if pre_args else options["pre_args"] = []
+        options["post_args"] = post_args if post_args else options["post_args"] = []
         super(ProcessRunnerTest, self).__init__(**options)
 
         self._test_context = None

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -496,19 +496,11 @@ class ProcessRunnerTest(Test):
     _VERIFICATION_TESTCASE_NAME = "ExitCodeCheck"
     _MAX_RETAINED_LOG_SIZE = 4096
 
-    def __init__(self, pre_args=None, post_args=None, **options):
+    def __init__(self, **options):
         proc_env = os.environ.copy()
         if options.get("proc_env"):
             proc_env.update(options["proc_env"])
         options["proc_env"] = proc_env
-        if pre_args:
-            options["pre_args"] = pre_args
-        else:
-            options["pre_args"] = []
-        if post_args:
-            options["post_args"] = post_args
-        else:
-            options["post_args"] = []
         super(ProcessRunnerTest, self).__init__(**options)
 
         self._test_context = None

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -555,7 +555,7 @@ class ProcessRunnerTest(Test):
         :return: Command to list tests
         :rtype: ``list`` of ``str`` or ``NoneType``
         """
-        return None
+        return []
 
     def get_test_context(self, list_cmd=None):
         """
@@ -568,7 +568,7 @@ class ProcessRunnerTest(Test):
         :rtype: ``list`` of ``list``
         """
         cmd = list_cmd or self.list_command()
-        if cmd is None:
+        if not cmd:
             return [(self._DEFAULT_SUITE_NAME, ())]
 
         proc = subprocess_popen(

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -437,6 +437,8 @@ class ProcessRunnerTestConfig(TestConfig):
                 None, float, int, Use(parse_duration)
             ),
             ConfigOption("ignore_exit_codes", default=[]): [int],
+            ConfigOption("pre_args", default=[]): list,
+            ConfigOption("post_args", default=[]): list,
         }
 
 
@@ -488,11 +490,15 @@ class ProcessRunnerTest(Test):
     _VERIFICATION_TESTCASE_NAME = "ExitCodeCheck"
     _MAX_RETAINED_LOG_SIZE = 4096
 
-    def __init__(self, **options):
+    def __init__(self, pre_args=[], post_args=[], **options):
         proc_env = os.environ.copy()
         if options.get("proc_env"):
             proc_env.update(options["proc_env"])
         options["proc_env"] = proc_env
+        if pre_args:
+            options["pre_args"] = pre_args
+        if post_args:
+            options["post_args"] = post_args
         super(ProcessRunnerTest, self).__init__(**options)
 
         self._test_context = None
@@ -529,7 +535,13 @@ class ProcessRunnerTest(Test):
         :return: Command to run test process
         :rtype: ``list`` of ``str``
         """
-        return [self.cfg.binary]
+        if self.cfg.pre_args:
+            cmd = [*self.cfg.pre_args, self.cfg.binary]
+        else:
+            cmd = [self.cfg.binary]
+        if self.cfg.post_args:
+            cmd.extend(self.cfg.post_args)
+        return cmd
 
     def list_command(self):
         """

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -560,10 +560,11 @@ class ProcessRunnerTest(Test):
         :rtype:  ``list`` of ``str`` or ``NoneType``
         """
         cmd = self._list_command()
-        if self.cfg.pre_args:
-            cmd = self.cfg.pre_args + cmd
-        if self.cfg.post_args:
-            cmd = cmd + self.cfg.post_args
+        if cmd:
+            if self.cfg.pre_args:
+                cmd = self.cfg.pre_args + cmd
+            if self.cfg.post_args:
+                cmd = cmd + self.cfg.post_args
         return cmd
 
     def _list_command(self):

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -495,8 +495,14 @@ class ProcessRunnerTest(Test):
         if options.get("proc_env"):
             proc_env.update(options["proc_env"])
         options["proc_env"] = proc_env
-        options["pre_args"] = pre_args if pre_args else options["pre_args"] = []
-        options["post_args"] = post_args if post_args else options["post_args"] = []
+        if pre_args:
+            options["pre_args"] = pre_args
+        else:
+            options["pre_args"] = []
+        if post_args:
+            options["post_args"] = post_args
+        else:
+            options["post_args"] = []
         super(ProcessRunnerTest, self).__init__(**options)
 
         self._test_context = None

--- a/testplan/testing/cpp/cppunit.py
+++ b/testplan/testing/cpp/cppunit.py
@@ -107,28 +107,19 @@ class Cppunit(ProcessRunnerTest):
         else:
             return os.path.join(self._runpath, "report.xml")
 
-    def test_command(self):
+    def _test_command(self):
         cmd = [self.cfg.binary]
         if self.cfg.filtering_flag and self.cfg.cppunit_filter:
             cmd.extend([self.cfg.filtering_flag, self.cfg.cppunit_filter])
         if self.cfg.file_output_flag:
             cmd.extend([self.cfg.file_output_flag, self.report_path])
-        if self.cfg.pre_args:
-            cmd = [*self.cfg.pre_args, *cmd]
-        if self.cfg.post_args:
-            cmd.extend(self.cfg.post_args)
         return cmd
 
-    def list_command(self):
+    def _list_command(self):
         if self.cfg.listing_flag:
-            cmd = [self.cfg.binary, self.cfg.listing_flag]
+            return [self.cfg.binary, self.cfg.listing_flag]
         else:
-            cmd = super(Cppunit, self).list_command()
-        if self.cfg.pre_args:
-            cmd = [*self.cfg.pre_args, *cmd]
-        if self.cfg.post_args:
-            cmd.extend(self.cfg.post_args)
-        return cmd
+            return super(Cppunit, self)._list_command()
 
     def read_test_data(self):
 

--- a/testplan/testing/cpp/cppunit.py
+++ b/testplan/testing/cpp/cppunit.py
@@ -113,13 +113,22 @@ class Cppunit(ProcessRunnerTest):
             cmd.extend([self.cfg.filtering_flag, self.cfg.cppunit_filter])
         if self.cfg.file_output_flag:
             cmd.extend([self.cfg.file_output_flag, self.report_path])
+        if self.cfg.pre_args:
+            cmd = [*self.cfg.pre_args, *cmd]
+        if self.cfg.post_args:
+            cmd.extend(self.cfg.post_args)
         return cmd
 
     def list_command(self):
         if self.cfg.listing_flag:
-            return [self.cfg.binary, self.cfg.listing_flag]
+            cmd = [self.cfg.binary, self.cfg.listing_flag]
         else:
-            return super(Cppunit, self).list_command()
+            cmd = super(Cppunit, self).list_command()
+        if self.cfg.pre_args:
+            cmd = [*self.cfg.pre_args, *cmd]
+        if self.cfg.post_args:
+            cmd.extend(self.cfg.post_args)
+        return cmd
 
     def read_test_data(self):
 

--- a/testplan/testing/cpp/gtest.py
+++ b/testplan/testing/cpp/gtest.py
@@ -121,19 +121,17 @@ class GTest(ProcessRunnerTest):
             cmd.append("--gtest_filter={}".format(self.cfg.gtest_filter))
         return cmd
 
-    def test_command(self):
+    def _test_command(self):
         cmd = self.base_command() + [
             "--gtest_output=xml:{}".format(self.report_path),
             "--gtest_death_test_style={}".format(
                 self.cfg.gtest_death_test_style
             ),
         ]
-
         if self.cfg.gtest_also_run_disabled_tests:
             cmd.append("--gtest_also_run_disabled_tests")
         if self.cfg.gtest_repeat > 1:
             cmd.append("--gtest_repeat={}".format(self.cfg.gtest_repeat))
-
         # TODO: Add integration with ShuffleSorter
         if self.cfg.gtest_shuffle:
             cmd.append("--gtest_shuffle")
@@ -141,28 +139,16 @@ class GTest(ProcessRunnerTest):
                 cmd.append(
                     "--gtest_random_seed={}".format(self.cfg.gtest_random_seed)
                 )
-
         if self.cfg.gtest_stream_result_to:
             cmd.append(
                 "--gtest_stream_result_to={}".format(
                     self.cfg.gtest_stream_result_to
                 )
             )
-
-        if self.cfg.pre_args:
-            cmd = [*self.cfg.pre_args, *cmd]
-        if self.cfg.post_args:
-            cmd.extend(self.cfg.post_args)
-
         return cmd
 
-    def list_command(self):
-        cmd = self.base_command() + ["--gtest_list_tests"]
-        if self.cfg.pre_args:
-            cmd = [*self.cfg.pre_args, *cmd]
-        if self.cfg.post_args:
-            cmd.extend(self.cfg.post_args)
-        return cmd
+    def _list_command(self):
+        return self.base_command() + ["--gtest_list_tests"]
 
     def read_test_data(self):
         importer = GTestResultImporter(self.report_path)

--- a/testplan/testing/cpp/gtest.py
+++ b/testplan/testing/cpp/gtest.py
@@ -149,10 +149,20 @@ class GTest(ProcessRunnerTest):
                 )
             )
 
+        if self.cfg.pre_args:
+            cmd = [*self.cfg.pre_args, *cmd]
+        if self.cfg.post_args:
+            cmd.extend(self.cfg.post_args)
+
         return cmd
 
     def list_command(self):
-        return self.base_command() + ["--gtest_list_tests"]
+        cmd = self.base_command() + ["--gtest_list_tests"]
+        if self.cfg.pre_args:
+            cmd = [*self.cfg.pre_args, *cmd]
+        if self.cfg.post_args:
+            cmd.extend(self.cfg.post_args)
+        return cmd
 
     def read_test_data(self):
         importer = GTestResultImporter(self.report_path)

--- a/testplan/testing/cpp/hobbestest.py
+++ b/testplan/testing/cpp/hobbestest.py
@@ -81,10 +81,18 @@ class HobbesTest(ProcessRunnerTest):
             cmd.append("--tests")
             cmd += self.cfg.tests
         cmd += self.cfg.other_args
+        if self.cfg.pre_args:
+            cmd = [*self.cfg.pre_args, *cmd]
+        if self.cfg.post_args:
+            cmd.extend(self.cfg.post_args)
         return cmd
 
     def list_command(self):
         cmd = [self.cfg.binary, "--list"]
+        if self.cfg.pre_args:
+            cmd = [*self.cfg.pre_args, *cmd]
+        if self.cfg.post_args:
+            cmd.extend(self.cfg.post_args)
         return cmd
 
     def read_test_data(self):

--- a/testplan/testing/cpp/hobbestest.py
+++ b/testplan/testing/cpp/hobbestest.py
@@ -75,24 +75,16 @@ class HobbesTest(ProcessRunnerTest):
         options["proc_cwd"] = os.path.dirname(options["binary"])
         super(HobbesTest, self).__init__(**options)
 
-    def test_command(self):
+    def _test_command(self):
         cmd = [self.cfg.binary] + ["--json", self.report_path]
         if self.cfg.tests:
             cmd.append("--tests")
             cmd += self.cfg.tests
         cmd += self.cfg.other_args
-        if self.cfg.pre_args:
-            cmd = [*self.cfg.pre_args, *cmd]
-        if self.cfg.post_args:
-            cmd.extend(self.cfg.post_args)
         return cmd
 
-    def list_command(self):
+    def _list_command(self):
         cmd = [self.cfg.binary, "--list"]
-        if self.cfg.pre_args:
-            cmd = [*self.cfg.pre_args, *cmd]
-        if self.cfg.post_args:
-            cmd.extend(self.cfg.post_args)
         return cmd
 
     def read_test_data(self):

--- a/testplan/testing/junit.py
+++ b/testplan/testing/junit.py
@@ -75,19 +75,14 @@ class JUnit(ProcessRunnerTest):
         super(JUnit, self).__init__(**options)
         self._results_dir = None
 
-    def test_command(self):
-        cmd = (
+    def _test_command(self):
+        return (
             [self.cfg.binary]
             + (self.cfg.junit_args or [])
             + (self.cfg.junit_filter or [])
         )
-        if self.cfg.pre_args:
-            cmd = [*self.cfg.pre_args, *cmd]
-        if self.cfg.post_args:
-            cmd.extend(self.cfg.post_args)
-        return cmd
 
-    def list_command(self):
+    def _list_command(self):
         """JUnit test does not support filtering."""
         return None
 

--- a/testplan/testing/junit.py
+++ b/testplan/testing/junit.py
@@ -76,11 +76,16 @@ class JUnit(ProcessRunnerTest):
         self._results_dir = None
 
     def test_command(self):
-        return (
+        cmd = (
             [self.cfg.binary]
             + (self.cfg.junit_args or [])
             + (self.cfg.junit_filter or [])
         )
+        if self.cfg.pre_args:
+            cmd = [*self.cfg.pre_args, *cmd]
+        if self.cfg.post_args:
+            cmd.extend(self.cfg.post_args)
+        return cmd
 
     def list_command(self):
         """JUnit test does not support filtering."""

--- a/tests/functional/testplan/testing/cpp/test_cppunit.py
+++ b/tests/functional/testplan/testing/cpp/test_cppunit.py
@@ -72,3 +72,100 @@ def test_cppunit_no_report(mockplan):
     assert mockplan.run().run is True
     assert mockplan.report.status == Status.ERROR
     assert "FileNotFoundError" in mockplan.report.flattened_logs[-1]["message"]
+
+
+def test_cppunit_custom_args():
+    pre_cmd = ["echo", '"Hi"']
+    post_cmd = ["echo", '"Bye"']
+    pre_cmds = pre_cmd + ["echo", "it's a pre arg"]
+    post_cmds = post_cmd + ["echo", "it's a post arg"]
+
+    binary_path = os.path.join(
+        "..",
+        "..",
+        "..",
+        "..",
+        "..",
+        "examples",
+        "Cpp",
+        "Cppunit",
+        "test",
+        "runTests",
+    )
+
+    default_runner = Cppunit(name="Default cppunit test", binary=binary_path)
+    default_runner.run()
+
+    assert default_runner.test_command() == default_runner._test_command()
+    assert not default_runner.list_command()
+
+    default_runner = Cppunit(
+        name="Default cppunit test", binary=binary_path, listing_flag="-l"
+    )
+    assert default_runner.list_command() == default_runner._list_command()
+
+    basic_runner = Cppunit(
+        name="Cppunit test with one pre and one post arg",
+        binary=binary_path,
+        pre_args=pre_cmd,
+        post_args=post_cmd,
+    )
+    basic_runner.run()
+
+    assert (
+        basic_runner.test_command()[0:2]
+        == basic_runner.cfg._options["pre_args"]
+    )
+    assert (
+        basic_runner.test_command()[-2:]
+        == basic_runner.cfg._options["post_args"]
+    )
+    assert not basic_runner.list_command()
+    basic_runner = Cppunit(
+        name="Cppunit test with one pre and one post arg",
+        binary=binary_path,
+        pre_args=pre_cmd,
+        post_args=post_cmd,
+        listing_flag="-l",
+    )
+    assert (
+        basic_runner.list_command()[0:2]
+        == basic_runner.cfg._options["pre_args"]
+    )
+    assert (
+        basic_runner.list_command()[-2:]
+        == basic_runner.cfg._options["post_args"]
+    )
+
+    extra_runner = Cppunit(
+        name="Cppunit test with pre args and post args",
+        binary=binary_path,
+        pre_args=pre_cmds,
+        post_args=post_cmds,
+    )
+    extra_runner.run()
+
+    assert (
+        extra_runner.test_command()[0:4]
+        == extra_runner.cfg._options["pre_args"]
+    )
+    assert (
+        extra_runner.test_command()[-4:]
+        == extra_runner.cfg._options["post_args"]
+    )
+    assert not extra_runner.list_command()
+    extra_runner = Cppunit(
+        name="Cppunit test with pre args and post args",
+        binary=binary_path,
+        pre_args=pre_cmds,
+        post_args=post_cmds,
+        listing_flag="-l",
+    )
+    assert (
+        extra_runner.list_command()[0:4]
+        == extra_runner.cfg._options["pre_args"]
+    )
+    assert (
+        extra_runner.list_command()[-4:]
+        == extra_runner.cfg._options["post_args"]
+    )

--- a/tests/functional/testplan/testing/cpp/test_gtest.py
+++ b/tests/functional/testplan/testing/cpp/test_gtest.py
@@ -70,3 +70,79 @@ def test_gtest_no_report(mockplan):
     assert mockplan.run().run is True
     assert mockplan.report.status == Status.ERROR
     assert "FileNotFoundError" in mockplan.report.flattened_logs[-1]["message"]
+
+
+def test_gtest_custom_args():
+    pre_cmd = ["echo", '"Hi"']
+    post_cmd = ["echo", '"Bye"']
+    pre_cmds = pre_cmd + ["echo", "it's a pre arg"]
+    post_cmds = post_cmd + ["echo", "it's a post arg"]
+
+    binary_path = os.path.join(
+        "..",
+        "..",
+        "..",
+        "..",
+        "..",
+        "examples",
+        "Cpp",
+        "GTest",
+        "test",
+        "runTests",
+    )
+
+    default_runner = GTest(name="Default GTest test", binary=binary_path)
+    default_runner.run()
+
+    assert default_runner.test_command() == default_runner._test_command()
+    assert default_runner.list_command() == default_runner._list_command()
+
+    basic_runner = GTest(
+        name="GTest test with one pre and one post arg",
+        binary=binary_path,
+        pre_args=pre_cmd,
+        post_args=post_cmd,
+    )
+    basic_runner.run()
+
+    assert (
+        basic_runner.test_command()[0:2]
+        == basic_runner.cfg._options["pre_args"]
+    )
+    assert (
+        basic_runner.test_command()[-2:]
+        == basic_runner.cfg._options["post_args"]
+    )
+    assert (
+        basic_runner.list_command()[0:2]
+        == basic_runner.cfg._options["pre_args"]
+    )
+    assert (
+        basic_runner.list_command()[-2:]
+        == basic_runner.cfg._options["post_args"]
+    )
+
+    extra_runner = GTest(
+        name="GTest test with pre args and post args",
+        binary=binary_path,
+        pre_args=pre_cmds,
+        post_args=post_cmds,
+    )
+    extra_runner.run()
+
+    assert (
+        extra_runner.test_command()[0:4]
+        == extra_runner.cfg._options["pre_args"]
+    )
+    assert (
+        extra_runner.test_command()[-4:]
+        == extra_runner.cfg._options["post_args"]
+    )
+    assert (
+        extra_runner.list_command()[0:4]
+        == extra_runner.cfg._options["pre_args"]
+    )
+    assert (
+        extra_runner.list_command()[-4:]
+        == extra_runner.cfg._options["post_args"]
+    )

--- a/tests/functional/testplan/testing/cpp/test_hobbestest.py
+++ b/tests/functional/testplan/testing/cpp/test_hobbestest.py
@@ -92,3 +92,81 @@ def test_hobbestest_listing(binary_dir, expected_output):
             print(log_capture.output)
             assert log_capture.output == expected_output
             assert len(result.test_report) == 0, "No tests should be run."
+
+
+def test_hobbestest_custom_args():
+    pre_cmd = ["echo", '"Hi"']
+    post_cmd = ["echo", '"Bye"']
+    pre_cmds = pre_cmd + ["echo", "it's a pre arg"]
+    post_cmds = post_cmd + ["echo", "it's a post arg"]
+
+    binary_path = os.path.join(
+        "..",
+        "..",
+        "..",
+        "..",
+        "..",
+        "examples",
+        "Cpp",
+        "HobbesTest",
+        "test",
+        "hobbes-test",
+    )
+
+    default_runner = HobbesTest(
+        name="Default HobbesTest test", binary=binary_path
+    )
+    default_runner.run()
+
+    assert default_runner.test_command() == default_runner._test_command()
+    assert default_runner.list_command() == default_runner._list_command()
+
+    basic_runner = HobbesTest(
+        name="HobbesTest test with one pre and one post arg",
+        binary=binary_path,
+        pre_args=pre_cmd,
+        post_args=post_cmd,
+    )
+    basic_runner.run()
+
+    assert (
+        basic_runner.test_command()[0:2]
+        == basic_runner.cfg._options["pre_args"]
+    )
+    assert (
+        basic_runner.test_command()[-2:]
+        == basic_runner.cfg._options["post_args"]
+    )
+    assert (
+        basic_runner.list_command()[0:2]
+        == basic_runner.cfg._options["pre_args"]
+    )
+    assert (
+        basic_runner.list_command()[-2:]
+        == basic_runner.cfg._options["post_args"]
+    )
+
+    extra_runner = HobbesTest(
+        name="HobbesTest test with pre args and post args",
+        binary=binary_path,
+        pre_args=pre_cmds,
+        post_args=post_cmds,
+    )
+    extra_runner.run()
+
+    assert (
+        extra_runner.test_command()[0:4]
+        == extra_runner.cfg._options["pre_args"]
+    )
+    assert (
+        extra_runner.test_command()[-4:]
+        == extra_runner.cfg._options["post_args"]
+    )
+    assert (
+        extra_runner.list_command()[0:4]
+        == extra_runner.cfg._options["pre_args"]
+    )
+    assert (
+        extra_runner.list_command()[-4:]
+        == extra_runner.cfg._options["post_args"]
+    )

--- a/tests/functional/testplan/testing/junit/test_junit.py
+++ b/tests/functional/testplan/testing/junit/test_junit.py
@@ -132,3 +132,53 @@ def test_run_test(mockplan):
     assert len(mt_report.entries) == 3
 
     check_report(expect_report, mt_report)
+
+
+def test_custom_args():
+    pre_cmd = ["echo", '"Hi"']
+    post_cmd = ["echo", '"Bye"']
+    pre_cmds = pre_cmd + ["echo", "it's a pre arg"]
+    post_cmds = post_cmd + ["echo", "it's a post arg"]
+
+    default_runner = junit.JUnit(
+        name="My Junit", binary=JUNIT_FAKE_BIN, results_dir=REPORT_PATH
+    )
+
+    assert default_runner.test_command() == default_runner._test_command()
+    assert not default_runner.list_command()
+
+    basic_runner = junit.JUnit(
+        name="My Junit",
+        binary=JUNIT_FAKE_BIN,
+        results_dir=REPORT_PATH,
+        pre_args=pre_cmd,
+        post_args=post_cmd,
+    )
+
+    assert (
+        basic_runner.test_command()[0:2]
+        == basic_runner.cfg._options["pre_args"]
+    )
+    assert (
+        basic_runner.test_command()[-2:]
+        == basic_runner.cfg._options["post_args"]
+    )
+    assert not basic_runner.list_command()
+
+    extra_runner = junit.JUnit(
+        name="My Junit",
+        binary=JUNIT_FAKE_BIN,
+        results_dir=REPORT_PATH,
+        pre_args=pre_cmds,
+        post_args=post_cmds,
+    )
+
+    assert (
+        extra_runner.test_command()[0:4]
+        == extra_runner.cfg._options["pre_args"]
+    )
+    assert (
+        extra_runner.test_command()[-4:]
+        == extra_runner.cfg._options["post_args"]
+    )
+    assert not extra_runner.list_command()


### PR DESCRIPTION
## Bug / Requirement Description
Some tests can take extra user parameters. However, they can't be added to the executable. The goal is to let ProcessRunnerTest based tests to pass user arguments to the executable in list and in execute mode as well.

## Solution description
ProcessRunnerTest's config was extended with two parameters (pre_args and post_args) that meant to be prepended and appended to the list of args to the test runnable in list_command and test_command methods. The original methods were made to private members of the class.

## Checklist:
- [x] Test
- [x] News fragment present for release notes
- [x] MS info leakage check
