### PR TITLE
Add average load to hardware information

### DIFF
--- a/doc/newsfragments/2262_new.average_load_utility.rst
+++ b/doc/newsfragments/2262_new.average_load_utility.rst
@@ -1,0 +1,1 @@
+Added :py:meth:`get_hardware_info <testplan.common.utils.helper.get_hardware_info>` for returning hardware information independent of reporting. :py:meth:`log_hardware <testplan.common.utils.helper.log_hardware>` now logs average load.

--- a/testplan/common/utils/helper.py
+++ b/testplan/common/utils/helper.py
@@ -8,6 +8,7 @@ Also provided is a predefined testsuite that can be included in user's
 """
 
 __all__ = [
+    "get_hardware_info",
     "log_pwd",
     "log_hardware",
     "log_cmd",
@@ -25,12 +26,37 @@ import psutil
 import shutil
 import socket
 import sys
+from typing import Dict
 
 from testplan.common.entity import Environment
 from testplan.common.utils.logger import TESTPLAN_LOGGER
 from testplan.common.utils.path import pwd
 from testplan.testing.multitest import testsuite, testcase
 from testplan.testing.multitest.result import Result
+
+
+def get_hardware_info() -> Dict:
+    """
+    Return a variety of host hardware information.
+
+    :return: dictionary of hardware information
+    """
+    return {
+        "CPU count": psutil.cpu_count(),
+        "CPU frequence": str(psutil.cpu_freq()),
+        "CPU percent": psutil.cpu_percent(interval=1, percpu=True),
+        "Average load": dict(
+            zip(
+                ["Over 1 min", "Over 5 min", "Over 15 min"],
+                os.getloadavg(),
+            )
+        ),
+        "Memory": str(psutil.virtual_memory()),
+        "Swap": str(psutil.swap_memory()),
+        "Disk usage": str(psutil.disk_usage(os.getcwd())),
+        "Net interface addresses": psutil.net_if_addrs(),
+        "PID": os.getpid(),
+    }
 
 
 def log_hardware(result: Result) -> None:
@@ -40,16 +66,7 @@ def log_hardware(result: Result) -> None:
     :param result: testcase result
     """
     result.log(socket.getfqdn(), description="Current Host")
-    hardware = {
-        "CPU count": psutil.cpu_count(),
-        "CPU frequence": str(psutil.cpu_freq()),
-        "CPU percent": psutil.cpu_percent(interval=1, percpu=True),
-        "Memory": str(psutil.virtual_memory()),
-        "Swap": str(psutil.swap_memory()),
-        "Disk usage": str(psutil.disk_usage(os.getcwd())),
-        "Net interface addresses": psutil.net_if_addrs(),
-        "PID": os.getpid(),
-    }
+    hardware = get_hardware_info()
     result.dict.log(hardware, description="Hardware info")
 
 


### PR DESCRIPTION
## Bug / Requirement Description
There is a request to add average load to the hardware log utility.

## Solution description
Added average load to hardware information. The dictionary itself is made accessible through another utility function to support different reporting uses.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
