### PR TITLE
fix flaky pool testcase

### DIFF
--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -746,11 +746,11 @@ class TestRunner(Runnable):
                 # Poll the resource's health - if it has unexpectedly died
                 # then abort the entire test to avoid hanging.
                 if not resource.is_alive:
+                    self.result.test_report.status_override = Status.ERROR
                     self.logger.critical(
                         "Aborting %s - %s unexpectedly died", self, resource
                     )
                     self.abort()
-                    self.result.test_report.status_override = Status.ERROR
 
             if pending_work is False:
                 break


### PR DESCRIPTION
## Bug / Requirement Description
The problem was that the TestRunner abort is called before setting the
error state. But an aborted testrunner, will abort the testplan itself
on another thread, which may happen earlier than status override set,
and the report remains success.

## Solution description
With the reordering this should be ok now.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
