### PR TITLE
clean up patched modulefinder after test properly

### DIFF
--- a/tests/unit/testplan/runnable/interactive/test_reloader.py
+++ b/tests/unit/testplan/runnable/interactive/test_reloader.py
@@ -193,7 +193,6 @@ def mock_reload_env():
             reloader._GraphModuleFinder.__bases__ = old_bases
 
 
-
 def test_dependency_reload(mock_reload_env):
     r"""
     Test reload of dependencies. We set up a module dependency structure

--- a/tests/unit/testplan/runnable/interactive/test_reloader.py
+++ b/tests/unit/testplan/runnable/interactive/test_reloader.py
@@ -180,13 +180,18 @@ def mock_reload_env():
         # Despite mocking modulefinder.ModuleFinder above, we also need to
         # swap out the real ModuleFinder with our mock one in the list of
         # bases for the GraphModuleFinder.
-        reloader._GraphModuleFinder.__bases__ = (
-            MockModuleFinder,
-            logger.Loggable,
-        )
-        reload_obj = reloader.ModuleReloader()
+        old_bases = reloader._GraphModuleFinder.__bases__
+        try:
+            reloader._GraphModuleFinder.__bases__ = (
+                MockModuleFinder,
+                logger.Loggable,
+            )
+            reload_obj = reloader.ModuleReloader()
 
-        yield reload_obj, mock_reload, mock_stat
+            yield reload_obj, mock_reload, mock_stat
+        finally:
+            reloader._GraphModuleFinder.__bases__ = old_bases
+
 
 
 def test_dependency_reload(mock_reload_env):


### PR DESCRIPTION
## Bug / Requirement Description
The patch is not reverted properly other tests, like test_interactive,
will use the mocked modulefinder, and fail if running after test_reloader in the same process. This could happen when
these tests are run parallel

## Solution description
restore the bases afet yield

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
