### PR TITLE
No longer check if self.cfg.binary exists in ProcessRunnerTest run_te…

### DIFF
--- a/doc/newsfragments/fix_gtest_binary_check.rst
+++ b/doc/newsfragments/fix_gtest_binary_check.rst
@@ -1,0 +1,1 @@
+* ProcessRunnerTest no longer checks if self.cfg.binary exists, as the inheritances might derive actual binary path.

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -680,13 +680,6 @@ class ProcessRunnerTest(Test):
                 self.stderr, "w"
             ) as stderr, open(self.stdout, "w") as stdout:
 
-                if not os.path.exists(self.cfg.binary):
-                    raise IOError(
-                        "No runnable found at {} for {}".format(
-                            self.cfg.binary, self
-                        )
-                    )
-
                 test_cmd = self.test_command()
                 if not test_cmd:
                     raise ValueError(


### PR DESCRIPTION
…sts(),

as the inheritances might derive actually binary path internally.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
