### PR TITLE
Revert dict.match update

### DIFF
--- a/doc/newsfragments/2042_changed.dict_match_for_ignored_fields.rst
+++ b/doc/newsfragments/2042_changed.dict_match_for_ignored_fields.rst
@@ -1,0 +1,1 @@
+Reverted latest change to :py:meth:`dict.match <testplan.testing.multitest.result.DictNamespace.match>` introducing breaking changes.

--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -475,6 +475,7 @@ def _cmp_dicts(lhs, rhs, ignore, only, report_mode, value_cmp_func):
     """
     Compares dictionaries
     """
+
     def should_ignore_key(key):
         """
         Decide if a key should be ignored.

--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -475,11 +475,9 @@ def _cmp_dicts(lhs, rhs, ignore, only, report_mode, value_cmp_func):
     """
     Compares dictionaries
     """
-
     def should_ignore_key(key):
         """
         Decide if a key should be ignored.
-
         Decision is based on ``ignore`` and ``only``. If ``only`` is ``True``
         then keys that are not in ``lhs`` will be ignored.
         """
@@ -491,44 +489,17 @@ def _cmp_dicts(lhs, rhs, ignore, only, report_mode, value_cmp_func):
             should_ignore = False
         return should_ignore
 
-    def process_ignored(val):
-        """
-        Whatever the result is, just mark all flags of comparison to be "i"
-        (which means ignored), because the upper level key is in ignore list.
-        """
-        if val[0] == 1:
-            return 1, [process_ignored(item) for item in val[1]]
-        elif val[0] == 2:
-            return 2, [
-                (item[0], Match.IGNORED, process_ignored(item[2]))
-                for item in val[1]
-            ]
-        elif val[0] == 3:
-            return 3, Match.IGNORED, process_ignored(val[2])
-        else:
-            return val
-
     results = []
     match = Match.IGNORED
-
     for iter_key, lhs_val, rhs_val in _idictzip_all(lhs, rhs):
         if should_ignore_key(iter_key):
             if report_mode == ReportOptions.ALL:
-                key, _, lhs, rhs = _rec_compare(
-                    lhs_val,
-                    rhs_val,
-                    ignore,
-                    only,
-                    iter_key,
-                    report_mode,
-                    value_cmp_func,
-                )
                 results.append(
-                    (
-                        key,
-                        Match.IGNORED,
-                        process_ignored(lhs),
-                        process_ignored(rhs),
+                    _build_res(
+                        key=iter_key,
+                        match=Match.IGNORED,
+                        lhs=fmt(lhs_val),
+                        rhs=fmt(rhs_val),
                     )
                 )
         else:
@@ -541,7 +512,6 @@ def _cmp_dicts(lhs, rhs, ignore, only, report_mode, value_cmp_func):
                 report_mode,
                 value_cmp_func,
             )
-
             # Decide whether to keep or discard the result, depending on the
             # reporting mode.
             if report_mode in (ReportOptions.ALL, ReportOptions.NO_IGNORED):
@@ -550,7 +520,6 @@ def _cmp_dicts(lhs, rhs, ignore, only, report_mode, value_cmp_func):
                 keep_result = not Match.to_bool(result[1])
             else:
                 raise ValueError("Invalid report mode {}".format(report_mode))
-
             if keep_result:
                 results.append(result)
             match = Match.combine(match, result[1])

--- a/tests/unit/testplan/testing/multitest/test_result.py
+++ b/tests/unit/testplan/testing/multitest/test_result.py
@@ -494,65 +494,6 @@ class TestDictNamespace:
             and tea_1[4][0] == "REGEX"
         )
 
-    def test_exclude_keys_on_nested_object(self, dict_ns):
-        """Test a dict match even the comparison key can be excluded."""
-        obj_1 = [
-            {
-                "hello": "Hello",
-                "hi": [{"abc": "ABC", "xyz": {"x": "X", "y": "Y", "z": "Z"}}],
-            }
-        ]
-
-        assert dict_ns.match(
-            actual={"foo": obj_1, "bar": obj_1},
-            expected={"foo": obj_1, "bar": obj_1},
-            description="complex dictionary comparison for excluded keys",
-            exclude_keys=["bar"],
-        )
-        assert len(dict_ns.result.entries) == 1
-        comp_result = dict_ns.result.entries[0].comparison
-
-        # Comparison result can be divided into two parts, the former and the
-        # latter are almost same except that flag "Ignored" replaces "Passed".
-        # key "foo" in comp_result[0] and key "bar" in comp_result[size]
-        size = int(len(comp_result) / 2)
-        for i in range(1, size):
-            assert len(comp_result[i]) == len(comp_result[i + size])
-            for item_1, item_2 in zip(comp_result[i], comp_result[i + size]):
-                assert (
-                    item_1 == item_2
-                    or item_1.lower() == "passed"
-                    and item_2.lower() == "ignored"
-                )
-
-        obj_2 = [
-            {
-                "hello": {"baz": "BAZ", "qux": "QUX"},
-                "hey": [{"abc": "ABC", "xyz": {"x": "X", "y": "Y", "z": "Z"}}],
-            }
-        ]
-        obj_3 = copy.deepcopy(obj_2)
-        obj_3[0]["hello"]["baz"] = "BAR"
-        obj_4 = copy.deepcopy(obj_2)
-        obj_4[0]["hey"][0]["xyz"]["z"] = "U"
-
-        assert dict_ns.match(
-            actual={"foo": obj_2, "bar": obj_2},
-            expected={"foo": obj_3, "bar": obj_4},
-            description="complex dictionary comparison for excluded keys",
-            exclude_keys=["hello", "xyz"],
-        )
-        assert len(dict_ns.result.entries) == 2
-        comp_result = dict_ns.result.entries[1].comparison
-
-        # "hello" and "xyz" are exclued keys and all items under them should
-        # be marked as "ignored" no matter they are same or different.
-        for result in comp_result:
-            if result[1] in ("foo", "bar", "hey", "abc", ""):
-                assert result[2].lower() == "passed"
-            else:
-                assert result[2].lower() == "ignored"
-
 
 class TestFIXNamespace:
     """Unit testcases for the result.FixNamespace class."""


### PR DESCRIPTION
## Bug / Requirement Description
Latest change meant to properly display ignored fields in dictionary match introduced a hidden bug.

## Solution description
Reversion of change until better understanding of the problem.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
