### PR TITLE
Bugfix/ignored display unordered

### DIFF
--- a/doc/newsfragments/2042_changed.ignored_display_issue.rst
+++ b/doc/newsfragments/2042_changed.ignored_display_issue.rst
@@ -1,0 +1,1 @@
+Fixed issue with :py:meth:`dict.match <testplan.testing.multitest.result.DictNamespace.match>` that resulted in incorrect key-value pairing in matches for ignored keys.

--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -556,14 +556,14 @@ def _rec_compare(
     ):
         return _build_res(
             key=key,
-            match=Match.PASS if lhs_cat == rhs_cat else Match.FAIL,
+            match=Match.IGNORED if value_cmp_func is None else Match.PASS if lhs_cat == rhs_cat else Match.FAIL,
             lhs=fmt(lhs),
             rhs=fmt(rhs),
         )
 
     ## CALLABLES
     if lhs_cat == rhs_cat == Category.CALLABLE:
-        match = Match.from_bool(lhs == rhs)
+        match = Match.IGNORED if value_cmp_func is None else Match.from_bool(lhs == rhs)
         return _build_res(
             key=key,
             match=match,
@@ -575,7 +575,7 @@ def _rec_compare(
         result, error = compare_with_callable(callable_obj=lhs, value=rhs)
         return _build_res(
             key=key,
-            match=Match.from_bool(result),
+            match=Match.IGNORED if value_cmp_func is None else Match.from_bool(result),
             lhs=(0, "func", callable_name(lhs)),
             rhs=fmt("Value: {}, Error: {}".format(rhs, error))
             if error
@@ -586,7 +586,7 @@ def _rec_compare(
         result, error = compare_with_callable(callable_obj=rhs, value=lhs)
         return _build_res(
             key=key,
-            match=Match.from_bool(result),
+            match=Match.IGNORED if value_cmp_func is None else Match.from_bool(result),
             lhs=fmt("Value: {}, Error: {}".format(lhs, error))
             if error
             else fmt(lhs),
@@ -595,7 +595,7 @@ def _rec_compare(
 
     ## REGEXES
     if lhs_cat == rhs_cat == Category.REGEX:
-        match = _regex_adapter.compare(lhs, rhs)
+        match = Match.IGNORED if value_cmp_func is None else _regex_adapter.compare(lhs, rhs)
         return _build_res(
             key=key,
             match=match,
@@ -604,7 +604,7 @@ def _rec_compare(
         )
 
     if lhs_cat == Category.REGEX:
-        match = _regex_adapter.match(regex=lhs, value=rhs)
+        match = Match.IGNORED if value_cmp_func is None else _regex_adapter.match(regex=lhs, value=rhs)
         return _build_res(
             key=key,
             match=match,
@@ -613,7 +613,7 @@ def _rec_compare(
         )
 
     if rhs_cat == Category.REGEX:
-        match = _regex_adapter.match(regex=rhs, value=lhs)
+        match = Match.IGNORED if value_cmp_func is None else _regex_adapter.match(regex=rhs, value=lhs)
         return _build_res(
             key=key,
             match=match,

--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -4,7 +4,7 @@ import operator
 import traceback
 from collections.abc import Mapping, Iterable, Container
 from itertools import zip_longest
-from typing import List, Tuple, Dict, Hashable, Callable, Union
+from typing import List, Tuple, Dict, Hashable, Union
 
 from .reporting import Absent, fmt, NATIVE_TYPES, callable_name
 
@@ -477,8 +477,8 @@ def _partition(results):
 def _cmp_dicts(
     lhs: Dict,
     rhs: Dict,
-    ignore: Container[Hashable],
-    only: Container[Hashable],
+    ignore: Container,
+    only: Container,
     report_mode: int,
     value_cmp_func: Union[Callable, None],
 ) -> Tuple[str, List]:

--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -496,11 +496,14 @@ def _cmp_dicts(lhs, rhs, ignore, only, report_mode, value_cmp_func):
         if should_ignore_key(iter_key):
             if report_mode == ReportOptions.ALL:
                 results.append(
-                    _build_res(
-                        key=iter_key,
-                        match=Match.IGNORED,
-                        lhs=fmt(lhs_val),
-                        rhs=fmt(rhs_val),
+                    _rec_compare(
+                        lhs_val,
+                        rhs_val,
+                        ignore,
+                        only,
+                        iter_key,
+                        report_mode,
+                        value_cmp_func=None,
                     )
                 )
         else:
@@ -620,9 +623,9 @@ def _rec_compare(
 
     ## VALUES
     if lhs_cat == rhs_cat == Category.VALUE:
-        response = value_cmp_func(lhs, rhs)
-
-        match = Match.from_bool(response)
+        match = Match.from_bool(
+            value_cmp_func(lhs, rhs)
+        ) if value_cmp_func is not None else Match.IGNORED
         return _build_res(key=key, match=match, lhs=fmt(lhs), rhs=fmt(rhs))
 
     ## ITERABLE


### PR DESCRIPTION
## Bug / Requirement Description
In current implementation, ignored nested structures in dictionary matching result in a faulty display due to lazy formatting of values below top level.

## Solution description
The deep recursive comparison gets all pairing right and we can introduce an optional behavior by setting the value comparison function to None and setting the match value conditional on that rather than executing the actual comparison.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
