### PR TITLE
In dict match all content under excluded key should be marked ignored

### DIFF
--- a/doc/newsfragments/1937_changed.dict_match_for_ignored_fields.rst
+++ b/doc/newsfragments/1937_changed.dict_match_for_ignored_fields.rst
@@ -1,0 +1,1 @@
+When :py:meth:`dict.match <testplan.testing.multitest.result.DictNamespace.match>` ``exclude_keys`` has nested dict, align the values under the same key between actual and expected on Web UI.

--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -491,20 +491,29 @@ def _cmp_dicts(lhs, rhs, ignore, only, report_mode, value_cmp_func):
             should_ignore = False
         return should_ignore
 
+    def mark_ignored(val):
+        """
+        Whatever the result is, just mark all flags of comparison to be "i"
+        (which means ignored), because the upper level key is in ignore list.
+        """
+        if val[0] == 1:
+            return 1, [mark_ignored(item) for item in val[1]]
+        elif val[0] == 2:
+            return 2, [
+                (item[0], Match.IGNORED, mark_ignored(item[2]))
+                for item in val[1]
+            ]
+        elif val[0] == 3:
+            return 3, Match.IGNORED, mark_ignored(val[2])
+        else:
+            return val
+
     results = []
     match = Match.IGNORED
+
     for iter_key, lhs_val, rhs_val in _idictzip_all(lhs, rhs):
-        if should_ignore_key(iter_key):
-            if report_mode == ReportOptions.ALL:
-                results.append(
-                    _build_res(
-                        key=iter_key,
-                        match=Match.IGNORED,
-                        lhs=fmt(lhs_val),
-                        rhs=fmt(rhs_val),
-                    )
-                )
-        else:
+        ignore_key = should_ignore_key(iter_key)
+        if report_mode == ReportOptions.ALL or not ignore_key:
             result = _rec_compare(
                 lhs_val,
                 rhs_val,
@@ -514,6 +523,14 @@ def _cmp_dicts(lhs, rhs, ignore, only, report_mode, value_cmp_func):
                 report_mode,
                 value_cmp_func,
             )
+
+            if ignore_key:
+                result = (
+                    result[0],
+                    Match.IGNORED,
+                    mark_ignored(result[2]),
+                    mark_ignored(result[3]),
+                )
 
             # Decide whether to keep or discard the result, depending on the
             # reporting mode.
@@ -527,6 +544,7 @@ def _cmp_dicts(lhs, rhs, ignore, only, report_mode, value_cmp_func):
             if keep_result:
                 results.append(result)
             match = Match.combine(match, result[1])
+
     return match, results
 
 

--- a/tests/unit/testplan/testing/multitest/test_result.py
+++ b/tests/unit/testplan/testing/multitest/test_result.py
@@ -494,6 +494,37 @@ class TestDictNamespace:
             and tea_1[4][0] == "REGEX"
         )
 
+    def test_exclude_key_on_nested_object(self, dict_ns):
+        """Test a dict match even the comparison key can be excluded."""
+        obj = [
+            {
+                "hello": "Hello",
+                "hi": [{"abc": "ABC", "xyz": {"x": "X", "y": "Y", "z": "Z"}}],
+            }
+        ]
+        assert dict_ns.match(
+            actual={"foo": obj, "bar": obj},
+            expected={"foo": obj, "bar": obj},
+            description="complex dictionary comparison for excluded keys",
+            exclude_keys=["bar"],
+        )
+        assert len(dict_ns.result.entries) == 1
+
+        # Comparison result can be divided into two parts, the former and the
+        # latter are almost same except that flag "Ignored" replaces "Passed".
+        comp_result = dict_ns.result.entries[0].comparison
+        size = int(len(comp_result) / 2)
+
+        # key "foo" in comp_result[0] and key "bar" in comp_result[size]
+        for i in range(1, size):
+            assert len(comp_result[i]) == len(comp_result[i + size])
+            for item_1, item_2 in zip(comp_result[i], comp_result[i + size]):
+                assert (
+                    item_1 == item_2
+                    or item_1.lower() == "passed"
+                    and item_2.lower() == "ignored"
+                )
+
 
 class TestFIXNamespace:
     """Unit testcases for the result.FixNamespace class."""


### PR DESCRIPTION
* If a key should be ignored for comparison, the value should still be
  compared with details displayed on web UI, that is, sub keys can be
   mapped one by one for easy viewing.
* On web UI not only the excluded keys are marked with grey color, but
  all that sub keys under it should all be marked "ignored" in grey.
* Update testcase.


## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
