### PR TITLE
make it possible to skip a testcase from the testcase itself

### DIFF
--- a/doc/en/assertions.rst
+++ b/doc/en/assertions.rst
@@ -664,6 +664,17 @@ Downloadable examples that use codelog assertion can be found
         )
 
 
+:py:meth:`result.skip <testplan.testing.multitest.result.Result.skip>`
+------------------------------------------------------------------------------
+Skip a testcase with the given reason.
+Downloadable examples that use skip assertion can be found
+:ref:`here <example_assertions>`.
+
+    .. code-block:: python
+
+        result.skip(reason="skip me")
+
+
 :py:meth:`result.matplot <testplan.testing.multitest.result.Result.matplot>`
 ----------------------------------------------------------------------------
 

--- a/doc/en/download/Assertions.rst
+++ b/doc/en/download/Assertions.rst
@@ -18,6 +18,13 @@ test_plan_basic.py
 Required files:
   - :download:`test_plan_group.py <../../../examples/Assertions/Basic/test_plan_group.py>`
 
+test_plan_skip.py
+++++++++++++++++++
+.. literalinclude:: ../../../examples/Assertions/Basic/test_plan_skip.py
+
+Required files:
+  - :download:`test_plan_exception.py <../../../examples/Assertions/Basic/test_plan_skip.py>`
+
 test_plan_group.py
 ++++++++++++++++++
 .. literalinclude:: ../../../examples/Assertions/Basic/test_plan_group.py

--- a/doc/newsfragments/1984_new.add_skip_assertion.rst
+++ b/doc/newsfragments/1984_new.add_skip_assertion.rst
@@ -1,0 +1,1 @@
+* Add new assertion :py:meth:`result.skip <testplan.testing.multitest.result.Result.skip>` which allow you to skip a testcase from the testcase itself.

--- a/examples/Assertions/Basic/test_plan_skip.py
+++ b/examples/Assertions/Basic/test_plan_skip.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""
+This example shows usage of skip assertion.
+"""
+import sys
+from testplan import test_plan
+from testplan.testing.multitest import MultiTest, testsuite, testcase
+from testplan.report.testing.styles import Style, StyleEnum
+
+
+@testsuite
+class SkipSuite:
+    @testcase
+    def skip_me(self, env, result):
+        result.true(True)
+        result.skip("call skip assertion")
+        result.fail("skip me")
+
+    @testcase(parameters=tuple(range(10)))
+    def condition_skip(self, env, result, num):
+        if num % 2 == 0:
+            result.skip("This testcase is marked as skipped")
+        else:
+            result.log("This is a log message")
+
+
+@test_plan(
+    name="Skip Assertion Example",
+    stdout_style=Style(
+        passing=StyleEnum.ASSERTION_DETAIL, failing=StyleEnum.ASSERTION_DETAIL
+    ),
+)
+def main(plan):
+    plan.add(
+        MultiTest(
+            name="Skip Assertion Test",
+            suites=[
+                SkipSuite(),
+            ],
+        )
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(not main())

--- a/testplan/common/report/__init__.py
+++ b/testplan/common/report/__init__.py
@@ -1,1 +1,7 @@
-from .base import Report, ReportGroup, ExceptionLogger, MergeError
+from .base import (
+    Report,
+    ReportGroup,
+    ExceptionLogger,
+    MergeError,
+    SkipTestcaseException,
+)

--- a/testplan/common/report/base.py
+++ b/testplan/common/report/base.py
@@ -19,6 +19,10 @@ class MergeError(Exception):
     """Raised when a merge operation fails."""
 
 
+class SkipTestcaseException(Exception):
+    """Raised from an explicit call to result.skip."""
+
+
 class ExceptionLogger:
     """
     A context manager used for suppressing & logging an exception.

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -12,7 +12,7 @@ import platform
 import re
 import threading
 from functools import wraps
-from typing import Callable
+from typing import Callable, Optional
 import functools
 
 from testplan import defaults
@@ -20,6 +20,7 @@ from testplan.common.utils.package import MOD_LOCK
 from testplan.common.utils import comparison
 from testplan.common.utils import strings
 from testplan.defaults import STDOUT_STYLE
+from testplan.common.report.base import SkipTestcaseException
 
 from .entries import assertions, base
 from .entries.schemas.base import registry as schema_registry
@@ -2406,6 +2407,18 @@ class Result:
         in related ``TestCaseReport``'s ``entries`` attribute.
         """
         return [schema_registry.serialize(entry) for entry in self]
+
+    def skip(self, reason: str, description: Optional[str] = None):
+        """
+        Skip a testcase with the given reason.
+
+        :param reason: The message to show the user as reason for the skip.
+        :type reason: ``str``
+        :param description:  Text description for the assertion.
+        :type description: ``str``
+        """
+        self.log(reason, description)
+        raise SkipTestcaseException(reason)
 
     def __repr__(self):
         return repr(self.entries)

--- a/tests/unit/testplan/testing/multitest/test_result.py
+++ b/tests/unit/testplan/testing/multitest/test_result.py
@@ -22,6 +22,8 @@ from testplan.common.utils import path as path_utils
 from testplan.testing.multitest import result as result_mod
 from testplan.testing.multitest import MultiTest
 from testplan.testing.multitest.suite import testcase, testsuite
+from testplan.report.testing import base as report_base
+
 
 matplotlib.use("agg")
 
@@ -271,6 +273,43 @@ def test_assertion_extra_attribute(mockplan):
 
     for idx, custom_style in enumerate(expected):
         assert custom_style == assertions[idx]["custom_style"]
+
+
+@testsuite
+class SkipSuite:
+    @testcase
+    def skip_me(self, env, result):
+        result.true(True)
+        result.skip("call skip assertion")
+        result.fail("skip me")
+
+    @testcase(parameters=tuple(range(10)))
+    def condition_skip(self, env, result, num):
+        if num % 2 == 0:
+            result.skip("This testcase is marked as skipped")
+            result.fail("skip me")
+        else:
+            result.log("This is a log message")
+
+
+def test_assertion_skip(mockplan):
+    mtest = MultiTest(name="SkipAssertion", suites=[SkipSuite()])
+    mtest.cfg.parent = mockplan.cfg
+    mtest.run()
+
+    skip_multitest = mtest.report.flatten()[0]
+    skip_suite = skip_multitest.entries[0]
+    skip_me_case = skip_suite.entries[0]
+    assert skip_me_case.status == report_base.Status.SKIPPED
+    assert skip_me_case.failed is False
+    assert len(skip_me_case.entries) == 2
+
+    for index, condition_skip_case in enumerate(skip_suite.entries[1]):
+        if index % 2 == 0:
+            assert condition_skip_case.status == report_base.Status.SKIPPED
+        else:
+            assert condition_skip_case.status == report_base.Status.PASSED
+        assert len(condition_skip_case.entries) == 1
 
 
 @pytest.fixture


### PR DESCRIPTION
Add a new assertion `result.skip`


## Checklist:
- [x] Test
- [x] Example (both test_plan.py and .rst)
- [x] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
