### PR TITLE
use a boobytrap file for the suicide task in pool test

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -952,6 +952,7 @@ class Runnable(Entity):
         :param step: step to execute
         :type step: ``Callable``
         """
+        res = None
         try:
             res = step(*args, **kwargs)
         except Exception as exc:

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -1,6 +1,6 @@
 """MultiTest test execution framework."""
 
-import collections
+import collections.abc
 import concurrent
 import functools
 import itertools
@@ -35,7 +35,7 @@ from testplan.report import (
 
 def iterable_suites(obj):
     """Create an iterable suites object."""
-    suites = [obj] if not isinstance(obj, collections.Iterable) else obj
+    suites = [obj] if not isinstance(obj, collections.abc.Iterable) else obj
 
     # If multiple objects from one test suite class are added into a Multitest,
     # it's better provide naming function to avoid duplicate test suite names.

--- a/testplan/testing/multitest/logging.py
+++ b/testplan/testing/multitest/logging.py
@@ -137,6 +137,7 @@ class LogCaptureMixin(Loggable):
         :return: returns the suite level logger
         :rtype: logging.Logger
         """
+        info = None
         try:
             info = self._attach_handler(
                 result,
@@ -147,7 +148,8 @@ class LogCaptureMixin(Loggable):
 
             yield self.logger
         finally:
-            self._detach_handler(info)
+            if info:
+                self._detach_handler(info)
 
     def select_loggers(self, capture_level):
         if isinstance(capture_level, (tuple, list)):

--- a/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
+++ b/tests/functional/testplan/runners/pools/func_pool_base_tasks.py
@@ -1,6 +1,8 @@
 """Base Testplan Tasks shared by different functional tests."""
 
 import os
+from pathlib import Path
+
 import psutil
 import tempfile
 
@@ -45,14 +47,13 @@ def get_mtest_imported(name):
 
 @testsuite
 class SuiteKillingWorker:
-    def __init__(self, parent_pid, size):
-        self._parent_pid = parent_pid
-        self._size = size
+    def __init__(self, boobytrap_path: str):
+        self._boobytrap_path = Path(boobytrap_path)
 
     @testcase
     def test_comparison(self, env, result):
-        parent = psutil.Process(self._parent_pid)
-        if len(parent.children(recursive=False)) == self._size:
+        if self._boobytrap_path.exists():
+            self._boobytrap_path.unlink()
             print("Killing worker {}".format(os.getpid()))
             os.kill(os.getpid(), 9)
         result.equal(1, 1, "equality description")
@@ -62,10 +63,10 @@ class SuiteKillingWorker:
         assert env.parent.runpath.endswith(slugify(env.parent.cfg.name))
 
 
-def multitest_kill_one_worker(parent_pid, size):
+def multitest_kill_one_worker(boobytrap: str):
     """Test that kills one worker."""
     return MultiTest(
-        name="MTestKiller", suites=[SuiteKillingWorker(parent_pid, size)]
+        name="MTestKiller", suites=[SuiteKillingWorker(boobytrap)]
     )
 
 

--- a/tests/functional/testplan/runners/pools/test_pool_process.py
+++ b/tests/functional/testplan/runners/pools/test_pool_process.py
@@ -1,6 +1,7 @@
 """Process worker pool functional tests."""
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -21,7 +22,7 @@ def test_pool_basic(mockplan):
     )
 
 
-def test_kill_one_worker(mockplan):
+def test_kill_one_worker(mockplan, tmp_path: Path):
     """Kill one worker but pass after reassigning task."""
     pool_name = ProcessPool.__name__
     pool_size = 4
@@ -37,11 +38,14 @@ def test_kill_one_worker(mockplan):
 
     dirname = os.path.dirname(os.path.abspath(__file__))
 
+    boobytrap = tmp_path / "boobytrap"
+    boobytrap.touch()
+
     kill_uid = mockplan.schedule(
         target="multitest_kill_one_worker",
         module="func_pool_base_tasks",
         path=dirname,
-        args=(os.getpid(), pool_size),  # kills 4th worker
+        args=(str(boobytrap),),
         resource=pool_name,
     )
 


### PR DESCRIPTION
## Bug / Requirement Description
The number of child process used by this testcase is not deterministic, as another worker thread of the parent may starting other processes, so the number might be not the expected.

## Solution description
a temp file is created which signal the testsuite it need to commit
suicide. The file is removed before the suicide so next run of the same
task will be successful


## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
