### PR TITLE
Record exception that could possibly happen in _wait_start()

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -176,8 +176,16 @@ class Environment:
 
         # Wait resources status to be STARTED.
         for resource in resources_to_wait_for:
-            resource.wait(resource.STATUS.STARTED)
-            resource.logger.debug("%s started", resource)
+            try:
+                resource.wait(resource.STATUS.STARTED)
+            except Exception:
+                msg = "While starting resource [{}]\n{}".format(
+                    resource.cfg.name, traceback.format_exc()
+                )
+                resource.logger.error(msg)
+                self.start_exceptions[resource] = msg
+            else:
+                resource.logger.debug("%s started", resource)
 
     def start_in_pool(self, pool):
         """

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -715,9 +715,8 @@ class TestRunner(Runnable):
         if self.resources.start_exceptions:
             for resource, exception in self.resources.start_exceptions.items():
                 self.logger.critical(
-                    "Aborting {} due to start exception:".format(resource)
+                    "Aborting %s due to start exception", resource
                 )
-                self.logger.error(exception)
                 resource.abort()
 
         _start_ts = (
@@ -747,10 +746,8 @@ class TestRunner(Runnable):
                 # Poll the resource's health - if it has unexpectedly died
                 # then abort the entire test to avoid hanging.
                 if not resource.is_alive:
-                    self.result.test_report.logger.critical(
-                        "Aborting {} - {} unexpectedly died".format(
-                            self, resource
-                        )
+                    self.logger.critical(
+                        "Aborting %s - %s unexpectedly died", self, resource
                     )
                     self.abort()
                     self.result.test_report.status_override = Status.ERROR


### PR DESCRIPTION
## Bug / Requirement Description
Environment start might exception in resource _wait_start(), and cause testplan to hang in _wait_ongoing().

## Solution description
Record exception and handle in TestRunner.
Test is in internal PR.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
