### PR TITLE
Add setter functionality to port property in Zookeeper driver

### DIFF
--- a/testplan/testing/multitest/driver/zookeeper.py
+++ b/testplan/testing/multitest/driver/zookeeper.py
@@ -86,6 +86,10 @@ class ZookeeperStandalone(Driver):
         """Port to listen on."""
         return self._port
 
+    @port.setter
+    def port(self, port):
+        self._port = port
+
     @emphasized
     @property
     def connection_str(self):


### PR DESCRIPTION
## Bug / Requirement Description
port member of Zookeeper driver class was updated to be a property. A setter member function was not included

## Solution description
Setter member function is now included. 

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
