### PR TITLE
Enable users to add customized exporters after Testplan is initialized

### DIFF
--- a/doc/newsfragments/add_exporters.feature.rst
+++ b/doc/newsfragments/add_exporters.feature.rst
@@ -1,0 +1,1 @@
+* Enables users to add customized exporters after Testplan is initialized by calling :py:meth:`plan.add_exporters([exporter1, exporter2, ...]) <testplan.runnable.base.TestRunner.add_exporters>`.

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -7,7 +7,7 @@ pytz
 lxml
 python-dateutil
 reportlab
-marshmallow==3.0.0b2
+marshmallow==3.11.1
 termcolor
 colorama
 pyzmq

--- a/testplan/exporters/testing/json/__init__.py
+++ b/testplan/exporters/testing/json/__init__.py
@@ -5,7 +5,6 @@ for `dict` serialization and JSON conversion.
 
 import os
 import json
-import copy
 import pathlib
 import hashlib
 

--- a/testplan/importers/cppunit.py
+++ b/testplan/importers/cppunit.py
@@ -6,7 +6,7 @@ from lxml import objectify, etree
 from lxml.builder import E
 from lxml.objectify import Element
 
-from testplan.importers import ResultImporter, ImportedResult
+from testplan.importers import ImportedResult
 from testplan.importers.base import ThreePhaseFileImporter, T
 from testplan.importers.suitesresults import SuitesResult
 

--- a/testplan/importers/gtest.py
+++ b/testplan/importers/gtest.py
@@ -3,12 +3,11 @@ from typing import List
 from lxml import objectify
 from lxml.objectify import Element
 
-from testplan.importers import ImportedResult, ResultImporter
+from testplan.importers import ImportedResult
 from testplan.importers.base import T, ThreePhaseFileImporter
 from testplan.importers.suitesresults import SuitesResult
 from testplan.report import (
     TestGroupReport,
-    TestReport,
     ReportCategories,
     TestCaseReport,
     RuntimeStatus,

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -832,7 +832,10 @@ class TestCaseReport(Report):
         """
         Shortcut for checking if report status should be considered failed.
         """
-        return Status.STATUS_CATEGORY[self.status] == Status.FAILED
+        return Status.STATUS_CATEGORY[self.status] in (
+            Status.FAILED,
+            Status.ERROR,
+        )
 
     @property
     def unstable(self):

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -325,7 +325,7 @@ class TestRunner(Runnable):
     def exporters(self):
         """
         Return a list of
-        :py:class:`Resources <testplan.exporters.testing.base.Exporter>`.
+        :py:class:`report exporters <testplan.exporters.testing.base.Exporter>`.
         """
         if self._exporters is None:
             self._exporters = self.get_default_exporters()
@@ -405,14 +405,26 @@ class TestRunner(Runnable):
             resource, uid=uid or getattr(resource, "uid", strings.uuid4)()
         )
 
+    def add_exporters(self, exporters):
+        """
+        Add a list of
+        :py:class:`report exporters <testplan.exporters.testing.base.Exporter>`
+        for outputting test report.
+
+        :param exporters: Test exporters to be added.
+        :type exporters: ``list`` of :py:class:`~testplan.runners.base.Executor`
+        """
+        self.cfg.exporters.extend(get_exporters(exporters))
+
     def add_remote_service(self, remote_service):
         """
         Adds a remote service
         :py:class:`~testplan.common.remote.remote_service.RemoteService`
         object to test runner.
+
         :param remote_service: RemoteService object
-        :param uid:
-        :return:
+        :param remote_service:
+            :py:class:`~testplan.common.remote.remote_service.RemoteService`
         """
         name = remote_service.cfg.name
         if name in self.remote_services:

--- a/testplan/testing/cpp/gtest.py
+++ b/testplan/testing/cpp/gtest.py
@@ -1,16 +1,6 @@
 from schema import Or
-from lxml import objectify
 
 from testplan.common.config import ConfigOption
-
-from testplan.report import (
-    TestGroupReport,
-    TestCaseReport,
-    ReportCategories,
-    RuntimeStatus,
-)
-from testplan.testing.multitest.entries.assertions import RawAssertion
-from testplan.testing.multitest.entries.schemas.base import registry
 
 from ..base import ProcessRunnerTest, ProcessRunnerTestConfig
 from ...importers.gtest import GTestResultImporter
@@ -60,7 +50,7 @@ class GTest(ProcessRunnerTest):
     https://github.com/google/googletest/blob/master/googletest/docs/AdvancedGuide.md
     https://github.com/google/googletest/blob/master/googletest/docs/FAQ.md
 
-    Most of the configuratin options of GTest are
+    Most of the configuration options of GTest are
     just simple wrappers for native arguments.
 
     :param name: Test instance name, often used as uid of test entity.


### PR DESCRIPTION
* We can add exporters by comman line options, or programmtically
  define them in @test_plan decorator, however, all these things
  happen before Testplan instance is initialized. Sometimes user
  cannot decide the arguments for exporters at the beginning, so
  we should allow them add exporters later in a more dynamic way.
* Fix the `@failed` property of `TestCasereport`.
* Fix some typo.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
