### PR TITLE
Fix an issue that pool monitor may make wrong action

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -380,6 +380,12 @@ class EntityStatus:
             msg = f"On status change from {current} to {new} - {exc}"
             raise StatusTransitionException(msg)
 
+    def reset(self):
+        """
+        Reset status as None.
+        """
+        self._current = self.NONE
+
     def update_metadata(self, **metadata):
         """
         Updates metadata.


### PR DESCRIPTION
* To make code robust, we have a testcase which start/stop a process
  pool from time to time, but we found that the pool monitor can make
  wrong decision. The monitor is started in the main loop, while all
  workers should start after ZMQ server is ready, When the pool is
  restarted, workers' status is STOPPED, the monitor might think that
  workers had died. Another thing is that when the pool wants to stop,
  workers will firstly stop to disconnect to ZMQ server, monitor may
  think that workers had died and aborts the pool, that's not correct,
  should check if the `_exit_loop` flag is changed to True.
* Update logs for pool and worker.
