### PR TITLE
Before `Worker` changed to `STOPPED` status it should be dead

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -1311,7 +1311,7 @@ class Resource(Entity):
             or self.status == self.STATUS.STARTED
         ):
             self.logger.debug(
-                "start() has been called on %r, skip starting", self
+                "start() has been called on %s, skip starting", self
             )
             return
 
@@ -1337,7 +1337,7 @@ class Resource(Entity):
             self.logger.warning(f"Stop %s but it has already aborted", self)
 
         if self.status == self.STATUS.NONE:
-            self.logger.debug("%r not started, skip stopping", self)
+            self.logger.debug("%s not started, skip stopping", self)
             return
 
         if (
@@ -1345,7 +1345,7 @@ class Resource(Entity):
             or self.status == self.STATUS.STOPPED
         ):
             self.logger.debug(
-                "stop() has been called on %r, skip stopping", self
+                "stop() has been called on %s, skip stopping", self
             )
             return
 

--- a/testplan/runners/base.py
+++ b/testplan/runners/base.py
@@ -103,10 +103,7 @@ class Executor(Resource):
     @property
     def is_alive(self):
         """Poll the loop handler thread to check it is running as expected."""
-        if self._loop_handler:
-            return self._loop_handler.is_alive()
-        else:
-            return False
+        return self._loop_handler and self._loop_handler.is_alive()
 
     def pending_work(self):
         """Resource has pending work."""

--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -139,7 +139,7 @@ class ProcessWorker(Worker):
 
         # Check if the child process already terminated.
         if self._handler.poll() is not None:
-            self.logger.critical(
+            self.logger.info(
                 "Worker process exited with code %d", self._handler.returncode
             )
             self._handler = None
@@ -151,12 +151,11 @@ class ProcessWorker(Worker):
         """Stop child process worker."""
         if hasattr(self, "_handler") and self._handler:
             kill_process(self._handler)
-        self.status.change(self.STATUS.STOPPED)
 
     def aborting(self):
         """Process worker abort logic."""
         self._transport.disconnect()
-        self.stop()
+        self.stopping()
 
 
 class ProcessPoolConfig(PoolConfig):

--- a/tests/functional/testplan/runners/pools/test_pool_base.py
+++ b/tests/functional/testplan/runners/pools/test_pool_base.py
@@ -92,6 +92,9 @@ def schedule_tests_to_pool(plan, pool, **pool_cfg):
     assert [plan.result.test_results[uid].report.name for uid in uids] == names
     assert list(pool._executed_tests) == uids[::-1]
 
+    assert not pool.is_alive
+    assert not any(worker.is_alive for worker in pool._workers)
+
 
 def test_pool_basic(mockplan):
     schedule_tests_to_pool(mockplan, Pool, size=2)

--- a/tests/functional/testplan/runners/pools/test_pool_process.py
+++ b/tests/functional/testplan/runners/pools/test_pool_process.py
@@ -69,7 +69,7 @@ def test_kill_one_worker(mockplan, tmp_path: Path):
             [
                 worker
                 for worker in mockplan.resources[pool_uid]._workers
-                if worker._aborted is True
+                if worker.aborted
             ]
         )
         == 1
@@ -119,7 +119,7 @@ def test_kill_all_workers(mockplan):
             [
                 worker
                 for worker in mockplan.resources[pool_uid]._workers
-                if worker._aborted is True
+                if worker.aborted
             ]
         )
         == pool_size
@@ -165,7 +165,7 @@ def test_reassign_times_limit(mockplan):
             [
                 worker
                 for worker in mockplan.resources[pool_uid]._workers
-                if worker._aborted is True
+                if worker.aborted is True
             ]
         )
         == retries_limit + 1
@@ -213,7 +213,7 @@ def test_disable_rerun_in_pool(mockplan):
             [
                 worker
                 for worker in mockplan.resources[pool_uid]._workers
-                if worker._aborted is True
+                if worker.aborted is True
             ]
         )
         == 0
@@ -332,7 +332,7 @@ def test_restart_worker(mockplan):
             [
                 worker
                 for worker in mockplan.resources[pool_uid]._workers
-                if worker._aborted is True
+                if worker.aborted is True
             ]
         )
         == 0


### PR DESCRIPTION
* A pool worker has a handler for a standalone thread or process.
  Before the pool exit and wait workers to be `STOPPED`, should check
  that worker is not alive through its handler.
* Avoid changing `Resource`'s status in its startig/stopping/aborting
  methods unless necessary you know clearly the process of how status
  of `Resource` changes. BTW, These methods are interfaces for derived
  class and in which better not call start/stop/abort methods because
  they manage the process of status transition.
* Fix a bug that pool monitor starts before workers actually start so
  it may fetch workers's out-of-date status (STOPPED after last run)
  and unexpectedly abort. Thread lock should be applied for workers.
* Update testcases.