### PR TITLE
[WIP] Bug Fix: DEBUG log unexpectedly printed in interactive mode

### DIFF
--- a/testplan/common/utils/logger.py
+++ b/testplan/common/utils/logger.py
@@ -28,6 +28,7 @@ DRIVER_INFO = 27
 INFO = logging.INFO  # 20
 DEBUG = logging.DEBUG  # 10
 
+LOGGER_NAME = "TESTPLAN"
 LOGFILE_NAME = "testplan.log"
 LOGFILE_FORMAT = (
     "%(asctime)-24s %(processName)-12s %(threadName)-12s "
@@ -116,9 +117,10 @@ def _initial_setup():
     to stdout with default level TEST_INFO.
 
     :return: root logger object and stdout logging handler
+    :type: ``tuple``
     """
     logging.setLoggerClass(TestplanLogger)
-    root_logger = logging.getLogger("testplan")
+    root_logger = logging.getLogger(LOGGER_NAME)
 
     # Set the level of the root logger to DEBUG so that nothing is filtered out
     # by the logger itself - the handlers will perform filtering.
@@ -223,10 +225,9 @@ class Loggable:
         if self._logger:
             return self._logger
 
-        logger_name = ".".join(
-            ["testplan", self.__class__.__name__, uuid4()[-8:]]
+        self._logger = logging.getLogger(
+            ".".join([LOGGER_NAME, self.__class__.__name__, uuid4()[-8:]])
         )
-        self._logger = logging.getLogger(logger_name)
         return self._logger
 
     @property

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -782,7 +782,7 @@ class TestRunnerIHandler(entity.Entity):
                 "Interactive Testplan web service is not available"
             )
 
-        self.logger.debug(
+        self.logger.info(
             "\nInteractive Testplan API is running. View the API schema:\n%s",
             networking.format_access_urls(host, port, "/api/v1/interactive/"),
         )

--- a/tests/functional/testplan/test_timeout.py
+++ b/tests/functional/testplan/test_timeout.py
@@ -5,16 +5,6 @@ import psutil
 import subprocess
 import sys
 import tempfile
-import threading
-
-
-def _timeout_cbk(proc):
-    """
-    Callback function called if the testplan subprocess doesn't terminate in a
-    reasonable length of time.
-    """
-    proc.kill()
-    raise RuntimeError("Timeout popped.")
 
 
 def test_runner_timeout():
@@ -37,13 +27,12 @@ def test_runner_timeout():
         )
 
         # Set our own timeout so that we don't wait forever if the testplan
-        # script fails to timeout. 10 minutes ought to be long enough.
-        # In Python 3 we could wait() with a timeout, but this is not
-        # available in Python 2 so we need to roll our own timeout mechanism.
-        timer = threading.Timer(300, _timeout_cbk, args=[proc])
-        timer.start()
-        stdout, _ = proc.communicate()
-        timer.cancel()
+        # script fails to timeout. 5 minutes ought to be long enough.
+        try:
+            proc.communicate(timeout=300)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
 
         rc = proc.returncode
 
@@ -52,15 +41,16 @@ def test_runner_timeout():
 
         # Check that the testplan exited with an error status.
         assert rc == 1
+        assert len(report["entries"]) == 2
         assert report["status"] == "error"
         assert report["counter"]["error"] == 1
 
         # Check that the timeout is logged to stdout.
         if not re.search(
-            r"Timeout: Aborting execution after 5 seconds", stdout
+            r"Timeout: Aborting execution after 5 seconds",
+            report["logs"][0]["message"],
         ):
-            print(stdout)
-            raise RuntimeError("Timeout log not found in stdout")
+            raise RuntimeError("Timeout log not found")
 
         # Check that no extra child processes remain since before starting.
         assert current_proc.children() == start_procs

--- a/tests/functional/testplan/testing/multitest/test_logging.py
+++ b/tests/functional/testplan/testing/multitest/test_logging.py
@@ -13,6 +13,7 @@ from testplan.testing.multitest.logging import (
     AutoLogCaptureMixin,
 )
 from testplan.common.utils.testing import log_propagation_disabled
+from testplan.common.utils.logger import LOGGER_NAME as TESTPLAN_LOGGER_NAME
 
 SIMPLE_LOG = "Simple log"
 LOGGER_LEVEL_PATTERN = r"([^ ]*) *([^ ]*) *{}$".format(SIMPLE_LOG)
@@ -124,7 +125,7 @@ def auto_suite_logger_spy():
 
 @pytest.fixture
 def testplan_logger_spy():
-    return LoggerSpy(name="testplan")
+    return LoggerSpy(name=TESTPLAN_LOGGER_NAME)
 
 
 @pytest.fixture
@@ -225,9 +226,9 @@ def test_plan_level(
         message = case_result.entries[0]["message"]
         assert message.count(SIMPLE_LOG) == 2
         result = re.findall(LOGGER_LEVEL_PATTERN, message, re.M)
-        assert result[0][0].startswith("testplan.LoggingSuite")
+        assert result[0][0].startswith(f"{TESTPLAN_LOGGER_NAME}.LoggingSuite")
         assert result[0][1] == "INFO"
-        assert result[1:] == [("testplan", "DEBUG")]
+        assert result[1:] == [(TESTPLAN_LOGGER_NAME, "DEBUG")]
 
 
 def test_root_level(
@@ -252,9 +253,12 @@ def test_root_level(
         message = case_result.entries[0]["message"]
         assert message.count(SIMPLE_LOG) == 3
         result = re.findall(LOGGER_LEVEL_PATTERN, message, re.M)
-        assert result[0][0].startswith("testplan.LoggingSuite")
+        assert result[0][0].startswith(f"{TESTPLAN_LOGGER_NAME}.LoggingSuite")
         assert result[0][1] == "INFO"
-        assert result[1:] == [("testplan", "DEBUG"), ("root", "WARNING")]
+        assert result[1:] == [
+            (TESTPLAN_LOGGER_NAME, "DEBUG"),
+            ("root", "WARNING"),
+        ]
 
 
 def test_attach_log(get_filtered_plan, suite_logger_spy):
@@ -314,4 +318,4 @@ def test_log_propagation_disabled(
         assert case_result.entries[0]["type"] == "Log"
         message = case_result.entries[0]["message"]
         result = re.findall(LOGGER_LEVEL_PATTERN, message, re.M)
-        assert result[0] == ("testplan", "DEBUG")
+        assert result[0] == (TESTPLAN_LOGGER_NAME, "DEBUG")

--- a/tests/functional/testplan/timeout_test_plan.py
+++ b/tests/functional/testplan/timeout_test_plan.py
@@ -8,6 +8,13 @@ from testplan.testing import multitest
 
 
 @multitest.testsuite
+class NormalSuite:
+    @multitest.testcase
+    def case(self, env, result):
+        result.log("Run testcase.")
+
+
+@multitest.testsuite
 class TimeoutSuite:
     @multitest.testcase
     def blocks(self, env, result):
@@ -17,6 +24,7 @@ class TimeoutSuite:
 
 @test_plan(name="Timeout example", timeout=5)
 def main(plan):
+    plan.add(multitest.MultiTest(name="MTest", suites=[NormalSuite()]))
     plan.add(
         multitest.MultiTest(name="Timeout MTest", suites=[TimeoutSuite()])
     )


### PR DESCRIPTION
* Default `logger_level` is "TEST_INFO" for console printing, if '-v'
  specified in command line it is changed to "INFO",  with '-d' it is
  changed to "DEBUG". However, neither '-d' is passed to command line
  nor specified programmatically, there's always debug log printed if
  running Testplan in interactive mode. This a bug. The reason is that
  another output handler is binded to `sys.stderr` and it is added to
  the logger named "testplan", recently we've updated the version of
  Flask and correspondingly the restful framework, for each blueprint
  registered to flask app, there might be logger instances created
  according to the name of blueprint, unfortunately our blueprint has
  name "testplan", which means name conflict, we cannot change it or
  APIs will change. The easiest way to fix the issue is to modify the
  name of Testplan root logger. In our code we did not directly get
  this logger by name but import `TESTPLAN_LOGGER` from common utils.
* Also fix an issue that function definition is not correct since that
  it's used for handling signal.
* Update testcases.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
