### PR TITLE
Reset uid when saving report in interactive mode.

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Set up Kafka for tests
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          wget https://downloads.apache.org/kafka/2.8.1/kafka_2.12-2.8.1.tgz -O kafka.tgz
+          wget https://downloads.apache.org/kafka/2.8.2/kafka_2.13-2.8.2.tgz -O kafka.tgz
           sudo mkdir /opt/kafka
           sudo chown -R $USER:$USER /opt/kafka
           tar zxf kafka.tgz -C /opt/kafka --strip-components 1

--- a/doc/newsfragments/2117_changed.interactive_uid.rst
+++ b/doc/newsfragments/2117_changed.interactive_uid.rst
@@ -1,0 +1,1 @@
+Fixed an issue where report saved from interactive mode having problem with testcases having the same name.

--- a/examples/Interactive/Basic/test_plan.py
+++ b/examples/Interactive/Basic/test_plan.py
@@ -23,7 +23,7 @@ def main(plan):
     plan.add(make_multitest(idx="1"))
     plan.schedule(
         target="make_multitest",
-        module="mytests.mtest",
+        module="my_tests.mtest",
         path=".",
         kwargs=dict(idx=2),
     )

--- a/testplan/runnable/interactive/http.py
+++ b/testplan/runnable/interactive/http.py
@@ -4,6 +4,7 @@ Http handler for interactive mode.
 
 import os
 import time
+import copy
 import functools
 import traceback
 
@@ -577,7 +578,9 @@ def generate_interactive_api(ihandler):
                             "uid": strings.uuid4(),
                         }
                         try:
-                            export_path = exporter.export(ihandler.report)
+                            report = copy.deepcopy(ihandler.report)
+                            report.reset_uid()
+                            export_path = exporter.export(report)
                             export_result["success"] = True
                             export_result["message"] = export_path
                         except Exception:


### PR DESCRIPTION
## Bug / Requirement Description
There are some potential issues if we use same testcase name in different testsuites. 

## Solution description
Reset uid when saving report in interactive mode.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
