### PR TITLE
disable usr1/usr2 signal handler for now

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -1605,10 +1605,11 @@ class RunnableManager(Entity):
         try:
             for sig in self._cfg.abort_signals:
                 signal.signal(sig, self._handle_abort)
-            if hasattr(signal, "SIGUSR1"):
-                signal.signal(signal.SIGUSR1, pdb_drop_handler)
-            if hasattr(signal, "SIGUSR2"):
-                signal.signal(signal.SIGUSR2, print_current_status)
+            # TODO: breaks test internally
+            # if hasattr(signal, "SIGUSR1"):
+            #     signal.signal(signal.SIGUSR1, pdb_drop_handler)
+            # if hasattr(signal, "SIGUSR2"):
+            #     signal.signal(signal.SIGUSR2, print_current_status)
         except ValueError:
             self.logger.warning(
                 "Not able to install signal handler -"


### PR DESCRIPTION
## Bug / Requirement Description
It breaks test internally. Will fix and add these properly.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
