### PR TITLE
Support timeout on setup and teardown methods in a test suite

### DIFF
--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -1345,13 +1345,31 @@ If testcases are susceptible to hanging, or not expected to be time consuming, y
 
 .. code-block:: python
 
-    @testcase(timeout=10*60)  # 10 minute timeout, given in seconds.
+    @testcase(timeout=10*60)  # 10 minutes timeout, given in seconds.
     def test_hanging(self, env, result):
         ...
 
 If the testcase times out it will raise a :py:class:`TimeoutException <testplan.common.utils.timing.TimeoutException>`, causing its status to be "ERROR". The timeout will be noted on the report in the same way as any other unhandled Exception. The timeout parameter can be combined with other testcase parameters (e.g. used with parametrized testcases) in the way you would expect - each individual parametrized testcase will be subject to a seperate timeout.
 
 Also keep in mind that testplan will take a little bit of effort to monitor execution time of testcases with ``timeout`` attribute, so it is better to allocate a little more seconds than you have estimated how long a testcase would need.
+
+Similarly, ``setup`` and ``teardown`` methods in a test suite can be limited to run in specified time period, like this:
+
+.. code-block:: python
+
+    from testplan.testing.multitest.suite import timeout
+
+.. code-block:: python
+
+    @timeout(120)  # 2 minutes timeout, given in seconds.
+    def setup(self, env, result):
+        ...
+
+    @timeout(60)  # 1 minute timeout, given in seconds.
+    def teardown(self, env):
+        ...
+
+It's useful when ``setup`` has much initialization work that takes long, e.g. connects to a server but has no response and makes program hanging. Note that this ``@timeout`` decorator can also be used for ``pre_testcase`` and ``post_testcase``, but that is not suggested because pre/post testcase methods are called everytime before/after each testcase runs, they should be written as simple as possible.
 
 Xfail
 -----

--- a/doc/newsfragments/setup_teardown_timeout.rst
+++ b/doc/newsfragments/setup_teardown_timeout.rst
@@ -1,0 +1,20 @@
+* ``setup`` and ``teardown`` methods in test suites are timeout configurable to avoid program from hanging.
+
+    .. code-block:: python
+
+        from testplan.testing.multitest.suite import timeout
+
+        @testsuite
+        class MySuite(object):
+
+            @timeout(300)
+            def setup(self, env, result):
+                ...
+
+            @testcase(timeout=120)
+            def test_example(self, env, result):
+                ...
+
+            @timeout(60)
+            def teardown(self, env, result):
+                ...

--- a/testplan/common/utils/timing.py
+++ b/testplan/common/utils/timing.py
@@ -86,7 +86,7 @@ class KThread(threading.Thread):
 
 def timeout(seconds, err_msg="Timeout after {} seconds."):
     """
-    Decorator for a normal funtion to limit its execution time.
+    Decorator for a normal function to limit its execution time.
 
     :param seconds: Time limit for task execution.
     :type seconds: ``int``
@@ -97,7 +97,7 @@ def timeout(seconds, err_msg="Timeout after {} seconds."):
     """
 
     def timeout_decorator(func):
-        """"""
+        """The real decorator used for setup, teardown and testcase methods."""
 
         def _new_func(result, old_func, old_func_args, old_func_kwargs):
             try:

--- a/testplan/testing/multitest/__init__.py
+++ b/testplan/testing/multitest/__init__.py
@@ -1,4 +1,4 @@
 """Multitest main test execution framework."""
 
 from .base import MultiTest
-from .suite import testcase, testsuite, xfail
+from .suite import testcase, testsuite, xfail, timeout

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -222,7 +222,7 @@ class MultiTest(testing_base.Test):
         result=result.Result,
         fix_spec_path=None,
         testcase_report_target=True,
-        **options
+        **options,
     ):
         self._tags_index = None
 
@@ -893,16 +893,16 @@ class MultiTest(testing_base.Test):
         """
         return self._run_suite_related(testsuite, "teardown")
 
-    def _run_suite_related(self, testsuite, method):
+    def _run_suite_related(self, testsuite, method_name):
         """Runs testsuite related special methods setup/teardown/etc."""
-        testsuite_method = getattr(testsuite, method, None)
+        testsuite_method = getattr(testsuite, method_name, None)
         if testsuite_method is None:
             return None
         elif not callable(testsuite_method):
-            raise TypeError("{} expected to be callable.".format(method))
+            raise TypeError("{} expected to be callable.".format(method_name))
 
         method_report = TestCaseReport(
-            name=method, uid=method, suite_related=True
+            name=method_name, uid=method_name, suite_related=True
         )
         case_result = self.cfg.result(
             stdout_style=self.stdout_style, _scratch=self._scratch
@@ -919,7 +919,18 @@ class MultiTest(testing_base.Test):
 
         with method_report.timer.record("run"):
             with method_report.logged_exceptions():
-                testsuite_method(*method_args)
+                time_restriction = getattr(testsuite_method, "timeout", None)
+                if time_restriction:
+                    # pylint: disable=unbalanced-tuple-unpacking
+                    executed, execution_result = timing.timeout(
+                        time_restriction,
+                        f"`{method_name}` timeout after {{}} second(s)",
+                    )(testsuite_method)(*method_args)
+                    if not executed:
+                        method_report.logger.error(execution_result)
+                        method_report.status_override = Status.ERROR
+                else:
+                    testsuite_method(*method_args)
 
         method_report.extend(case_result.serialized_entries)
         method_report.attachments.extend(case_result.attachments)
@@ -933,17 +944,29 @@ class MultiTest(testing_base.Test):
             interface.check_signature(
                 method, ["self", "name", "env", "result"]
             )
-            method(testcase.name, resources, case_result)
+            method_args = (testcase.name, resources, case_result)
         except interface.MethodSignatureMismatch:
             interface.check_signature(
                 method, ["self", "name", "env", "result", "kwargs"]
             )
-            method(
+            method_args = (
                 testcase.name,
                 resources,
                 case_result,
                 getattr(testcase, "_parametrization_kwargs", {}),
             )
+
+        time_restriction = getattr(method, "timeout", None)
+        if time_restriction:
+            # pylint: disable=unbalanced-tuple-unpacking
+            executed, execution_result = timing.timeout(
+                time_restriction,
+                f"`{method.__name__}` timeout after {{}} second(s)",
+            )(method)(*method_args)
+            if not executed:
+                raise Exception(execution_result)
+        else:
+            method(*method_args)
 
     def _run_testcase(
         self, testcase, pre_testcase, post_testcase, testcase_report=None
@@ -975,7 +998,8 @@ class MultiTest(testing_base.Test):
                 if time_restriction:
                     # pylint: disable=unbalanced-tuple-unpacking
                     executed, execution_result = timing.timeout(
-                        time_restriction, "Testcase timeout after {} second(s)"
+                        time_restriction,
+                        f"`{testcase.name}` timeout after {{}} second(s)",
                     )(testcase)(resources, case_result)
                     if not executed:
                         testcase_report.logger.error(execution_result)
@@ -983,7 +1007,6 @@ class MultiTest(testing_base.Test):
                 else:
                     testcase(resources, case_result)
 
-            with testcase_report.logged_exceptions():
                 if post_testcase and callable(post_testcase):
                     self._run_case_related(
                         post_testcase, testcase, resources, case_result

--- a/testplan/testing/multitest/suite.py
+++ b/testplan/testing/multitest/suite.py
@@ -840,3 +840,20 @@ def xfail(reason, strict=False):
         return test
 
     return _xfail_test
+
+
+def timeout(seconds):
+    """
+    Decorator for non-testcase method in a test suite, can be used for
+    setup, teardown, pre_testcase and post_testcase.
+    """
+
+    assert (
+        isinstance(seconds, int) and seconds > 0
+    ), "Invalid use of `suite.timeout`, argument must be a positive integer"
+
+    def inner(function):
+        function.timeout = seconds
+        return function
+
+    return inner

--- a/tests/functional/testplan/testing/multitest/test_timeout_on_testcases.py
+++ b/tests/functional/testplan/testing/multitest/test_timeout_on_testcases.py
@@ -1,6 +1,6 @@
 import time
 
-from testplan.testing.multitest import MultiTest, testsuite, testcase
+from testplan.testing.multitest import MultiTest, testsuite, testcase, timeout
 
 from testplan.runners.pools.base import Pool as ThreadPool
 from testplan.runners.pools.tasks import Task
@@ -23,7 +23,7 @@ class Suite1:
     def test_normal(self, env, result):
         result.log("Testcase will finish execution in time")
 
-    @testcase(timeout=3)
+    @testcase(timeout=2)
     def test_abnormal(self, env, result):
         result.log("Testcase will definitely timeout")
         time.sleep(5)
@@ -33,22 +33,90 @@ class Suite1:
 class Suite2:
     """A test suite with parameterized testcases in different exec groups."""
 
-    @testcase(parameters=(1, 2, 3), execution_group="first", timeout=5)
-    def test_timeout_1(self, env, result, val):
+    @testcase(parameters=(1, 2, 0.5), execution_group="first", timeout=5)
+    def test_not_timeout(self, env, result, val):
         result.log("Testcase will sleep for {} seconds".format(val))
         time.sleep(val)
 
-    @testcase(parameters=(1, 2, 8), execution_group="second", timeout=3)
-    def test_timeout_2(self, env, result, val):
+    @testcase(parameters=(1, 0.5, 5), execution_group="second", timeout=2)
+    def test_timeout(self, env, result, val):
         result.log("Testcase will sleep for {} seconds".format(val))
         time.sleep(val)
 
 
-def get_mtest():
-    test = MultiTest(
-        name="MTest", suites=[Suite1(), Suite2()], thread_pool_size=2
+@testsuite
+class Suite3(object):
+    """A test suite with teardown method and it will timeout."""
+
+    @timeout(3)
+    def setup(self, env, result):
+        result.log("Setup method will sleep for 1 second")
+        time.sleep(1)
+
+    @testcase
+    def test_normal(self, env, result):
+        result.log("Testcase will finish execution in time")
+
+    @timeout(1)
+    def teardown(self, env):
+        time.sleep(3)
+
+
+@testsuite
+class Suite4(object):
+    """A test suite with setup method and it will timeout."""
+
+    @timeout(1)
+    def setup(self, env, result):
+        result.log("Setup method will sleep for 5 seconds")
+        time.sleep(5)
+
+    @testcase
+    def test_abnormal(self, env, result):
+        result.log("Testcase will never run")
+
+    def teardown(self, env, result):
+        result.log("Teardown method can still run")
+
+
+@testsuite
+class Suite5(object):
+    """A test suite with pre/post testcase methods which may not run."""
+
+    @timeout(3)
+    def pre_testcase(self, name, env, result):
+        result.log("Pre testcase method will always be OK")
+        time.sleep(1)
+
+    @timeout(2)
+    def post_testcase(self, name, env, result, kwargs):
+        val = kwargs.get("val")
+        if val < 2:
+            result.log("Post testcase method can still run")
+        time.sleep(val)
+
+    @testcase(parameters=(1, 5))
+    def test_method(self, env, result, val):
+        result.log(f"Get value {val}")
+        result.log("Testcase will finish in a short time")
+
+
+def get_mtest1():
+    return MultiTest(
+        name="MTest1", suites=[Suite1(), Suite2()], thread_pool_size=2
     )
-    return test
+
+
+def get_mtest2():
+    return MultiTest(
+        name="MTest2",
+        suites=[Suite3(), Suite4()],
+        stop_on_error=True,
+    )
+
+
+def get_mtest3():
+    return MultiTest(name="MTest3", suites=[Suite5()], stop_on_error=True)
 
 
 def _create_testcase_report(name, status_override=None, entries=None):
@@ -64,7 +132,7 @@ def test_timeout_on_testcases(mockplan):
     pool = ThreadPool(name="MyPool", size=2)
     mockplan.add_resource(pool)
 
-    task = Task(target=get_mtest())
+    task = Task(target=get_mtest1())
     mockplan.schedule(task, resource="MyPool")
 
     mockplan.run()
@@ -73,7 +141,7 @@ def test_timeout_on_testcases(mockplan):
         name="plan",
         entries=[
             TestGroupReport(
-                name="MTest",
+                name="MTest1",
                 category=ReportCategories.MULTITEST,
                 entries=[
                     TestGroupReport(
@@ -108,11 +176,11 @@ def test_timeout_on_testcases(mockplan):
                         category=ReportCategories.TESTSUITE,
                         entries=[
                             TestGroupReport(
-                                name="test_timeout_1",
+                                name="test_not_timeout",
                                 category=ReportCategories.PARAMETRIZATION,
                                 entries=[
                                     TestCaseReport(
-                                        name="test_timeout_1 <val=1>",
+                                        name="test_not_timeout <val=1>",
                                         entries=[
                                             {
                                                 "type": "Log",
@@ -121,7 +189,7 @@ def test_timeout_on_testcases(mockplan):
                                         ],
                                     ),
                                     TestCaseReport(
-                                        name="test_timeout_1 <val=2>",
+                                        name="test_not_timeout <val=2>",
                                         entries=[
                                             {
                                                 "type": "Log",
@@ -130,22 +198,22 @@ def test_timeout_on_testcases(mockplan):
                                         ],
                                     ),
                                     TestCaseReport(
-                                        name="test_timeout_1 <val=3>",
+                                        name="test_not_timeout <val=0.5>",
                                         entries=[
                                             {
                                                 "type": "Log",
-                                                "message": "Testcase will sleep for 3 seconds",
+                                                "message": "Testcase will sleep for 0.5 seconds",
                                             }
                                         ],
                                     ),
                                 ],
                             ),
                             TestGroupReport(
-                                name="test_timeout_2",
+                                name="test_timeout",
                                 category=ReportCategories.PARAMETRIZATION,
                                 entries=[
                                     TestCaseReport(
-                                        name="test_timeout_2 <val=1>",
+                                        name="test_timeout <val=1>",
                                         entries=[
                                             {
                                                 "type": "Log",
@@ -154,21 +222,21 @@ def test_timeout_on_testcases(mockplan):
                                         ],
                                     ),
                                     TestCaseReport(
-                                        name="test_timeout_2 <val=2>",
+                                        name="test_timeout <val=0.5>",
                                         entries=[
                                             {
                                                 "type": "Log",
-                                                "message": "Testcase will sleep for 2 seconds",
+                                                "message": "Testcase will sleep for 0.5 seconds",
                                             }
                                         ],
                                     ),
                                     _create_testcase_report(
-                                        name="test_timeout_2 <val=8>",
+                                        name="test_timeout <val=5>",
                                         status_override=Status.ERROR,
                                         entries=[
                                             {
                                                 "type": "Log",
-                                                "message": "Testcase will sleep for 8 seconds",
+                                                "message": "Testcase will sleep for 5 seconds",
                                             }
                                         ],
                                     ),
@@ -182,3 +250,167 @@ def test_timeout_on_testcases(mockplan):
     )
 
     check_report(expected_report, mockplan.report)
+
+
+def test_timeout_on_suite_related_methods(mockplan):
+
+    pool = ThreadPool(name="MyPool", size=1)
+    mockplan.add_resource(pool)
+
+    task = Task(target=get_mtest2())
+    mockplan.schedule(task, resource="MyPool")
+
+    mockplan.run()
+
+    expected_report = TestReport(
+        name="plan",
+        entries=[
+            TestGroupReport(
+                name="MTest2",
+                category=ReportCategories.MULTITEST,
+                entries=[
+                    TestGroupReport(
+                        name="Suite3",
+                        description="A test suite with teardown method and it will timeout.",
+                        category=ReportCategories.TESTSUITE,
+                        entries=[
+                            TestCaseReport(
+                                name="setup",
+                                entries=[
+                                    {
+                                        "type": "Log",
+                                        "message": "Setup method will sleep for 1 second",
+                                    }
+                                ],
+                            ),
+                            TestCaseReport(
+                                name="test_normal",
+                                entries=[
+                                    {
+                                        "type": "Log",
+                                        "message": "Testcase will finish execution in time",
+                                    }
+                                ],
+                            ),
+                            _create_testcase_report(
+                                name="teardown",
+                                status_override=Status.ERROR,
+                                entries=[],
+                            ),
+                        ],
+                    ),
+                    TestGroupReport(
+                        name="Suite4",
+                        description="A test suite with setup method and it will timeout.",
+                        category=ReportCategories.TESTSUITE,
+                        entries=[
+                            _create_testcase_report(
+                                name="setup",
+                                status_override=Status.ERROR,
+                                entries=[
+                                    {
+                                        "type": "Log",
+                                        "message": "Setup method will sleep for 5 seconds",
+                                    }
+                                ],
+                            ),
+                            TestCaseReport(
+                                name="teardown",
+                                entries=[
+                                    {
+                                        "type": "Log",
+                                        "message": "Teardown method can still run",
+                                    }
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+
+    check_report(expected_report, mockplan.report)
+
+
+def test_timeout_on_case_related_methods(mockplan):
+
+    pool = ThreadPool(name="MyPool", size=1)
+    mockplan.add_resource(pool)
+
+    task = Task(target=get_mtest3())
+    mockplan.schedule(task, resource="MyPool")
+
+    mockplan.run()
+
+    expected_report = TestReport(
+        name="plan",
+        entries=[
+            TestGroupReport(
+                name="MTest3",
+                category=ReportCategories.MULTITEST,
+                entries=[
+                    TestGroupReport(
+                        name="Suite5",
+                        description="A test suite with pre/post testcase methods which may not run.",
+                        category=ReportCategories.TESTSUITE,
+                        entries=[
+                            TestGroupReport(
+                                name="test_method",
+                                category=ReportCategories.PARAMETRIZATION,
+                                entries=[
+                                    TestCaseReport(
+                                        name="test_method <val=1>",
+                                        entries=[
+                                            {
+                                                "type": "Log",
+                                                "message": "Pre testcase method will always be OK",
+                                            },
+                                            {
+                                                "type": "Log",
+                                                "message": "Get value 1",
+                                            },
+                                            {
+                                                "type": "Log",
+                                                "message": "Testcase will finish in a short time",
+                                            },
+                                            {
+                                                "type": "Log",
+                                                "message": "Post testcase method can still run",
+                                            },
+                                        ],
+                                    ),
+                                    TestCaseReport(
+                                        name="test_method <val=5>",
+                                        entries=[
+                                            {
+                                                "type": "Log",
+                                                "message": "Pre testcase method will always be OK",
+                                            },
+                                            {
+                                                "type": "Log",
+                                                "message": "Get value 5",
+                                            },
+                                            {
+                                                "type": "Log",
+                                                "message": "Testcase will finish in a short time",
+                                            },
+                                        ],
+                                        status_override=Status.ERROR,
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+
+    check_report(expected_report, mockplan.report)
+    assert (
+        "`post_testcase` timeout"
+        in mockplan.report["MTest3"]["Suite5"]["test_method"][
+            "test_method__val_5"
+        ].logs[0]["message"]
+    )


### PR DESCRIPTION
* For each testcase, we can add `timeout` argument to restrict the
  execution time, however, suite related methods such as `setup`,
  `teardown`, `pre_testcase`, `post_testcase` can also take long,
  so user reuqest timeout feature on it. A new decorator is added
  in module `testplan.testing.multitest.suite`.
* Update document.
* Add testcases.


## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [x] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
