### PR TITLE
Feature/junit exporter tpr

### DIFF
--- a/doc/newsfragments/add_junit_exporter.feature.rst
+++ b/doc/newsfragments/add_junit_exporter.feature.rst
@@ -1,0 +1,1 @@
+* Added JUnit exporter command ``tojunit`` to TPS utility tool.

--- a/testplan/cli/commands/writers.py
+++ b/testplan/cli/commands/writers.py
@@ -84,13 +84,13 @@ class ToPDFAction(ProcessResultAction, logger.Loggable):
     type=click.Choice(
         ["result", "summary", "extended", "detailed"], case_sensitive=False
     ),
-    help='''result - only the result of the run will be shown\n
+    help="""result - only the result of the run will be shown\n
             summary - test details will be shown\n
             extended - passing tests will include testcase detail,\
              while failing tests will include assertion detail\n
             detailed - passing tests will include assertion detail,\
              while failing tests will include assertion detail\n
-        ''',
+        """,
 )
 def to_pdf(filename: click.Path, pdf_style: click.Choice) -> ToPDFAction:
     """

--- a/testplan/cli/commands/writers.py
+++ b/testplan/cli/commands/writers.py
@@ -9,7 +9,7 @@ import click
 from testplan.cli.utils.actions import ProcessResultAction
 from testplan.cli.utils.command_list import CommandList
 from testplan.common.utils import logger
-from testplan.exporters.testing import JSONExporter, PDFExporter
+from testplan.exporters.testing import JSONExporter, PDFExporter, XMLExporter
 from testplan.report import TestReport
 from testplan.report.testing.styles import StyleArg
 from testplan.web_ui.server import WebUIServer
@@ -31,7 +31,7 @@ class ToJsonAction(ProcessResultAction):
 
     def __call__(self, result: TestReport) -> TestReport:
         """
-        :param result: testplan result to export
+        :param result: Testplan report to export
         """
         exporter = JSONExporter(json_path=self.output)
         exporter.export(result)
@@ -65,6 +65,9 @@ class ToPDFAction(ProcessResultAction, logger.Loggable):
         self.style = style
 
     def __call__(self, result: TestReport) -> TestReport:
+        """
+        :param result: Testplan report to export
+        """
         exporter = PDFExporter(
             pdf_path=self.filename, pdf_style=self.style.value
         )
@@ -81,11 +84,13 @@ class ToPDFAction(ProcessResultAction, logger.Loggable):
     type=click.Choice(
         ["result", "summary", "extended", "detailed"], case_sensitive=False
     ),
-    help="""result - only the result of the run will be shown\n
+    help='''result - only the result of the run will be shown\n
             summary - test details will be shown\n
-            extended - passing tests will include testcase detail, while failing tests will include assertion detail\n
-            detailed - passing tests will include assertion detail, while failing tests will include assertion detail\n
-        """,
+            extended - passing tests will include testcase detail,\
+             while failing tests will include assertion detail\n
+            detailed - passing tests will include assertion detail,\
+             while failing tests will include assertion detail\n
+        ''',
 )
 def to_pdf(filename: click.Path, pdf_style: click.Choice) -> ToPDFAction:
     """
@@ -102,6 +107,37 @@ def to_pdf(filename: click.Path, pdf_style: click.Choice) -> ToPDFAction:
         return ToPDFAction(filename=filename, style=StyleArg.EXTENDED_SUMMARY)
     elif pdf_style == "detailed":
         return ToPDFAction(filename=filename, style=StyleArg.DETAILED)
+
+
+class ToJUnitAction(ProcessResultAction, logger.Loggable):
+    """
+    Writer action for exporting JUnit XML format.
+    """
+
+    def __init__(self, dir_name: str) -> None:
+        """
+        :param dir_name: directory to write XML files to
+        """
+        logger.Loggable.__init__(self)
+        self.dir_name = dir_name
+
+    def __call__(self, result: TestReport) -> TestReport:
+        exporter = XMLExporter(xml_dir=self.dir_name)
+        exporter.export(result)
+        self.logger.test_info(f"XML files written to {self.dir_name}")
+        return result
+
+
+@writer_commands.command(name="tojunit")
+@click.argument("dir_name", required=True, type=click.Path())
+def to_junit(dir_name: click.Path) -> ToJUnitAction:
+    """
+    Writer command for exporting JUnit format.
+
+    :param dir_name: directory to write XML files to
+    :return: JUnit writer action to perform
+    """
+    return ToJUnitAction(dir_name=dir_name)
 
 
 class DisplayAction(ProcessResultAction):

--- a/testplan/exporters/testing/base.py
+++ b/testplan/exporters/testing/base.py
@@ -1,3 +1,4 @@
+""" TODO """
 """
 Implements base exporter objects.
 """
@@ -65,13 +66,13 @@ class TagFilteredExporter(Exporter):
 
     def get_exporter(self, **params) -> BaseExporter:
         """
-        Return a new instance of `exporter_class`,
-        initialized with given `params`.
+        Instantiates `exporter_class` with given `params`.
 
-        :param params: Keyword arguments that will be
-                       used for initializing `exporter_class`.
-        :return: Instance of `exporter_class`
+        :param params: keyword arguments used for initializing `exporter_class`
+        :return: instance of `exporter_class`
+        :raises AttributeError: if there is no exporter class set
         """
+        # TODO: shouldn't this be a TypeError for non-BaseExporter instance?
         if not self.exporter_class:
             raise AttributeError("`exporter_class` not set.")
 
@@ -94,6 +95,7 @@ class TagFilteredExporter(Exporter):
         :param source: Testplan report
         :param tag_dict: tag context for filtering
         :param filter_type: all / any
+        :return: filtered clone
         """
         tag_label = tagging.tag_label(tag_dict)
         result = source.filter_by_tags(
@@ -109,6 +111,8 @@ class TagFilteredExporter(Exporter):
         filter_type: str,
     ) -> str:
         """
+        Produces message logged if filtered clone is empty.
+
         :param source: cloned test report
         :param tag_dict: tag context for the current filtered test report
         :param filter_type: all / any
@@ -178,6 +182,7 @@ def save_attachments(report: TestReport, directory: str) -> Dict[str, str]:
 
     :param report: Testplan report.
     :param directory: directory to save attachments in
+    :return: dictionary of destination paths
     """
     moved_attachments = {}
     attachments = getattr(report, "attachments", None)

--- a/testplan/exporters/testing/base.py
+++ b/testplan/exporters/testing/base.py
@@ -1,4 +1,8 @@
+"""
+Implements base exporter objects.
+"""
 import os
+from typing import Dict, List, Optional
 from shutil import copyfile
 
 from schema import Use
@@ -7,14 +11,22 @@ from testplan.common.config import ConfigOption
 from testplan.common.exporters import BaseExporter, ExporterConfig
 from testplan.common.utils.logger import TESTPLAN_LOGGER
 from testplan.common.utils.path import makedirs
+from testplan.report.testing.base import TestReport
 from testplan.testing import tagging
 
 
+# TODO: what we mean here? This is just another dot on the inheritance graph.
 class Exporter(BaseExporter):
+    """TODO"""
+
     pass
 
 
 class TagFilteredExporterConfig(ExporterConfig):
+    """
+    Configuration object for :py:class:`~TagFilteredExporter`.
+    """
+
     @classmethod
     def get_options(cls):
         return {
@@ -27,34 +39,31 @@ class TagFilteredExporter(Exporter):
     """
     This is a meta exporter that generates tag filtered clones
     of the original test report and calls `export` operation on a new
-    instance of `exporter_class`.
+    instance of an `Exporter` class.
 
-    Basically multiple sub-export operations will be
-    run for each generated clone report, however if the clone report
-    is empty the export operation will be skipped.
+    This is achieved, by running multiple sub-export operations for each clone.
+    However, if the clone report is empty, the export operation is skipped.
     """
 
-    ALL = "all"
-    ANY = "any"
+    ALL: str = "all"
+    ANY: str = "any"
 
-    CONFIG = TagFilteredExporterConfig
-    exporter_class = None
+    CONFIG: TagFilteredExporterConfig = TagFilteredExporterConfig
+    exporter_class: BaseExporter = None
 
-    def get_params(self, tag_dict, filter_type):
+    def get_params(self, tag_dict: Dict, filter_type: str) -> Dict:
         """
         Return the keyword parameters (as a dict) that will be used for
         `exporter_class` instance initialization. The keys and values
         should be valid arguments in line with `exporter_class`'s config.
 
-        :param tag_dict: Tag context for the current sub-export operation.
-        :type tag_dict: ``dict`` of ``set``
+        :param tag_dict: tag context for the current sub-export operation
         :param filter_type: all / any
-        :type filter_type: ``str``
-        :return: dict of keyword arguments
+        :return: dictionary of keyword arguments
         """
         return {}
 
-    def get_exporter(self, **params):
+    def get_exporter(self, **params) -> BaseExporter:
         """
         Return a new instance of `exporter_class`,
         initialized with given `params`.
@@ -73,20 +82,18 @@ class TagFilteredExporter(Exporter):
         exporter.cfg.parent = self.cfg
         return exporter
 
-    def get_filtered_source(self, source, tag_dict, filter_type):
+    def get_filtered_source(
+        self,
+        source: TestReport,
+        tag_dict: Dict,
+        filter_type: str,
+    ) -> TestReport:
         """
-        Create a clone of the original report and
-        filter it with the given filter type & tag context.
+        Creates a filtered clone of the report by filter type and tag context.
 
-        Also populate cloned report's meta
-        attribute with the tag label.
-
-        :param source: Original test report.
-        :type source: :py:class:`~testplan.report.testing.base.TestReport`
-        :param tag_dict: Tag context for the current filtered test report.
-        :type tag_dict: ``dict`` of ``set``
+        :param source: Testplan report
+        :param tag_dict: tag context for filtering
         :param filter_type: all / any
-        :type filter_type: ``str``
         """
         tag_label = tagging.tag_label(tag_dict)
         result = source.filter_by_tags(
@@ -95,16 +102,17 @@ class TagFilteredExporter(Exporter):
         result.meta["report_tags_{}".format(filter_type)] = tag_label
         return result
 
-    def get_skip_message(self, source, tag_dict, filter_type):
+    def get_skip_message(
+        self,
+        source: Optional[TestReport],
+        tag_dict: Dict,
+        filter_type: str,
+    ) -> str:
         """
-        :param source: Cloned test report.
-        :type source: :py:class:`~testplan.report.testing.base.TestReport`
-        :param tag_dict: Tag context for the current filtered test report.
-        :type tag_dict: ``dict`` of ``set``
+        :param source: cloned test report
+        :param tag_dict: tag context for the current filtered test report
         :param filter_type: all / any
-        :type filter_type: ``str``
-        :return: String message to be displayed on skipped export operations.
-        :rtype: ``str``
+        :return: string message to be displayed on skipped export operations
         """
         return (
             "Empty report for tags: `{tag_label}`, filter_type:"
@@ -113,21 +121,20 @@ class TagFilteredExporter(Exporter):
             tag_label=tagging.tag_label(tag_dict), filter_type=filter_type
         )
 
-    def export_clones(self, source, tag_dicts, filter_type):
+    def export_clones(
+        self,
+        source: TestReport,
+        tag_dicts: List[Dict],
+        filter_type: str,
+    ) -> None:
         """
-        Create clones of the original report using the given tag & filter
+        Creates clones of the report using the given tag & filter
         context, initialize a new exporter for each clone and run the export
         operation, if the clone report is not empty.
 
-        :param source: Original test report.
-        :type source: :py:class:`~testplan.report.testing.base.TestReport`
-        :param tag_dicts: List of tag dictionaries, a new export operation
-                          will be run for each dict in the list.
-        :type tag_dicts: ``list`` of ``dict``
-        :param filter_type: all / any, will be used for tag filtering strategy.
-        :type filter_type: ``str``
-        :return: ``None``
-        :rtype: ``NoneType``
+        :param source: Testplan report
+        :param tag_dicts: list of tag dictionaries, export is run for each item
+        :param filter_type: all / any
         """
         if filter_type not in [self.ALL, self.ANY]:
             raise ValueError("Invalid filter type: {}".format(filter_type))
@@ -148,14 +155,11 @@ class TagFilteredExporter(Exporter):
                     )
                 )
 
-    def export(self, source):
+    def export(self, source: TestReport) -> None:
         """
-        Run export operation for exact (all) and any matching tag groups.
+        Runs the export operation for exact (all) and any matching tag groups.
 
-        :param source: Test report.
-        :type source: :py:class:`~testplan.report.testing.base.TestReport`
-        :return: ``None``
-        :rtype: ``NoneType``
+        :param source: Testplan report to export
         """
         self.export_clones(
             source=source, tag_dicts=self.cfg.report_tags, filter_type=self.ANY
@@ -168,13 +172,12 @@ class TagFilteredExporter(Exporter):
         )
 
 
-def save_attachments(report, directory):
+def save_attachments(report: TestReport, directory: str) -> Dict[str, str]:
     """
-    Save the report attachments to the given directory.
+    Saves the report attachments to the given directory.
+
     :param report: Testplan report.
-    :type report: ``testplan.testing.report.TestReport``
-    :param directory: Directory to save attachments in.
-    :type directory: ``str``
+    :param directory: directory to save attachments in
     """
     moved_attachments = {}
     attachments = getattr(report, "attachments", None)

--- a/testplan/exporters/testing/http/__init__.py
+++ b/testplan/exporters/testing/http/__init__.py
@@ -42,7 +42,7 @@ class HTTPExporterConfig(ExporterConfig):
 
 class HTTPExporter(Exporter):
     """
-    JSON exporter.
+    HTTP exporter.
 
     :param http_url: Http url for posting data.
     :type http_url: ``str``

--- a/testplan/exporters/testing/http/__init__.py
+++ b/testplan/exporters/testing/http/__init__.py
@@ -1,25 +1,25 @@
 """
-HTTP exporter for uploading test reports via http transmission. The web server
+HTTP exporter for uploading test reports via HTTP transmission. The web server
 must be able to handle POST request and receive data in JSON format.
 """
 
 import json
+from typing import Any, Tuple, Union
 
 import requests
 from schema import Or, And, Use
 
 from testplan.common.config import ConfigOption
-from testplan.common.utils.validation import is_valid_url
 from testplan.common.exporters import ExporterConfig
+from testplan.common.utils.validation import is_valid_url
 from testplan.report.testing.schemas import TestReportSchema
-
 from ..base import Exporter
 
 
 class CustomJsonEncoder(json.JSONEncoder):
     """To jsonify data that cannot be serialized by default JSONEncoder."""
 
-    def default(self, obj):  # pylint: disable = method-hidden
+    def default(self, obj: Any) -> str:  # pylint: disable = method-hidden
         return str(obj)
 
 
@@ -42,26 +42,32 @@ class HTTPExporterConfig(ExporterConfig):
 
 class HTTPExporter(Exporter):
     """
-    Json Exporter.
+    JSON exporter.
 
     :param http_url: Http url for posting data.
     :type http_url: ``str``
     :param timeout: Connection timeout.
     :type timeout: ``int``
 
-    Also inherits all
-    :py:class:`~testplan.exporters.testing.base.Exporter` options.
+    Inherits all :py:class:`~testplan.exporters.testing.base.Exporter` options.
     """
 
     CONFIG = HTTPExporterConfig
 
-    def __init__(self, name="HTTP exporter", **options):
+    def __init__(self, name: str = "HTTP exporter", **options):
         super(HTTPExporter, self).__init__(name=name, **options)
 
-    def _upload_report(self, url, data):
+    def _upload_report(
+        self, url: str, data: Any
+    ) -> Tuple[Union[None, requests.Request], str]:
         """
         Upload Json data, then return the response from server with an
         error message (if any).
+
+        :param url:
+        :param data:
+        :return: response, even if None, and error message pair
+        :raises HTTPError: thrown if response results in HTTP error
         """
         response = None
         errmsg = ""
@@ -86,8 +92,8 @@ class HTTPExporter(Exporter):
 
         return response, errmsg
 
-    def export(self, source):
-
+    def export(self, source) -> Union[None, str]:
+        """TODO"""
         http_url = self.cfg.http_url
         test_plan_schema = TestReportSchema()
         data = test_plan_schema.dump(source)

--- a/testplan/exporters/testing/json/__init__.py
+++ b/testplan/exporters/testing/json/__init__.py
@@ -3,20 +3,17 @@ JSON exporter for test reports, relies on `testplan.report.testing.schemas`
 for `dict` serialization and JSON conversion.
 """
 
-import os
-import json
-import pathlib
 import hashlib
+import json
+import os
+import pathlib
 
 from testplan import defaults
-
 from testplan.common.config import ConfigOption
 from testplan.common.exporters import ExporterConfig
-
 from testplan.report import ReportCategories
-from testplan.report.testing.schemas import TestReportSchema
 from testplan.report.testing.base import TestReport
-
+from testplan.report.testing.schemas import TestReportSchema
 from ..base import Exporter, save_attachments
 
 

--- a/testplan/exporters/testing/pdf/__init__.py
+++ b/testplan/exporters/testing/pdf/__init__.py
@@ -4,13 +4,13 @@ PDF Export logic for test reports via ReportLab.
 
 import os
 import pathlib
+import time
 import traceback
 import uuid
 import warnings
-import time
 from urllib.request import pathname2url
 
-from schema import Schema, Or
+from schema import Or
 
 try:
     from reportlab.platypus import SimpleDocTemplate
@@ -23,15 +23,12 @@ except Exception as exc:
     warnings.warn("reportlab must be supported: {}".format(exc))
 
 
-from testplan.common.utils.strings import slugify
-from testplan.common.report import Report
-
 from testplan.common.config import ConfigOption
 from testplan.common.exporters import ExporterConfig
-
+from testplan.common.report import Report
+from testplan.common.utils.strings import slugify
 from testplan.report.testing.styles import Style
 from testplan.testing import tagging
-
 from ..base import Exporter, TagFilteredExporter, TagFilteredExporterConfig
 
 try:

--- a/testplan/exporters/testing/pdf/renderers/base.py
+++ b/testplan/exporters/testing/pdf/renderers/base.py
@@ -1,4 +1,6 @@
-"""Base classes for rendering """
+"""
+Base classes for rendering.
+"""
 import collections
 import functools
 from html import escape
@@ -7,7 +9,6 @@ from reportlab.platypus import Paragraph
 
 from testplan.common.exporters.pdf import RowData
 from . import constants
-
 
 RowData = functools.partial(RowData, num_columns=constants.NUM_COLUMNS)
 

--- a/testplan/exporters/testing/pdf/renderers/constants.py
+++ b/testplan/exporters/testing/pdf/renderers/constants.py
@@ -1,3 +1,4 @@
+""" TODO """
 from reportlab.lib.pagesizes import A3
 from reportlab.lib.units import cm
 from reportlab.lib import colors
@@ -63,7 +64,6 @@ TABLE_STYLE = [
 ]
 
 # Displayed tables constants and style, used for table.log, table.match etc.
-# PAGE_WIDTH = constants.PAGE_WIDTH
 PAGE_WIDTH = PAGE_SIZE[0] - PAGE_MARGIN * 2
 
 NUM_DISPLAYED_ROWS = constants.NUM_DISPLAYED_ROWS

--- a/testplan/exporters/testing/pdf/renderers/entries/assertions.py
+++ b/testplan/exporters/testing/pdf/renderers/entries/assertions.py
@@ -1,5 +1,6 @@
-import re
+""" TODO """
 import functools
+import re
 from html import escape
 
 html_escape = functools.partial(escape, quote=False)
@@ -10,14 +11,11 @@ from reportlab.pdfbase.pdfmetrics import stringWidth
 
 from testplan.common.exporters.pdf import RowStyle, create_table
 from testplan.common.exporters.pdf import format_table_style, format_cell_data
-from testplan.common.utils.strings import wrap, split_line, split_text
+from testplan.common.utils.strings import split_line, split_text
 from testplan.common.utils.comparison import is_regex
 from testplan.exporters.testing.pdf.renderers.base import SlicedParagraph
-
 from testplan.report import Status
-
 from testplan.testing.multitest.entries import assertions
-
 from .base import SerializedEntryRenderer, registry
 from .. import constants as const
 from ..base import RowData

--- a/testplan/exporters/testing/pdf/renderers/entries/base.py
+++ b/testplan/exporters/testing/pdf/renderers/entries/base.py
@@ -1,21 +1,20 @@
+""" TODO """
 import pprint
 
+from PIL import Image as pil_image
 from reportlab.lib import colors
 from reportlab.lib.units import inch
 from reportlab.platypus import Image
-from testplan.exporters.testing.pdf.renderers.base import SlicedParagraph
-
-from PIL import Image as pil_image
 
 from testplan.common.exporters.pdf import RowStyle, create_table
 from testplan.common.exporters.pdf import format_table_style
 from testplan.common.utils.registry import Registry
 from testplan.common.utils.strings import split_text
+from testplan.exporters.testing.pdf.renderers.base import SlicedParagraph
 from testplan.testing.multitest.entries import base
-
+from .baseUtils import get_matlib_plot, export_plot_to_image, format_image
 from .. import constants
 from ..base import BaseRowRenderer, RowData
-from .baseUtils import get_matlib_plot, export_plot_to_image, format_image
 
 
 class SerializedEntryRegistry(Registry):

--- a/testplan/exporters/testing/pdf/renderers/entries/baseUtils.py
+++ b/testplan/exporters/testing/pdf/renderers/entries/baseUtils.py
@@ -1,10 +1,11 @@
 import os
-import uuid
 import tempfile
-import numpy as np
-from reportlab.platypus import Image
-from reportlab.lib.units import inch
+import uuid
+
 import matplotlib
+import numpy as np
+from reportlab.lib.units import inch
+from reportlab.platypus import Image
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plot

--- a/testplan/exporters/testing/pdf/renderers/reports.py
+++ b/testplan/exporters/testing/pdf/renderers/reports.py
@@ -1,5 +1,6 @@
-"""PDF Renderer classes for test report objects"""
-import os
+"""
+PDF Renderer classes for test report objects.
+"""
 import logging
 
 from reportlab.lib import colors

--- a/testplan/exporters/testing/xml/__init__.py
+++ b/testplan/exporters/testing/xml/__init__.py
@@ -67,7 +67,7 @@ class BaseRenderer:
     def get_testcase_reports(
         self,
         testsuite_report: Report,
-    ) -> Generator[TestCaseReport]:
+    ) -> Generator[TestCaseReport, None, None]:
         """
         Generator function to yield testcases from a suite report recursively.
 

--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -352,8 +352,8 @@ class App(Driver):
             self.cfg.expected_retcode != self.retcode
         ):
             err_msg = (
-                f"App drier error: {self.name},"
-                f" expected return cde is {self.cfg.expected_retcode},"
+                f"App driver error: {self.name},"
+                f" expected return code is {self.cfg.expected_retcode},"
                 f" but actual return code is {self.retcode}"
             )
             raise RuntimeError(err_msg)


### PR DESCRIPTION
## Bug / Requirement Description
Conversion to JUnit XML output through TPR is not possible which makes it inconvenient when test evidence is needed in that format.

## Solution description
The existing XML Exporter can be integrated through a new "to" action in the CLI.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [x] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
