### PR TITLE
restore result.log functionality to display xml as raw string

### DIFF
--- a/doc/newsfragments/2187_changed.result_log_raw_xml.rst
+++ b/doc/newsfragments/2187_changed.result_log_raw_xml.rst
@@ -1,0 +1,1 @@
+result.log should display xml as a raw string. This functionality was temporarily broken and is now restored.

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/basicAssertionUtils.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/basicAssertionUtils.js
@@ -48,7 +48,7 @@ function prepareLogContent(assertion, defaultContent) {
     
   decodedMsg = < div dangerouslySetInnerHTML = {
     {
-      __html: linkifyUrls(decodedMsg, {
+      __html: linkifyUrls(_.escape(decodedMsg), {
         attributes: {
           target: "_blank"
         }


### PR DESCRIPTION
## Bug / Requirement Description
result.log should display xml as a raw string. This functionality was broken in error.

## Solution description
Using lodash's escape function to prevent XML from being converted to html

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
