### PR TITLE
Check workspace availability on remote up-front.

### DIFF
--- a/doc/newsfragments/fix_runpath_in_ws.rst
+++ b/doc/newsfragments/fix_runpath_in_ws.rst
@@ -1,0 +1,1 @@
+* Fix a corner case for :py:class:`~testplan.common.remote.remote_resource.RemoteResource` and its inheritances that runpath might be under workspace.


### PR DESCRIPTION
There is a conner case that runpath is inside the workspace and when we create remote runpath, the workspace
availability check returns false positive.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
