### PR TITLE
Change the place where Resource's `post_start` and `post_stop` methods are called

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -177,7 +177,6 @@ class Environment:
         # Wait resources status to be STARTED.
         for resource in resources_to_wait_for:
             resource.wait(resource.STATUS.STARTED)
-            resource.post_start()
             resource.logger.debug("%s started", resource)
 
     def start_in_pool(self, pool):
@@ -211,7 +210,6 @@ class Environment:
         for resource in resources_to_wait_for:
             if resource not in self.start_exceptions:
                 resource.wait(resource.STATUS.STARTED)
-                resource.post_start()
                 resource.logger.debug("%s started", resource)
 
     def stop(self, is_reversed=False):
@@ -245,7 +243,6 @@ class Environment:
         # Wait resources status to be STOPPED.
         for resource in resources_to_wait_for:
             resource.wait(resource.STATUS.STOPPED)
-            resource.post_stop()
             resource.logger.debug("%s stopped", resource)
 
     def stop_in_pool(self, pool, is_reversed=False):
@@ -275,7 +272,6 @@ class Environment:
         for resource in resources_to_wait_for:
             if resource not in self.stop_exceptions:
                 resource.wait(resource.STATUS.STOPPED)
-                resource.post_stop()
                 resource.logger.debug("%s stopped", resource)
             else:
                 # Resource status should be STOPPED even it failed to stop
@@ -1267,7 +1263,6 @@ class Resource(Entity):
 
         if not self.async_start:
             self.wait(self.STATUS.STARTED)
-            self.post_start()
             self.logger.debug("%s started", self)
 
     def stop(self):
@@ -1300,7 +1295,6 @@ class Resource(Entity):
 
         if not self.async_start:
             self.wait(self.STATUS.STOPPED)
-            self.post_stop()
             self.logger.debug("%s stopped", self)
 
     def pre_start(self):
@@ -1335,6 +1329,7 @@ class Resource(Entity):
         :type timeout: ``int`` or ``NoneType``
         """
         self.status.change(self.STATUS.STARTED)
+        self.post_start()
 
     def _wait_stopped(self, timeout=None):
         """
@@ -1344,6 +1339,7 @@ class Resource(Entity):
         :type timeout: ``int`` or ``NoneType``
         """
         self.status.change(self.STATUS.STOPPED)
+        self.post_stop()
 
     def starting(self):
         """
@@ -1374,9 +1370,12 @@ class Resource(Entity):
         Stop and start the resource.
         """
         self.stop()
-        self.wait(self.STATUS.STOPPED)
+        if self.async_start:
+            self.wait(self.STATUS.STOPPED)
+
         self.start()
-        self.wait(self.STATUS.STARTED)
+        if self.async_start:
+            self.wait(self.STATUS.STARTED)
 
     def force_stopped(self):
         """

--- a/testplan/common/remote/remote_service.py
+++ b/testplan/common/remote/remote_service.py
@@ -178,7 +178,7 @@ class RemoteService(Resource, RemoteResource):
                     self.cfg.remote_host,
                     self.rpyc_port,
                 )
-                self.status.change(self.STATUS.STARTED)
+                super(RemoteService, self)._wait_started(timeout=timeout)
                 return
 
             if self.proc and self.proc.poll() is not None:

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -170,7 +170,7 @@ class Worker(WorkerBase):
     def _wait_started(self, timeout=None):
         """Ready to communicate with pool."""
         self.last_heartbeat = time.time()
-        self.status.change(self.STATUS.STARTED)
+        super(Worker, self)._wait_started(timeout=timeout)
 
     @property
     def is_alive(self):

--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -119,8 +119,7 @@ class ProcessWorker(Worker):
             if match_regexps_in_file(
                 self.outfile, [re.compile("Starting child process worker on")]
             )[0]:
-                self.last_heartbeat = time.time()
-                self.status.change(self.STATUS.STARTED)
+                super(ProcessWorker, self)._wait_started(timeout=timeout)
                 return
 
             if self._handler and self._handler.poll() is not None:

--- a/testplan/runners/pools/remote.py
+++ b/testplan/runners/pools/remote.py
@@ -152,6 +152,7 @@ class RemoteWorker(ProcessWorker, RemoteResource):
             if self.status != self.status.STOPPED:
                 self.logger.info("Waiting for workers to stop")
             else:
+                self.post_stop()
                 break
         else:
             msg = f"Not able to stop worker {self} after {timeout}s"

--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -382,6 +382,7 @@ class App(Driver):
         self.stop()
         if self.async_start:
             self.wait(self.status.STOPPED)
+
         if clean:
             self._move_app_path()
         else:
@@ -390,9 +391,11 @@ class App(Driver):
         # we don't want to cleanup runpath during restart
         path_cleanup = self.cfg.path_cleanup
         self.cfg._options["path_cleanup"] = False
+
         self.start()
         if self.async_start:
             self.wait(self.status.STARTED)
+
         self.cfg._options["path_cleanup"] = path_cleanup
 
     def _move_app_path(self):

--- a/testplan/testing/multitest/driver/base.py
+++ b/testplan/testing/multitest/driver/base.py
@@ -204,11 +204,11 @@ class Driver(Resource):
 
     def _wait_started(self, timeout=None):
         self.started_check(timeout=timeout)
-        self.status.change(self.STATUS.STARTED)
+        super(Driver, self)._wait_started(timeout=timeout)
 
     def _wait_stopped(self, timeout=None):
         self.stopped_check(timeout=timeout)
-        self.status.change(self.STATUS.STOPPED)
+        super(Driver, self)._wait_stopped(timeout=timeout)
 
     def aborting(self):
         """Trigger driver abort."""


### PR DESCRIPTION
* A resource's `start` method has the following steps:
  - pre_start
  - change status to starting
  - starting
  - wait stats to started
  - post_start

  the `stop` process is similar. `post` methods should be placed in
  `wait` so that user only need to call `wait` after `start` or `stop`
  and things become easier, this is important for `Driver`, e.g. its
  `restart` method is often called, which is made up of ony `start`,
  `_wait_started`, `stop` and `_wait_stoppped`.
