### PR TITLE
Feature/append pre post always

### DIFF
--- a/doc/newsfragments/1918_new.always_append_pre_post_steps_report.rst
+++ b/doc/newsfragments/1918_new.always_append_pre_post_steps_report.rst
@@ -1,0 +1,1 @@
+Pre/post steps report is now appended before resource startup and built upon continuously.

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -487,6 +487,7 @@ class MultiTest(testing_base.Test):
                     label="before_start", func=self.cfg.before_start
                 )
             )
+        self._add_step(self.append_pre_post_step_report)
 
     def pre_main_steps(self):
         """Runnable steps to be executed after environment starts."""
@@ -521,7 +522,6 @@ class MultiTest(testing_base.Test):
                     label="after_stop", func=self.cfg.after_stop
                 )
             )
-        self._add_step(self.append_pre_post_step_report)
         super(MultiTest, self).post_resource_steps()
 
     def should_run(self):

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -432,12 +432,12 @@ class MultiTest(testing_base.Test):
         Pre-resource step to append pre/post step report if any is configured.
         """
         if any(
-                [
-                    self.cfg.before_start,
-                    self.cfg.after_start,
-                    self.cfg.before_stop,
-                    self.cfg.after_stop
-                ],
+            [
+                self.cfg.before_start,
+                self.cfg.after_start,
+                self.cfg.before_stop,
+                self.cfg.after_stop,
+            ],
         ):
             self.report.append(self.pre_post_step_report)
 

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -427,13 +427,19 @@ class MultiTest(testing_base.Test):
             if testcases:
                 yield from self._run_testsuite_iter(testsuite, testcases)
 
-    def append_pre_post_step_report(self):
+    def append_pre_post_step_report(self) -> None:
         """
-        This will be called as a final step after multitest run is
-        complete, to group all step check results under a single report.
+        Pre-resource step to append pre/post step report if any is configured.
         """
-        if self._pre_post_step_report is not None:
-            self.report.append(self._pre_post_step_report)
+        if any(
+                [
+                    self.cfg.before_start,
+                    self.cfg.after_start,
+                    self.cfg.before_stop,
+                    self.cfg.after_stop
+                ],
+        ):
+            self.report.append(self.pre_post_step_report)
 
     def get_tags_index(self):
         """

--- a/tests/functional/testplan/testing/multitest/test_pre_post_steps.py
+++ b/tests/functional/testplan/testing/multitest/test_pre_post_steps.py
@@ -39,8 +39,6 @@ def check_func_4(env, result):
     result.attach(CURRENT_FILE, description="current file")
 
 
-
-
 expected_report = TestReport(
     name="plan",
     entries=[
@@ -78,9 +76,11 @@ expected_report = TestReport(
                     ],
                 ),
             ],
-        )
+        ),
     ],
 )
+
+
 def test_pre_post_steps(mockplan):
 
     multitest = MultiTest(

--- a/tests/functional/testplan/testing/multitest/test_pre_post_steps.py
+++ b/tests/functional/testplan/testing/multitest/test_pre_post_steps.py
@@ -39,6 +39,8 @@ def check_func_4(env, result):
     result.attach(CURRENT_FILE, description="current file")
 
 
+
+
 expected_report = TestReport(
     name="plan",
     entries=[
@@ -46,16 +48,6 @@ expected_report = TestReport(
             name="MyMultitest",
             category=ReportCategories.MULTITEST,
             entries=[
-                TestGroupReport(
-                    name="MySuite",
-                    category=ReportCategories.TESTSUITE,
-                    entries=[
-                        TestCaseReport(name="test_one"),
-                        TestCaseReport(
-                            name="teardown", entries=[{"type": "Attachment"}]
-                        ),
-                    ],
-                ),
                 TestGroupReport(
                     name="Pre/Post Step Checks",
                     category=ReportCategories.TESTSUITE,
@@ -75,12 +67,20 @@ expected_report = TestReport(
                         ),
                     ],
                 ),
+                TestGroupReport(
+                    name="MySuite",
+                    category=ReportCategories.TESTSUITE,
+                    entries=[
+                        TestCaseReport(name="test_one"),
+                        TestCaseReport(
+                            name="teardown", entries=[{"type": "Attachment"}]
+                        ),
+                    ],
+                ),
             ],
         )
     ],
 )
-
-
 def test_pre_post_steps(mockplan):
 
     multitest = MultiTest(


### PR DESCRIPTION
## Bug / Requirement Description
Pre/post steps of the report are appended in one batch as a group only at the end of the MultiTest during post resource steps. In case of an environment startup failure, even the before_start step is lost.

## Solution description
Appending the group straight away during pre resource steps allows us to leverage mutability of entries and all non-skipped steps are present in the report.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
