### PR TITLE
TESTPLAN-1776 Jinja2 support for context values

### DIFF
--- a/doc/newsfragments/1776_changed.jinja_templating.rst
+++ b/doc/newsfragments/1776_changed.jinja_templating.rst
@@ -1,0 +1,5 @@
+From now on Jinja2 is the template engine used for context values resolution. If a template does not conform to
+Jinja2 then Tempita is used for fallback for a transition period, and a warning is displayed.
+Tempita is considered deprecated, and it's support will be removed in an upcoming release. Please review your runs
+for the warnings, if no warning then your templates are Jinja2 compatible and no work is needed,
+else please update your templates

--- a/testplan/common/utils/context.py
+++ b/testplan/common/utils/context.py
@@ -1,6 +1,82 @@
 """TODO."""
+import warnings
+from typing import Union, Dict
 
-from testplan.vendor.tempita import Template
+from testplan.vendor.tempita import Template as TempitaTemplate
+from jinja2 import Template
+
+
+def parse_template(template: str) -> Union[TempitaTemplate, Template]:
+    tempita_failed = False
+    parsed_template = None
+    try:
+        parsed_template = Template(template)
+    except Exception:
+        try:
+            # Jinja failed try with tempita
+            parsed_template = TempitaTemplate(template)
+        except Exception:
+            tempita_failed = True
+        else:
+            tempita_warning = f"The template: '{template}' is not a valid Jinja2 template. Falling back to Tempita. Tempita will be decommisioned soon, please update your template."
+            warnings.warn(tempita_warning, FutureWarning)
+            pass
+        finally:
+            if tempita_failed:
+                # raise the original jinja exception so user will fix it for jinja
+                raise
+
+    return parsed_template
+
+
+class ContextValue:
+    """
+    A context value represents a combination of a driver name
+    and a tempita template, to be resolved on driver start.
+    """
+
+    def __init__(self, driver: str, value: str):
+        """
+        Create a new context value
+        """
+        self.driver = driver
+        self.template = parse_template(value)
+
+    def __call__(self, ctx):
+        """
+        Resolve the template.
+        """
+        if ctx is None:
+            raise ValueError(
+                f'Could not retrieve driver "{self.driver}" value'
+                " from NoneType context."
+            )
+        if self.driver not in ctx:
+            raise RuntimeError(
+                f'Driver "{self.driver}" is not present in context.'
+            )
+        return render(self.template, ctx[self.driver].context_input())
+
+
+def context(driver, value):
+    """
+    Create a context extractor from a driver name and a value
+    expression. Value expressions must be valid tempita templates,
+    which will be resolved from the context.
+    """
+    return ContextValue(driver, value)
+
+
+def is_context(value):
+    """
+    Checks if a value is a context value
+    :param value: Value which may have been constructed through `context`
+    :type value: ``object``
+
+    :return: True if it is a context value, otherwise False
+    :rtype: ``bool``
+    """
+    return isinstance(value, ContextValue)
 
 
 def expand(value, contextobj, constructor=None):
@@ -17,7 +93,11 @@ def expand(value, contextobj, constructor=None):
         return value
 
 
-def expand_env(orig, overrides, contextobj):
+def expand_env(
+    orig: Dict[str, str],
+    overrides: Dict[str, Union[str, ContextValue]],
+    contextobj,
+):
     """
     Copies the `orig` dict of environment variables.
     Applies specified overrides.
@@ -47,50 +127,12 @@ def expand_env(orig, overrides, contextobj):
     }
 
 
-class ContextValue:
-    """
-    A context value represents a combination of a driver name
-    and a tempita template, to be resolved on driver start.
-    """
+def render(template: Union[Template, TempitaTemplate, str], context):
+    if isinstance(template, str):
+        template = parse_template(template)
 
-    def __init__(self, driver, value):
-        """
-        Create a new context value
-        """
-        self.driver, self.value = driver, Template(value)
-
-    def __call__(self, ctx):
-        """
-        Resolve the template.
-        """
-        if ctx is None:
-            raise ValueError(
-                f'Could not retrieve driver "{self.driver}" value'
-                " from NoneType context."
-            )
-        if self.driver not in ctx:
-            raise RuntimeError(
-                f'Driver "{self.driver}" is not present in context.'
-            )
-        return self.value.substitute(ctx[self.driver].context_input())
-
-
-def context(driver, value):
-    """
-    Create a context extractor from a driver name and a value
-    expression. Value expressions must be valid tempita templates,
-    which will be resolved from the context.
-    """
-    return ContextValue(driver, value)
-
-
-def is_context(value):
-    """
-    Checks if a value is a context value
-    :param value: Value which may have been constructed through `context`
-    :type value: ``object``
-
-    :return: True if it is a context value, otherwise False
-    :rtype: ``bool``
-    """
-    return isinstance(value, ContextValue)
+    return (
+        template.substitute(context)
+        if isinstance(template, TempitaTemplate)
+        else template.render(context)
+    )

--- a/testplan/common/utils/path.py
+++ b/testplan/common/utils/path.py
@@ -9,9 +9,8 @@ import contextlib
 import tempfile
 import hashlib
 
+from testplan.common.utils.context import render
 from .strings import slugify
-
-from testplan.vendor.tempita import Template
 
 VAR_TMP = os.path.join(os.sep, "var", "tmp")
 
@@ -189,8 +188,7 @@ def instantiate(template, values, destination):
     with open(destination, "w") as target:
         with open(template, "r") as source:
             try:
-                tmplt = Template(source.read())
-                target.write(tmplt.substitute(values))
+                target.write(render(source.read(), values))
             except UnicodeDecodeError:
                 shutil.copy(template, destination)
             except Exception as exc:

--- a/tests/unit/testplan/common/utils/test_context.py
+++ b/tests/unit/testplan/common/utils/test_context.py
@@ -1,0 +1,92 @@
+from unittest.mock import Mock
+
+import pytest
+from jinja2 import Template
+from testplan.vendor.tempita import Template as TempitaTemplate
+from pytest import fixture
+
+from testplan.common.utils.context import (
+    ContextValue,
+    expand,
+    expand_env,
+    render,
+)
+
+
+@fixture(scope="module")
+def driver_context():
+    mock = Mock()
+    mock.context_input = Mock(return_value=dict(host="host.ms.com", port=123))
+    return {"driver": mock}
+
+
+def test_constructor_with_Jinja(driver_context):
+    cv = ContextValue("driver", "{{host}}")
+    assert isinstance(cv.template, Template)
+    value = cv(driver_context)
+    assert value == "host.ms.com"
+
+    cv = ContextValue("driver", "{{host}}:{{port}}")
+    assert isinstance(cv.template, Template)
+    value = cv(driver_context)
+    assert value == "host.ms.com:123"
+
+
+def test_constructor_with_Tempita(driver_context):
+    cv = ContextValue("driver", "{{if port > 1}}{{host}}{{endif}}")
+    assert isinstance(cv.template, TempitaTemplate)
+    value = cv(driver_context)
+    assert value == "host.ms.com"
+
+    cv = ContextValue(
+        "driver", "{{if port > 123}}{{host}}{{else}}{{port}}{{endif}}"
+    )
+    assert isinstance(cv.template, TempitaTemplate)
+    value = cv(driver_context)
+    assert value == "123"
+
+
+def test_constructor_with_Invalid():
+    with pytest.raises(Exception):
+        cv = ContextValue("driver", 123)
+
+
+def test_missing_driver(driver_context):
+    with pytest.raises(RuntimeError):
+        cv = ContextValue("driver2", "{{port}}")
+        cv(driver_context)
+
+
+def test_expand(driver_context):
+    assert expand(12, driver_context) == 12
+    assert expand("str", driver_context) == "str"
+    cv = ContextValue("driver", "{{port}}")
+    assert expand(cv, driver_context) == "123"
+    assert expand(cv, driver_context, int) == 123
+
+
+def test_expand_env(driver_context):
+    env = dict(a="1", b="2")
+    overrides = dict(
+        c="str",
+        d="{{notcontext}}",
+        e=ContextValue("driver", "{{host}}"),
+        b=ContextValue("driver", "{{port}}"),
+    )
+    result = expand_env(env, overrides, driver_context)
+
+    assert result["a"] == "1"
+    assert result["b"] == "123"
+    assert result["c"] == "str"
+    assert result["d"] == "{{notcontext}}"
+    assert result["e"] == "host.ms.com"
+
+
+def test_render():
+    context = dict(a="1", b=2)
+    expected = "1:2"
+    template = "{{a}}:{{b}}"
+
+    assert render(template, context) == expected
+    assert render(TempitaTemplate(template), context) == expected
+    assert render(Template(template), context) == expected


### PR DESCRIPTION
## Bug / Requirement Description
Tempita is old and has problems, move to a well supported template engine: Jinja2

## Solution description
- default templating with Jinja2
- warning on Tempita deprecation
- unit tests for context resolution


## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
