### PR TITLE
PyTest will properly save attachments to the report

### DIFF
--- a/doc/newsfragments/1878_changed.pytest_attachments.rst
+++ b/doc/newsfragments/1878_changed.pytest_attachments.rst
@@ -1,0 +1,1 @@
+:py:class:`PyTest <testplan.testing.py_test.PyTest>` will properly save attachments to the report.

--- a/examples/PyTest/pytest_tests.py
+++ b/examples/PyTest/pytest_tests.py
@@ -6,6 +6,8 @@ import os
 
 import pytest
 
+from testplan.testing.multitest.result import Result
+
 
 class TestPytestBasics:
     """
@@ -61,6 +63,10 @@ class TestWithDrivers:
             received.decode("utf-8"), message, description="Expect a message"
         )
 
+
+class TestWithAttachments:
+    def test_attachment(self, result: Result):
+        result.attach(__file__, "example attachment")
 
 class TestPytestMarks:
     """

--- a/examples/PyTest/pytest_tests.py
+++ b/examples/PyTest/pytest_tests.py
@@ -68,6 +68,7 @@ class TestWithAttachments:
     def test_attachment(self, result: Result):
         result.attach(__file__, "example attachment")
 
+
 class TestPytestMarks:
     """
     Demonstrate the use of Pytest marks. These can be used to skip a testcase,

--- a/testplan/testing/py_test.py
+++ b/testplan/testing/py_test.py
@@ -493,6 +493,10 @@ class _ReportPlugin:
                     )
                     self._current_case_report.append(serialized_entry)
 
+                self._current_case_report.attachments.extend(
+                    self._current_result_obj.attachments
+                )
+
             if report.failed:
                 self._current_case_report.status_override = Status.FAILED
             else:

--- a/tests/unit/testplan/testing/pytest_expected_data.py
+++ b/tests/unit/testplan/testing/pytest_expected_data.py
@@ -52,6 +52,16 @@ EXPECTED_DRY_RUN_REPORT = testplan.report.TestGroupReport(
             ],
         ),
         testplan.report.TestGroupReport(
+            name="pytest_tests.py::TestWithAttachments",
+            uid="pytest_tests.py::TestWithAttachments",
+            category="testsuite",
+            entries=[
+                testplan.report.TestCaseReport(
+                    name="test_attachment", uid="test_attachment"
+                )
+            ],
+        ),
+        testplan.report.TestGroupReport(
             name="pytest_tests.py::TestPytestMarks",
             uid="pytest_tests.py::TestPytestMarks",
             category="testsuite",

--- a/tests/unit/testplan/testing/test_pytest.py
+++ b/tests/unit/testplan/testing/test_pytest.py
@@ -50,7 +50,11 @@ def test_run_tests(pytest_test_inst):
     pytest_test_inst.run_tests()
 
     assert pytest_test_inst.report.status == report.Status.FAILED
-    _check_attachements(pytest_test_inst.result.report["pytest_tests.py::TestWithAttachments"]["test_attachment"])
+    _check_attachements(
+        pytest_test_inst.result.report["pytest_tests.py::TestWithAttachments"][
+            "test_attachment"
+        ]
+    )
     _check_all_testcounts(pytest_test_inst.report.counter)
 
 
@@ -70,7 +74,6 @@ def test_run_testcases_iter_all(pytest_test_inst):
 
     testcase_report, _ = all_results[7]
     _check_attachements(testcase_report)
-
 
 
 def test_run_testcases_iter_testsuite(pytest_test_inst):
@@ -165,9 +168,11 @@ def test_capture_stdout(pytest_test_inst):
     assert all_results[0][0]["runtime_status"] == report.RuntimeStatus.RUNNING
     assert all_results[1][0].entries[1]["message"] == "test output\n"
 
+
 def _check_attachements(report: TestCaseReport):
     assert len(report.attachments) == 1
     assert report.attachments[0].description == "example attachment"
+
 
 def _check_all_testcounts(counter):
     """Check the pass/fail/skip counts after running all tests."""


### PR DESCRIPTION
## Bug / Requirement Description
PyTest did not save the attachments to the report

## Solution description
The attachments are now copied over to the report

## Checklist:
- [X] Test
- [X] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
