### PR TITLE
Convert 'bytes' elements to 'str' in TableLogRenderer

### DIFF
--- a/testplan/testing/multitest/entries/stdout/base.py
+++ b/testplan/testing/multitest/entries/stdout/base.py
@@ -125,6 +125,12 @@ class DirectoryRenderer(BaseRenderer):
 @registry.bind(base.TableLog)
 class TableLogRenderer(BaseRenderer):
     def get_details(self, entry):
+        # AsciiTable doesn't support cells with 'bytes' values so we need to convert them to 'str'
+        for j, row in enumerate(entry.table):
+            for i, cell in enumerate(row):
+                if isinstance(cell, bytes):
+                    entry.table[j][i] = str(cell)
+
         return AsciiTable([entry.columns] + entry.table).table
 
 

--- a/tests/unit/testplan/testing/multitest/entries/test_base.py
+++ b/tests/unit/testplan/testing/multitest/entries/test_base.py
@@ -1,4 +1,5 @@
 from testplan.testing.multitest.entries import base
+from testplan.testing.multitest.entries.stdout import base as stdout_base
 
 from testplan.testing.multitest.entries import assertions
 
@@ -116,3 +117,22 @@ def test_summary():
 
     assert len(alpha_category_less_passing.entries) == summary.num_passing
     assert len(alpha_category_less_failing.entries) == summary.num_failing
+
+
+def test_TableLogRenderer():
+    dict_of_types = {
+        "bytes": "@βcdé".encode("UTF-8"),
+        "int": 24,
+        "string": "something",
+    }
+    list_of_lists = [[k, v] for k, v in dict_of_types.items()]
+    list_of_lists.insert(0, ["type", "value"])
+
+    # TableLogRenderer requires a 'TableLog' as an input and gives back a 'string'
+    flattened_table = stdout_base.TableLogRenderer().get_details(
+        base.TableLog(table=list_of_lists)
+    )
+
+    assert isinstance(flattened_table, str)
+    for value in dict_of_types.values():
+        assert str(value) in flattened_table


### PR DESCRIPTION
## Bug / Requirement Description
We are using AsciiTable class from terminaltables to draw tables to console using regular ASCII characters. The library doesn't support 'bytes' values and fails when the input table contains one.

## Solution description
TableLogRenderer looks for 'bytes' elements of the input table and converts them to 'str' before calling AsciiTables.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
