### PR TITLE
Make task discover work better for monorepo project

### DIFF
--- a/testplan/common/utils/path.py
+++ b/testplan/common/utils/path.py
@@ -254,7 +254,10 @@ def is_subdir(child, parent):
     :return: True if child is a sub-directory of the parent.
     :rtype: ``bool``
     """
-    return child.startswith(parent)
+
+    return fix_home_prefix(os.path.abspath(child)).startswith(
+        fix_home_prefix(os.path.abspath(parent))
+    )
 
 
 def hash_file(filepath):

--- a/testplan/runners/pools/child.py
+++ b/testplan/runners/pools/child.py
@@ -423,6 +423,7 @@ if __name__ == "__main__":
     ARGS = parse_cmdline()
     if ARGS.wd:
         os.chdir(ARGS.wd)
+        os.environ["PWD"] = ARGS.wd
 
     if ARGS.sys_path_file:
         sys.path = parse_syspath_file(ARGS.sys_path_file)

--- a/testplan/runners/pools/process.py
+++ b/testplan/runners/pools/process.py
@@ -49,9 +49,6 @@ class ProcessWorker(Worker):
 
     CONFIG = ProcessWorkerConfig
 
-    def __init__(self, **options):
-        super(ProcessWorker, self).__init__(**options)
-
     def _child_path(self):
         dirname = os.path.dirname(os.path.abspath(__file__))
         return os.path.join(dirname, "child.py")


### PR DESCRIPTION
## Bug / Requirement Description
change current dir to different sub dir if working on a monorepo proj

## Solution description
Example and new frag is in internal PR

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
