### PR TITLE
Append pre and post steps report unconditionally.

### DIFF
--- a/doc/newsfragments/1918_changed.append_pre_post_report_unconditionally.rst
+++ b/doc/newsfragments/1918_changed.append_pre_post_report_unconditionally.rst
@@ -1,0 +1,1 @@
+Pre/post steps report is now appended before resource startup and built upon continuously.

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -262,6 +262,7 @@ class MultiTest(testing_base.Test):
                 uid="Pre/Post Step Checks",
                 category=ReportCategories.TESTSUITE,
             )
+            self._pre_post_step_report.status = Status.PASSED
         return self._pre_post_step_report
 
     @property
@@ -427,13 +428,19 @@ class MultiTest(testing_base.Test):
             if testcases:
                 yield from self._run_testsuite_iter(testsuite, testcases)
 
-    def append_pre_post_step_report(self):
+    def append_pre_post_step_report(self) -> None:
         """
-        This will be called as a final step after multitest run is
-        complete, to group all step check results under a single report.
+        Pre-resource step to append pre/post step report if any is configured.
         """
-        if self._pre_post_step_report is not None:
-            self.report.append(self._pre_post_step_report)
+        if any(
+            [
+                self.cfg.before_start,
+                self.cfg.after_start,
+                self.cfg.before_stop,
+                self.cfg.after_stop,
+            ],
+        ):
+            self.report.append(self.pre_post_step_report)
 
     def get_tags_index(self):
         """
@@ -487,6 +494,7 @@ class MultiTest(testing_base.Test):
                     label="before_start", func=self.cfg.before_start
                 )
             )
+        self._add_step(self.append_pre_post_step_report)
 
     def pre_main_steps(self):
         """Runnable steps to be executed after environment starts."""
@@ -521,7 +529,6 @@ class MultiTest(testing_base.Test):
                     label="after_stop", func=self.cfg.after_stop
                 )
             )
-        self._add_step(self.append_pre_post_step_report)
         super(MultiTest, self).post_resource_steps()
 
     def should_run(self):

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -258,8 +258,8 @@ class MultiTest(testing_base.Test):
     def pre_post_step_report(self):
         if self._pre_post_step_report is None:
             self._pre_post_step_report = TestGroupReport(
-                name="Pre/Post Step Checks",
-                uid="Pre/Post Step Checks",
+                name="Before/After Step Checks",
+                uid="Before/After Step Checks",
                 category=ReportCategories.TESTSUITE,
             )
             self._pre_post_step_report.status = Status.PASSED

--- a/tests/functional/testplan/testing/multitest/test_pre_post_steps.py
+++ b/tests/functional/testplan/testing/multitest/test_pre_post_steps.py
@@ -47,16 +47,6 @@ expected_report = TestReport(
             category=ReportCategories.MULTITEST,
             entries=[
                 TestGroupReport(
-                    name="MySuite",
-                    category=ReportCategories.TESTSUITE,
-                    entries=[
-                        TestCaseReport(name="test_one"),
-                        TestCaseReport(
-                            name="teardown", entries=[{"type": "Attachment"}]
-                        ),
-                    ],
-                ),
-                TestGroupReport(
                     name="Pre/Post Step Checks",
                     category=ReportCategories.TESTSUITE,
                     entries=[
@@ -72,6 +62,16 @@ expected_report = TestReport(
                                 {"type": "Equal", "passed": False},
                                 {"type": "Attachment"},
                             ],
+                        ),
+                    ],
+                ),
+                TestGroupReport(
+                    name="MySuite",
+                    category=ReportCategories.TESTSUITE,
+                    entries=[
+                        TestCaseReport(name="test_one"),
+                        TestCaseReport(
+                            name="teardown", entries=[{"type": "Attachment"}]
                         ),
                     ],
                 ),

--- a/tests/functional/testplan/testing/multitest/test_pre_post_steps.py
+++ b/tests/functional/testplan/testing/multitest/test_pre_post_steps.py
@@ -7,6 +7,7 @@ from testplan.report import (
     TestGroupReport,
     TestCaseReport,
     ReportCategories,
+    Status,
 )
 
 CURRENT_FILE = os.path.abspath(__file__)
@@ -39,48 +40,6 @@ def check_func_4(env, result):
     result.attach(CURRENT_FILE, description="current file")
 
 
-expected_report = TestReport(
-    name="plan",
-    entries=[
-        TestGroupReport(
-            name="MyMultitest",
-            category=ReportCategories.MULTITEST,
-            entries=[
-                TestGroupReport(
-                    name="Pre/Post Step Checks",
-                    category=ReportCategories.TESTSUITE,
-                    entries=[
-                        TestCaseReport(
-                            name="before_start - check_func_1",
-                            entries=[{"type": "Equal", "passed": True}],
-                        ),
-                        TestCaseReport(name="after_start - check_func_2"),
-                        TestCaseReport(name="before_stop - check_func_3"),
-                        TestCaseReport(
-                            name="after_stop - check_func_4",
-                            entries=[
-                                {"type": "Equal", "passed": False},
-                                {"type": "Attachment"},
-                            ],
-                        ),
-                    ],
-                ),
-                TestGroupReport(
-                    name="MySuite",
-                    category=ReportCategories.TESTSUITE,
-                    entries=[
-                        TestCaseReport(name="test_one"),
-                        TestCaseReport(
-                            name="teardown", entries=[{"type": "Attachment"}]
-                        ),
-                    ],
-                ),
-            ],
-        )
-    ],
-)
-
-
 def test_pre_post_steps(mockplan):
 
     multitest = MultiTest(
@@ -91,9 +50,134 @@ def test_pre_post_steps(mockplan):
         before_stop=check_func_3,
         after_stop=check_func_4,
     )
-
     mockplan.add(multitest)
     mockplan.run()
 
+    expected_report = TestReport(
+        name="plan",
+        entries=[
+            TestGroupReport(
+                name="MyMultitest",
+                category=ReportCategories.MULTITEST,
+                entries=[
+                    TestGroupReport(
+                        name="Before/After Step Checks",
+                        category=ReportCategories.TESTSUITE,
+                        entries=[
+                            TestCaseReport(
+                                name="before_start - check_func_1",
+                                entries=[{"type": "Equal", "passed": True}],
+                            ),
+                            TestCaseReport(name="after_start - check_func_2"),
+                            TestCaseReport(name="before_stop - check_func_3"),
+                            TestCaseReport(
+                                name="after_stop - check_func_4",
+                                entries=[
+                                    {"type": "Equal", "passed": False},
+                                    {"type": "Attachment"},
+                                ],
+                            ),
+                        ],
+                    ),
+                    TestGroupReport(
+                        name="MySuite",
+                        category=ReportCategories.TESTSUITE,
+                        entries=[
+                            TestCaseReport(name="test_one"),
+                            TestCaseReport(
+                                name="teardown",
+                                entries=[{"type": "Attachment"}],
+                            ),
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+
     check_report(expected_report, mockplan.report)
     assert len(mockplan.report.attachments) == 2
+
+
+def test_empty_pre_post_steps(mockplan):
+    """
+    Runs a MultiTest without an empty after_start, expects it present and passing.
+    """
+    multitest = MultiTest(
+        name="MyMultiTest",
+        suites=[MySuite()],
+        after_start=check_func_2,
+    )
+    mockplan.add(multitest)
+    mockplan.run()
+
+    expected_report = TestReport(
+        name="plan",
+        entries=[
+            TestGroupReport(
+                name="MyMultiTest",
+                category=ReportCategories.MULTITEST,
+                entries=[
+                    TestGroupReport(
+                        name="Before/After Step Checks",
+                        category=ReportCategories.TESTSUITE,
+                        entries=[
+                            TestCaseReport(name="after_start - check_func_2"),
+                        ],
+                    ),
+                    TestGroupReport(
+                        name="MySuite",
+                        category=ReportCategories.TESTSUITE,
+                        entries=[
+                            TestCaseReport(name="test_one"),
+                            TestCaseReport(
+                                name="teardown",
+                                entries=[{"type": "Attachment"}],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    assert mockplan.report["MyMultiTest"].status == Status.PASSED
+    assert mockplan.report.status == Status.PASSED
+    check_report(expected_report, mockplan.report)
+
+
+def test_no_pre_post_steps(mockplan):
+    """
+    Runs a MultiTest w/o pre/post steps, expects no pre/post step report.
+    """
+    multitest = MultiTest(
+        name="MyMultiTest",
+        suites=[MySuite()],
+    )
+    mockplan.add(multitest)
+    mockplan.run()
+
+    expected_report = TestReport(
+        name="plan",
+        entries=[
+            TestGroupReport(
+                name="MyMultiTest",
+                category=ReportCategories.MULTITEST,
+                entries=[
+                    TestGroupReport(
+                        name="MySuite",
+                        category=ReportCategories.TESTSUITE,
+                        entries=[
+                            TestCaseReport(name="test_one"),
+                            TestCaseReport(
+                                name="teardown",
+                                entries=[{"type": "Attachment"}],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    check_report(expected_report, mockplan.report)


### PR DESCRIPTION
* Moved append_pre_post_step_report from post steps to pre steps.
* Updated unit test with proper order of expected data.
* Added news fragment.

## Bug / Requirement Description
Pre/post step report is appended as part of the post resource steps which makes it absent in case the MultiTest breaks earlier.

## Solution description
Pre/post step report is appended as an empty TestGroupReport in the pre resource steps if any pre/post step is configured and built upon continuously.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
