### PR TITLE
Bugfix/one sided repeated group display

### DIFF
--- a/testplan/common/utils/convert.py
+++ b/testplan/common/utils/convert.py
@@ -98,7 +98,6 @@ def expand_values(rows, level=0, ignore_key=False, key_path=None, match=""):
                     match=match,
                 )
         elif isinstance(val, list):
-            #if key is not Absent:  # if key is Absent and it is a list, then we bypass
             yield (tuple(key_path), level, key, match, "")
             yield from expand_values(
                 val, level=level, key_path=key_path, match=match

--- a/testplan/common/utils/convert.py
+++ b/testplan/common/utils/convert.py
@@ -28,27 +28,6 @@ def nested_groups(iterable, key_funcs):
 
     Key functions will be applied for sorting and group, beginning from the
     first function (top level).
-
-    The sample below will give us 2 top level groups and 4 sub groups:
-
-        * Numbers divisible by 10
-
-            - Numbers divisible by 10 and divisible by 3
-            - Numbers divisible by 10 and not divisible by 3
-
-        * Numbers not divisible by 10
-
-            - Numbers not divisible by 10 and divisible by 3
-            - Numbers not divisible by 10 and not divisible by 3
-
-    >>> nested_groups(
-    ...    range(1, 100),
-    ...    key_funcs=[
-    ...        lambda obj: obj % 10 == 0,
-    ...        lambda obj: obj % 3 == 0
-    ...    ]
-    ... )
-
     """
     first, rest = key_funcs[0], key_funcs[1:]
     grouping = sort_and_group(iterable, first)
@@ -109,7 +88,7 @@ def expand_values(rows, level=0, ignore_key=False, key_path=None, match=""):
         if isinstance(val, tuple):
             if val[0] == 0:  # value
                 yield (tuple(key_path), level, key, match, (val[1], val[2]))
-            elif val[0] in (1, 2, 3):
+            elif val[0] in (1, 2, 3):  # container
                 yield (tuple(key_path), level, key, match, "")
                 yield from expand_values(
                     val[1],
@@ -119,6 +98,7 @@ def expand_values(rows, level=0, ignore_key=False, key_path=None, match=""):
                     match=match,
                 )
         elif isinstance(val, list):
+            #if key is not Absent:  # if key is Absent and it is a list, then we bypass
             yield (tuple(key_path), level, key, match, "")
             yield from expand_values(
                 val, level=level, key_path=key_path, match=match
@@ -204,26 +184,6 @@ def flatten_formatted_object(formatted_obj):
 def flatten_dict_comparison(comparison):
     """
     Flatten the comparison object from dict/fix match into a list of rows.
-
-    Row elements: [level, key, status, left, right]
-
-    i.e:
-
-    .. code-block:: python
-
-      [
-          [0, 555, 'Passed', '', ''],
-          [0, '', 'Passed', '', ''],                       # Group result
-          [2, 600, 'Passed', ('str', 'A'), ('str', 'A')],
-          [2, 601, 'Passed', ('str', 'A'), ('str', 'A')],
-          [2, 683, 'Passed', '', ''],
-          [2, '', 'Passed', '', ''],                       # Group result
-          [4, 688, 'Passed', ('str', 'a'), ('str', 'a')],
-          [4, 689, 'Passed', ('str', 'a'), ('str', 'a')],
-          [2, '', 'Passed', '', ''],                       # Group result
-          [4, 688, 'Passed', ('str', 'b'), ('str', 'b')],
-          [4, 689, 'Passed', ('str', 'b'), ('str', 'b')]
-      ]
     """
     result_table = []  # level, key, left, right, result
 
@@ -233,7 +193,9 @@ def flatten_dict_comparison(comparison):
     while left or right:
         lpart, rpart = None, None
         if left and right:
-            if len(left[0][0]) > len(right[0][0]):
+            if left[0][2] is Absent and left[0][2] != right[0][2]:
+                lpart = left.pop(0)
+            elif len(left[0][0]) > len(right[0][0]):
                 lpart = left.pop(0)
             elif len(left[0][0]) < len(right[0][0]):
                 rpart = right.pop(0)

--- a/tests/unit/testplan/common/utils/test_convert.py
+++ b/tests/unit/testplan/common/utils/test_convert.py
@@ -1,0 +1,40 @@
+import pytest
+
+from testplan.common.utils.convert import flatten_dict_comparison
+
+
+comparisons = [
+    # expected = {38: 5, 555: [{600: 'A'}], 54: 2, 851: 4}
+    # actual = {38: 4, 54: 2, 20001: "SAMPLE"}
+    [
+        (38, "f", (0, "int", "5"), (0, "int", "4")),
+        (555, "f", (1, [(2, [(600, (0, "str", "A"))])]), (0, None, "ABSENT")),
+        (54, "p", (0, "int", "2"), (0, "int", "2")),
+        (851, "f", (0, "int", "4"), (0, None, "ABSENT")),
+        (20001, "f", (0, None, "ABSENT"), (0, "str", "SAMPLE")),
+    ],
+]
+result_tables = [
+    # expansion and extraction of left side from below comparison would
+    # produce an placeholder row
+    # ((555,), 1, 'ABSENT', 'f', '')
+    # which should not be popped together with a right side entry
+    # unless the same repeating group is present
+    [
+        [0, 38, "Failed", ("int", "5"), ("int", "4")],
+        [0, 555, "Failed", "", (None, "ABSENT")],
+        [0, "", "Failed", "", None],
+        [1, 600, "Failed", ("str", "A"), None],
+        [0, 54, "Passed", ("int", "2"), ("int", "2")],
+        [0, 851, "Failed", ("int", "4"), (None, "ABSENT")],
+        [0, 20001, "Failed", (None, "ABSENT"), ("str", "SAMPLE")],
+    ],
+]
+
+
+@pytest.mark.parametrize(
+    "comparison, result_table", zip(comparisons, result_tables)
+)
+def test_flatten_dict_comparison(comparison, result_table):
+    expected = flatten_dict_comparison(comparison)
+    assert expected == result_table


### PR DESCRIPTION
## Bug / Requirement Description
Reported in https://github.com/morganstanley/testplan/issues/848. The root cause is as follows: if in a dictionary comparison there is either a unique key referencing a container or the key is in both dictionaries, but one side is referencing a container value while the other not (container as handled in Testplan), then visual separators for separating groups break the construction of the result table in dictionary flattening.

## Solution description
For now, the visual separator row cannot be removed simply from the generator as it seems to be going "spaghetti" with some other logic. The row is of a special form and can be captured if only appears on one side of the comparison. This is exploited for a higher up filtering, just before the table is put together.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [x] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
