### PR TITLE
Fix an issue that arg `testcase_report_target` cannot work as expected

### DIFF
--- a/doc/newsfragments/1970_changed.testcase_report_target.rst
+++ b/doc/newsfragments/1970_changed.testcase_report_target.rst
@@ -1,0 +1,1 @@
+Fix an issue that report target feature cannot work on parametrized testcases.

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -330,7 +330,15 @@ class MultiTest(testing_base.Test):
 
             if self.cfg.testcase_report_target:
                 testcases_to_run = [
-                    report_target(testcase) for testcase in testcases_to_run
+                    report_target(
+                        func=testcase,
+                        ref_func=getattr(
+                            suite,
+                            getattr(testcase, "_parametrization_template", ""),
+                            None,
+                        ),
+                    )
+                    for testcase in testcases_to_run
                 ]
 
             if testcases_to_run:


### PR DESCRIPTION
* the argument `testcase_report_target` is used for Multitest object
  to make all testcases marked as report target. However, it cannot
  work well for parametrized testcases, the definition of generated
  function will unexpectedly be marked. But it will not affect the
  `report_target` decorator which can still work as expected.
* Also it should be work with "pre" and "post" decorator when the
  assertions is written in pre-testcase or post-testcase methods.
* Add testcases.


## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
