### PR TITLE
fix flaky test_kafka

### DIFF
--- a/tests/unit/testplan/testing/multitest/driver/mykafka/test_kafka.py
+++ b/tests/unit/testplan/testing/multitest/driver/mykafka/test_kafka.py
@@ -58,6 +58,7 @@ def test_kafka(kafka_server):
         {
             "bootstrap.servers": "localhost:{}".format(kafka_server.port),
             "max.in.flight": 1,
+            "broker.address.family": "v4",
         }
     )
     consumer = Consumer(
@@ -66,6 +67,7 @@ def test_kafka(kafka_server):
             "group.id": uuid.uuid4(),
             "default.topic.config": {"auto.offset.reset": "smallest"},
             "enable.auto.commit": True,
+            "broker.address.family": "v4",
         }
     )
 


### PR DESCRIPTION
## Bug / Requirement Description
test_kafka.py is flaky

## Solution description
Google suggest that it has to do with hostname randomly resolve to v4/v6 address.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
