### PR TITLE
split discover and schedule_all

### DIFF
--- a/doc/newsfragments/2032_new.disable_parts_for_interactive.rst
+++ b/doc/newsfragments/2032_new.disable_parts_for_interactive.rst
@@ -1,0 +1,3 @@
+:py:meth:`@task_target <testplan.runners.pools.tasks.base.task_target>` gets a ``multitest_parts`` parameter, and
+it will create multiple multitest parts instances from the target. Note that this feature does not apply to interactive
+mode. The :ref:`downloadable example <example_discover>` has been updated with this new usage.

--- a/examples/ExecutionPools/Discover/sub_proj1/tasks.py
+++ b/examples/ExecutionPools/Discover/sub_proj1/tasks.py
@@ -33,3 +33,23 @@ def make_multitest(name, part_tuple=None, suites=None):
         name=name, suites=[cls() for cls in suites], part=part_tuple
     )
     return test
+
+
+# an alternative way of specifying parts for multitest
+@task_target(
+    parameters=(
+        dict(
+            name="Proj1-Suite1-Again",
+            suites=[sub_proj1.suites.Suite1],
+        ),
+    ),
+    # instruct testplan to split each multitest task into parts
+    multitest_parts=2,
+    # additional args of Task class
+    rerun=1,
+    weight=1,
+)
+def make_multitest(name, suites=None):
+    # a test target shall only return 1 runnable object
+    test = MultiTest(name=name, suites=[cls() for cls in suites])
+    return test

--- a/testplan/common/report/base.py
+++ b/testplan/common/report/base.py
@@ -57,7 +57,7 @@ class Report:
         self.name = name
         self.description = description
 
-        self.uid = uid or strings.uuid4()
+        self.uid = uid or name
         self.entries = entries or []
 
         self.logs = []

--- a/testplan/common/utils/path.py
+++ b/testplan/common/utils/path.py
@@ -74,17 +74,19 @@ def change_directory(directory):
     :param directory: Directory to change into.
     :type directory: ``str``
     """
-    old_directory = os.getcwd()
-    directory = fix_home_prefix(directory)
-    os.chdir(directory)
-    if "PWD" in os.environ:
-        os.environ["PWD"] = directory
+    if directory:  # in case we get a None directory, do nothing
+        old_directory = os.getcwd()
+        directory = fix_home_prefix(directory)
+        os.chdir(directory)
+        if "PWD" in os.environ:
+            os.environ["PWD"] = directory
     try:
         yield
     finally:
-        os.chdir(old_directory)
-        if "PWD" in os.environ:
-            os.environ["PWD"] = old_directory
+        if directory:
+            os.chdir(old_directory)
+            if "PWD" in os.environ:
+                os.environ["PWD"] = old_directory
 
 
 def makedirs(path):

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -680,14 +680,14 @@ class TestRunner(Runnable):
 
     def _verify_test_target(
         self, target: Union[Test, Task, Callable]
-    ) -> Optional[Test]:
+    ) -> Optional[str]:
         """
         Materialize the test target, and:
         - check uniqueness
         - check against filter
         - check against lister
         - check runnable type
-        - cut conner for interactive mode
+        - cut corner for interactive mode
         Return the runnable uid if it should run, otherwise None.
         """
         # The target added into TestRunner can be: 1> a real test entity

--- a/testplan/runners/local.py
+++ b/testplan/runners/local.py
@@ -26,14 +26,12 @@ class LocalRunner(Executor):
         """Execute item implementation."""
         # First retrieve the input from its UID.
         target = self._input[uid]
-        task_path = None
 
         # Inspect the input type. Tasks must be materialized before
         # they can be run.
         if isinstance(target, Test):
             runnable = target
         elif isinstance(target, tasks.Task):
-            task_path = target._path
             runnable = target.materialize()
         elif callable(target):
             runnable = target()
@@ -53,12 +51,7 @@ class LocalRunner(Executor):
         if not runnable.cfg.parent:
             runnable.cfg.parent = self.cfg
 
-        # for task discovery used with a monorepo project
-        if task_path and not is_subdir(task_path, pwd()):
-            with change_directory(os.path.abspath(task_path)):
-                result = runnable.run()
-        else:
-            result = runnable.run()
+        result = runnable.run()
 
         self._results[uid] = result
 

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -219,7 +219,6 @@ class Worker(WorkerBase):
         :rtype: :py:class:`~testplan.runners.pools.tasks.base.TaskResult`
         """
         try:
-            task_path = getattr(task, "_rebased_path")
             runnable = task.materialize()
 
             if isinstance(runnable, entity.Runnable):
@@ -228,12 +227,7 @@ class Worker(WorkerBase):
                 if not runnable.cfg.parent:
                     runnable.cfg.parent = self.cfg
 
-            # for task discovery used with a monorepo project
-            if task_path and not is_subdir(task_path, pwd()):
-                with change_directory(os.path.abspath(task_path)):
-                    result = runnable.run()
-            else:
-                result = runnable.run()
+            result = runnable.run()
 
         except BaseException:
             task_result = TaskResult(

--- a/testplan/runners/pools/tasks/base.py
+++ b/testplan/runners/pools/tasks/base.py
@@ -7,7 +7,9 @@ from collections import OrderedDict
 
 import pickle
 import copy
+from typing import Union, Tuple, Optional
 
+from testplan.common.entity import Runnable
 from testplan.common.utils import strings
 from testplan.common.utils.package import import_tmp_module
 from testplan.common.utils.path import rebase_path, is_subdir, pwd
@@ -52,42 +54,33 @@ class Task:
     :param target: A runnable or a string path to a runnable or
                    a callable to a runnable or a string path to a callable
                    to a runnable.
-    :type target: ``str`` path or runnable ``object``
     :param module: Module name that contains the task target definition.
-    :type module: ``str``
     :param path: Path to module, default is current working directory.
-    :type path: ``str``
     :param args: Args of target for task materialization.
-    :type args: ``tuple``
     :param kwargs: Kwargs of target for task materialization.
-    :type kwargs: ``kwargs``
     :param uid: Task uid.
-    :type uid: ``str``
     :param rerun: Rerun the task up to user specified times until it passes,
         by default 0 (no rerun). To enable task rerun feature, set to positive
         value no greater than 3.
-    :type rerun: ``int``
     :param weight: Affects task scheduling - the larger the weight, the sooner
         task will be assigned to a worker. Default weight is 0, tasks with the
         same weight will be scheduled in the order they are added.
-    :type weight: ``int``
     :param part: part param that will be propagate to MultiTest
-    :type part: ``tuple`` of (``int``, ``int``)
     """
 
     MAX_RERUN_LIMIT = 3
 
     def __init__(
         self,
-        target=None,
-        module=None,
-        path=None,
-        args=None,
-        kwargs=None,
-        uid=None,
-        rerun=0,
-        weight=0,
-        part=None,
+        target: Optional[Union[str, Runnable]] = None,
+        module: Optional[str] = None,
+        path: Optional[str] = None,
+        args: Optional[tuple] = None,
+        kwargs: Optional[dict] = None,
+        uid: Optional[str] = None,
+        rerun: int = 0,
+        weight: int = 0,
+        part: Optional[Tuple[int, int]] = None,
     ):
         self._target = target
         self._module = module

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -5,7 +5,7 @@ import concurrent
 import functools
 import itertools
 import os
-from typing import Callable, Optional
+from typing import Callable, Optional, Tuple
 
 from schema import And, Or, Use
 
@@ -1235,7 +1235,7 @@ class MultiTest(testing_base.Test):
 
     def set_part(
         self,
-        part: tuple,
+        part: Tuple[int, int],
     ) -> None:
         """
         :param part: Enable the part feature and execute only a part of the

--- a/tests/functional/testplan/runnable/interactive/interactive_executable.py
+++ b/tests/functional/testplan/runnable/interactive/interactive_executable.py
@@ -490,6 +490,7 @@ def main():
         actual_reports=actual_reports,
         ignore=["file_path", "line_no", "machine_time", "utc_time"],
     )
+
     assert plan.i.report.passed is True
 
 

--- a/tests/functional/testplan/testing/fixtures/base/passing/report.py
+++ b/tests/functional/testplan/testing/fixtures/base/passing/report.py
@@ -8,7 +8,6 @@ from testplan.testing.multitest.entries.assertions import RawAssertion
 
 testcase_report = TestCaseReport(
     name="ExitCodeCheck",
-    uid="ExitCodeCheck",
     suite_related=True,
     entries=[
         {

--- a/tests/unit/testplan/common/report/test_base.py
+++ b/tests/unit/testplan/common/report/test_base.py
@@ -2,6 +2,7 @@ import logging
 import functools
 import re
 from unittest import mock
+import uuid
 
 import pytest
 
@@ -89,8 +90,8 @@ class TestReport:
         """Should raise ValueError on failure"""
 
         # These will have different ids
-        rep_1 = DummyReport()
-        rep_2 = DummyReport()
+        rep_1 = DummyReport(uid=1)
+        rep_2 = DummyReport(uid=2)
 
         with pytest.raises(AttributeError):
             rep_1._check_report(rep_2)
@@ -161,7 +162,7 @@ class TestReportGroup:
         report `ids` as keys and child report as values.
         """
         parent = DummyReportGroup()
-        children = [DummyReport() for idx in range(3)]
+        children = [DummyReport(uid=idx) for idx in range(3)]
 
         assert parent._index == {}
 
@@ -175,11 +176,11 @@ class TestReportGroup:
     def test_build_index_recursive(self):
         """Recursive index build should propagate to all children."""
         child_1, child_2, child_3, child_4 = [
-            DummyReport() for idx in range(4)
+            DummyReport(uid=idx) for idx in range(4)
         ]
 
-        parent_1 = DummyReportGroup()
-        parent_2 = DummyReportGroup()
+        parent_1 = DummyReportGroup(uid=0)
+        parent_2 = DummyReportGroup(uid=1)
         grand_parent = DummyReportGroup()
 
         assert grand_parent._index == {}

--- a/tests/unit/testplan/runnable/interactive/test_api.py
+++ b/tests/unit/testplan/runnable/interactive/test_api.py
@@ -31,11 +31,9 @@ def example_report():
     """Create a new report skeleton."""
     return report.TestReport(
         name="Interactive API Test",
-        uid="Interactive API Test",
         entries=[
             report.TestGroupReport(
                 name="MTest1",
-                uid="MTest1",
                 category=report.ReportCategories.MULTITEST,
                 env_status=entity.ResourceStatus.STOPPED,
                 parent_uids=["Interactive API Test"],

--- a/tests/unit/testplan/test_plan_base.py
+++ b/tests/unit/testplan/test_plan_base.py
@@ -48,9 +48,6 @@ class DummyTest(Test):
         self.resources.add(DummyDriver(), uid=self.name)
         self.resources.add(DummyDriver())
 
-    def uid(self):
-        return self.name or super(DummyTest, self).uid()
-
     def run_tests(self):
         self._result.custom = "{}Result[{}]".format(
             self.__class__.__name__, self.name


### PR DESCRIPTION
## Bug / Requirement Description
1) @task_target decorator now takes a multitest_parts param, and will automatically create multiple multitest instance from one target.
2) split discover and schedule_all
3) fix monorepo binary path derivation for interactive mode, and push the handling down to Test object
3) use name as uid for report (which later on will be reset to uuid)

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [ ] Test
- [x] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
