### PR TITLE
Allow user to access testcase report in testcase method

### DIFF
--- a/doc/newsfragments/report_in_testcase_method.rst
+++ b/doc/newsfragments/report_in_testcase_method.rst
@@ -1,0 +1,1 @@
+* Testcase report can be accessed from a testcase method through `env.runtime_info.testcase.report`.

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -72,6 +72,7 @@ class MultiTestRuntimeInfo:
 
     class TestcaseInfo:
         name = None
+        report = None
 
     def __init__(self):
         self.testcase = self.TestcaseInfo()
@@ -985,6 +986,7 @@ class MultiTest(testing_base.Test):
 
         runtime_info = MultiTestRuntimeInfo()
         runtime_info.testcase.name = testcase.name
+        runtime_info.testcase.report = testcase_report
         resources = RuntimeEnvironment(self.resources, runtime_info)
 
         with testcase_report.timer.record("run"):

--- a/tests/unit/testplan/testing/multitest/test_multitest.py
+++ b/tests/unit/testplan/testing/multitest/test_multitest.py
@@ -80,9 +80,10 @@ class Suite:
     def case(self, env, result):
         """Basic testcase."""
         result.true(True)
+        assert env.runtime_info.testcase.name == "case"
         assert (
-            env.runtime_info.testcase.name == "case"
-        )  # using pytest assert to check multitest runtime info
+            env.runtime_info.testcase.report.description == "Basic testcase."
+        )
 
     @multitest.testcase(parameters=[1, 2, 3])
     def parametrized(self, env, result, val):
@@ -91,6 +92,10 @@ class Suite:
         assert (
             env.runtime_info.testcase.name
             == "parametrized <val={}>".format(val)
+        )
+        assert (
+            env.runtime_info.testcase.report.description
+            == "Parametrized testcase."
         )
 
 
@@ -113,6 +118,7 @@ class ParallelSuite:
         self._barrier.wait()
         result.eq(0, 0)
         assert env.runtime_info.testcase.name == "case1"
+        assert env.runtime_info.testcase.report.description == "Testcase 1"
         self._barrier.wait()
 
     @multitest.testcase(execution_group="A")
@@ -121,6 +127,7 @@ class ParallelSuite:
         self._barrier.wait()
         result.eq(1, 1)
         assert env.runtime_info.testcase.name == "case2"
+        assert env.runtime_info.testcase.report.description == "Testcase 2"
         self._barrier.wait()
 
     @multitest.testcase(execution_group="A")
@@ -129,6 +136,7 @@ class ParallelSuite:
         self._barrier.wait()
         result.eq(2, 2)
         assert env.runtime_info.testcase.name == "case3"
+        assert env.runtime_info.testcase.report.description == "Testcase 3"
         self._barrier.wait()
 
     @multitest.testcase(execution_group="B", parameters=[1, 2, 3])


### PR DESCRIPTION
* Thus it is able to update some information about testcase (such as
  testcase description) while running testcases, because some details
  might be dynamically retrieved in testcase methods.
* Update testcases.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
