### PR TITLE
Fix a corner case of remote pool execution

### DIFF
--- a/testplan/runners/pools/child.py
+++ b/testplan/runners/pools/child.py
@@ -280,9 +280,16 @@ class RemoteChildLoop(ChildLoop):
 
     def _pre_loop_setup(self, message):
         super(RemoteChildLoop, self)._pre_loop_setup(message)
-        self._setup_metadata = self._send_and_expect(
-            message, message.MetadataPull, message.Metadata
-        ).data
+
+        response = self._send_and_expect(
+            message, message.MetadataPull, [message.Metadata, message.Stop]
+        )
+
+        if response.cmd == message.Stop:
+            print("Stop message received, child exits.")
+            os._exit(0)
+
+        self._setup_metadata = response.data
 
         if self._setup_metadata.env:
             for key, value in self._setup_metadata.env.items():


### PR DESCRIPTION

## Bug / Requirement Description
When pool worker request for meta data, it is possible to receive pool stop cmd (especially in test).

## Solution description
Add check for this corner case.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
