### PR TITLE
FixClient to raise if empty byte is received.

### DIFF
--- a/doc/newsfragments/2102_changed.fix_client.rst
+++ b/doc/newsfragments/2102_changed.fix_client.rst
@@ -1,0 +1,1 @@
+FixClient to raise if empty byte is received.

--- a/testplan/common/utils/sockets/fix/client.py
+++ b/testplan/common/utils/sockets/fix/client.py
@@ -155,6 +155,9 @@ class Client:
         self.socket.settimeout(float(timeout))
 
         data = self.socket.recv(1)
+        if not data:
+            self.log_callback("Received empty data, peer closed?")
+            raise socket.error("Received empty data")
 
         parser = FixParser()
         size = parser.consume(data)


### PR DESCRIPTION
## Bug / Requirement Description
FixClient.receive() will return empty fixmsg if server side close.

## Solution description
Check socket.recv() result.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
