### PR TITLE
Conditional status wait in Resource.__enter__

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      security-events: write
+      pull-requests: read
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -26,7 +31,7 @@ jobs:
       
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       # Override language selection by uncommenting this and choosing your languages
       with:
         languages: python

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -1458,7 +1458,8 @@ class Resource(Entity):
 
     def __enter__(self):
         self.start()
-        self.wait(self.STATUS.STARTED)
+        if self.async_start:
+            self.wait(self.STATUS.STARTED)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -1464,7 +1464,8 @@ class Resource(Entity):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()
-        self.wait(self.STATUS.STOPPED)
+        if self.async_start:
+            self.wait(self.STATUS.STOPPED)
 
     @property
     def is_alive(self):


### PR DESCRIPTION
## Bug / Requirement Description
Independent of whether the start is async or not, the context manager of a Resource would wait for STARTED status. This limits the usability of the started_check method.

## Solution description
Make the status wait dependent on the async_start flag.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
