### PR TITLE
Add path rebase logic for attachment and task when execute remotely

### DIFF
--- a/doc/newsfragments/1938_changed.pre_start.rst
+++ b/doc/newsfragments/1938_changed.pre_start.rst
@@ -1,0 +1,1 @@
+User-specified pre_start callable for drivers will now be called after framework-defined pre_start method.

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -1194,6 +1194,10 @@ class ResourceConfig(EntityConfig):
         return {
             ConfigOption("async_start", default=True): bool,
             ConfigOption("auto_start", default=True): bool,
+            ConfigOption("pre_start", default=None): Or(callable, None),
+            ConfigOption("post_start", default=None): Or(callable, None),
+            ConfigOption("pre_stop", default=None): Or(callable, None),
+            ConfigOption("post_stop", default=None): Or(callable, None),
         }
 
 
@@ -1314,6 +1318,8 @@ class Resource(Entity):
         self.logger.debug("Starting %s", self)
         self.status.change(self.STATUS.STARTING)
         self.pre_start()
+        if self.cfg.pre_start:
+            self.cfg.pre_start(self)
         self.starting()
 
         if not self.async_start:
@@ -1346,6 +1352,8 @@ class Resource(Entity):
         self.logger.debug("Stopping %s", self)
         self.status.change(self.STATUS.STOPPING)
         self.pre_stop()
+        if self.cfg.pre_stop:
+            self.cfg.pre_stop(self)
         self.stopping()
 
         if not self.async_start:
@@ -1385,6 +1393,8 @@ class Resource(Entity):
         """
         self.status.change(self.STATUS.STARTED)
         self.post_start()
+        if self.cfg.post_start:
+            self.cfg.post_start(self)
 
     def _wait_stopped(self, timeout=None):
         """
@@ -1395,6 +1405,8 @@ class Resource(Entity):
         """
         self.status.change(self.STATUS.STOPPED)
         self.post_stop()
+        if self.cfg.post_stop:
+            self.cfg.post_stop(self)
 
     def starting(self):
         """

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -131,6 +131,14 @@ class WorkerBase(entity.Resource):
         """
         self._transport.respond(msg)
 
+    def rebase_attachment(self, result):
+        """Rebase the path of attachment from remote to local"""
+        pass
+
+    def rebase_task_path(self, task):
+        """Rebase the path of task from local to remote"""
+        pass
+
     def __repr__(self):
         return "{}[{}]".format(self.__class__.__name__, self.cfg.index)
 
@@ -461,6 +469,7 @@ class Pool(Executor):
                     break
 
                 task = self._input[uid]
+                worker.rebase_task_path(task)
 
                 if self._can_assign_task(task):
                     if self._task_retries_cnt[uid] > self._task_retries_limit:
@@ -552,13 +561,7 @@ class Pool(Executor):
                 "De-assign {} from {}".format(task_result.task, worker)
             )
 
-            if task_result.result and isinstance(worker, RemoteResource):
-                for attachment in task_result.result.report.attachments:
-                    attachment.source_path = rebase_path(
-                        attachment.source_path,
-                        worker._remote_plan_runpath,
-                        worker._get_plan().runpath,
-                    )
+            worker.rebase_attachment(task_result.result)
 
             if task_should_rerun():
                 self.logger.test_info(

--- a/testplan/runners/pools/remote.py
+++ b/testplan/runners/pools/remote.py
@@ -54,10 +54,13 @@ class RemoteWorker(ProcessWorker, RemoteResource):
     Remote worker resource that pulls tasks from the transport provided,
     executes them in a local pool of workers and sends back task results.
 
-    :param workers: Number of remote workers of remote pool of child worker.
-    :type workers: ``int``
-    :param pool_type: Remote pool type that child worker will use.
+    :param pool_type: Child pool type that remote workers will use.
+    can be ``thread`` or ``process``, default to ``thread`` if
+    ``workers`` is 1 and otherwise ``process``.
     :type pool_type: ``str``
+    :param workers: Number of thread/process workers of the child
+    pool, default to 1.
+    :type workers: ``int``
 
     Also inherits all
     :py:class:`~testplan.runners.pools.process.ProcessWorkerConfig` and
@@ -66,6 +69,11 @@ class RemoteWorker(ProcessWorker, RemoteResource):
     """
 
     CONFIG = RemoteWorkerConfig
+
+    def __init__(self, **options):
+        if options["workers"] == 1:
+            options["pool_type"] = "thread"
+        super().__init__(**options)
 
     def _set_child_script(self):
         """Specify the remote worker executable file."""
@@ -159,6 +167,23 @@ class RemoteWorker(ProcessWorker, RemoteResource):
             self.logger.error(msg)
             raise RuntimeError(msg)
 
+    def rebase_attachment(self, result):
+        """Rebase the path of attachment from remote to local"""
+
+        if result:
+            for attachment in result.report.attachments:
+                attachment.source_path = rebase_path(
+                    attachment.source_path,
+                    self._remote_plan_runpath,
+                    self._get_plan().runpath,
+                )
+
+    def rebase_task_path(self, task):
+        """Rebase the path of task from local to remote"""
+        task.rebase_path(
+            self._workspace_paths.local, self._workspace_paths.remote
+        )
+
 
 class RemotePoolConfig(PoolConfig):
     """
@@ -184,7 +209,7 @@ class RemotePoolConfig(PoolConfig):
                 "abort_signals", default=[signal.SIGINT, signal.SIGTERM]
             ): [int],
             ConfigOption("worker_type", default=RemoteWorker): object,
-            ConfigOption("pool_type", default="thread"): str,
+            ConfigOption("pool_type", default="process"): str,
             ConfigOption("host", default=cls.default_hostname): str,
             ConfigOption("port", default=0): int,
             ConfigOption("worker_heartbeat", default=30): Or(int, float, None),
@@ -198,15 +223,16 @@ class RemotePool(Pool):
 
     :param name: Pool name.
     :type name: ``str``
-    :param hosts: Map of host(ip): number of their local workers.
+    :param hosts: Map of host(ip): number of their local thread/process workers.
         i.e {'hostname1': 2, '10.147.XX.XX': 4}
     :type hosts: ``dict`` of ``str``:``int``
     :param abort_signals: Signals to trigger abort logic. Default: INT, TERM.
     :type abort_signals: ``list`` of ``int``
     :param worker_type: Type of worker to be initialized.
     :type worker_type: :py:class:`~testplan.runners.pools.remote.RemoteWorker`
-    :param pool_type: Local pool that will be initialized in remote workers.
-        i.e ``thread``, ``process``.
+    :param pool_type: Child pool type that remote workers will use.
+    can be ``thread`` or ``process``, default to ``thread`` if
+    ``workers`` is 1 and otherwise ``process``.
     :type pool_type: ``str``
     :param host: Host that pool binds and listens for requests. Defaults to
         local hostname.
@@ -276,7 +302,7 @@ class RemotePool(Pool):
         hosts,
         abort_signals=None,
         worker_type=RemoteWorker,
-        pool_type="thread",
+        pool_type="process",
         host=CONFIG.default_hostname,
         port=0,
         worker_heartbeat=30,

--- a/testplan/testing/multitest/driver/base.py
+++ b/testplan/testing/multitest/driver/base.py
@@ -164,23 +164,6 @@ class Driver(Resource):
     def pre_start(self):
         """Steps to be executed right before resource starts."""
         self.make_runpath_dirs()
-        if self.cfg.pre_start:
-            self.cfg.pre_start(self)
-
-    def post_start(self):
-        """Steps to be executed right after resource is started."""
-        if self.cfg.post_start:
-            self.cfg.post_start(self)
-
-    def pre_stop(self):
-        """Steps to be executed right before resource stops."""
-        if self.cfg.pre_stop:
-            self.cfg.pre_stop(self)
-
-    def post_stop(self):
-        """Steps to be executed right after resource is stopped."""
-        if self.cfg.post_stop:
-            self.cfg.post_stop(self)
 
     def started_check(self, timeout=None):
         """Driver started status condition check."""

--- a/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
+++ b/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
@@ -305,6 +305,7 @@ def test_multitest_driver_start_timeout():
 
 
 def pre_start_fn(driver):
+    # make sure def pre_start is called before cfg.pre_start
     assert driver.pre_start_cnt > 0
     driver.pre_start_fn_cnt += 1
 
@@ -347,20 +348,20 @@ class CustomDriver(Driver):
         self.post_stop_fn_cnt = 0
 
     def pre_start(self):
-        self.pre_start_cnt += 1
         super(CustomDriver, self).pre_start()
+        self.pre_start_cnt += 1
 
     def post_start(self):
-        self.post_start_cnt += 1
         super(CustomDriver, self).post_start()
+        self.post_start_cnt += 1
 
     def pre_stop(self):
-        self.pre_stop_cnt += 1
         super(CustomDriver, self).pre_stop()
+        self.pre_stop_cnt += 1
 
     def post_stop(self):
-        self.post_stop_cnt += 1
         super(CustomDriver, self).post_stop()
+        self.post_stop_cnt += 1
 
 
 @testsuite


### PR DESCRIPTION
Call user-specified pre_start before framework-defined pre_start for drivers;
Use process pool instead of thread pool as default child pool for remote execution if size >1

Test is in internal PR

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
