### PR TITLE
Add async start support for FixClient

### DIFF
--- a/doc/newsfragments/2078_changed.fixclient_async_start.rst
+++ b/doc/newsfragments/2078_changed.fixclient_async_start.rst
@@ -1,0 +1,1 @@
+Add support for async start for FixClient driver.

--- a/testplan/common/utils/sockets/fix/server.py
+++ b/testplan/common/utils/sockets/fix/server.py
@@ -275,8 +275,7 @@ class Server:
 
         name = self._conndetails_by_fd[fdesc].name
         del self._conndetails_by_fd[fdesc]
-        if name in self._conndetails_by_name:
-            del self._conndetails_by_name[name]
+        self._conndetails_by_name.pop(name, None)
 
     def _remove_all_connections(self):
         """
@@ -289,7 +288,9 @@ class Server:
             )
             self._conndetails_by_fd[fdesc].connection.close()
 
-            del self._conndetails_by_name[self._conndetails_by_fd[fdesc].name]
+            self._conndetails_by_name.pop(
+                self._conndetails_by_fd[fdesc].name, None
+            )
         self._conndetails_by_fd = {}
 
     def _process_connection_event(self, fdesc, event):


### PR DESCRIPTION
## Bug / Requirement Description
Need async start support for fixclient, as server might come up after client.

## Solution description
1) add logoff_at_stop=True/False to FixClient
2) make FixClient support async_start
3) make FixServer more error-tolerant when removing un-logged connection

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
