### PR TITLE
Fix flaky interactive test with FileNotFoundError

### DIFF
--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -112,13 +112,13 @@ class TestRunnerIHandler(entity.Entity):
 
     def setup(self):
         """Set up the task pool and HTTP handler."""
+        self.target.make_runpath_dirs()
+        self.target._configure_file_logger()
         self.logger.test_info(
             "Starting {} for {}".format(self.__class__.__name__, self.target)
         )
         self._http_handler = self._setup_http_handler()
         self._pool = futures.ThreadPoolExecutor(max_workers=1)
-        self.target.make_runpath_dirs()
-        self.target._configure_file_logger()
 
     def run(self):
         """


### PR DESCRIPTION
## Bug / Requirement Description
Flaky interactive test in CI failed with FileNotFoundError

## Solution description
Prioritize the runpath creation ensuring that it gets created first

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
