### PR TITLE
Fix process pool test race condition.

### DIFF
--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -306,8 +306,8 @@ class Pool(Executor):
         self._conn.parent = self
         self._pool_lock = threading.Lock()
         self._metadata = None
-        # Set when Pool is started.
-        self._exit_loop = False
+        # Will set False when Pool is starting.
+        self._exit_loop = True
         self._start_monitor_thread = True
         # Methods for handling different Message types. These are expected to
         # take the worker, request and response objects as the only required
@@ -850,15 +850,16 @@ class Pool(Executor):
             raise RuntimeError("runpath was not set correctly")
         self._metadata = {"runpath": self.runpath}
 
+        if not self._workers:
+            self._add_workers()
+        else:
+            self._reset_workers()
+
         self._conn.start()
 
         self._exit_loop = False
         super(Pool, self).starting()  # start the loop & monitor
 
-        if not self._workers:
-            self._add_workers()
-        else:
-            self._reset_workers()
         self._start_workers()
 
         if self._workers.start_exceptions:


### PR DESCRIPTION
## Bug / Requirement Description
In case of pool restart, there is a chance that the monitor loop will kick in before worker ever start.

## Solution description
Reset worker before loop starts.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
