### PR TITLE
Fix unit test `test_restart` that may fail on Windows

### DIFF
--- a/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
+++ b/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
@@ -312,10 +312,14 @@ def test_stdin(runpath):
     assert stdout == "Repeat me\n"
 
 
-def test_restart():
+def test_restart(runpath):
     """Test restart of an App"""
     app = App(
-        name="Restarter", binary="echo", args=["Restarter app ran succesfully"]
+        name="Restarter",
+        binary="echo",
+        args=["Restarter app ran succesfully"],
+        shell=True,
+        runpath=runpath,
     )
 
     app.start()
@@ -345,6 +349,7 @@ def test_restart():
 
         if does_exist_new_stdout and does_exist_new_stderr:
             break
+
     assert does_exist_new_stdout and does_exist_new_stderr
 
 


### PR DESCRIPTION
* This test can run on linux, however may fail on Windows since that
  echo is a Windows cmd built-in, but on Linux it's a binary in $PATH
  so `shell=True` should be specified for `subprocess.Popen`.
* Specify `runpath` from PyTest config, just like other unit tests.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
