### PR TITLE
refine pool state transition

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -1400,6 +1400,12 @@ class Resource(Entity):
         """
         self.status.change(self.STATUS.STOPPED)
 
+    def force_started(self):
+        """
+        Change the status to STARTED (e.g. exception raised).
+        """
+        self.status.change(self.STATUS.STARTED)
+
     def __enter__(self):
         self.start()
         self.wait(self.STATUS.STARTED)

--- a/testplan/runners/pools/remote.py
+++ b/testplan/runners/pools/remote.py
@@ -18,7 +18,7 @@ from testplan.common.utils.path import (
     rebase_path,
 )
 from testplan.common.utils.remote import ssh_cmd, copy_cmd
-from testplan.common.utils.timing import get_sleeper
+from testplan.common.utils.timing import get_sleeper, wait
 from testplan.runners.pools.base import Pool, PoolConfig
 from testplan.runners.pools.communication import Message
 from testplan.runners.pools.connection import ZMQServer
@@ -371,7 +371,11 @@ class RemotePool(Pool):
         for worker in self._workers:
             if worker.status == worker.status.STARTING:
                 try:
-                    worker.wait(worker.status.STARTED)
+                    wait(
+                        lambda: worker.status
+                        in (worker.STATUS.STARTED, worker.STATUS.STOPPED),
+                        worker.cfg.status_wait_timeout,
+                    )
                 except Exception:
                     self.logger.error(
                         "Timeout waiting for worker {} to quit starting "


### PR DESCRIPTION
## Bug / Requirement Description
Add 'abort' status to _workers_monitoring, monitor will abort pool if all workers are aborting/aborted

## Solution description
test & news fragment, see internal change

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
