### PR TITLE
Replace os.getloadavg with psutil.getloadavg

### DIFF
--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -1,6 +1,6 @@
 pytest
 py
-psutil
+psutil>=5.6.7
 setuptools
 schema
 pytz

--- a/testplan/common/utils/helper.py
+++ b/testplan/common/utils/helper.py
@@ -48,7 +48,7 @@ def get_hardware_info() -> Dict:
         "Average load": dict(
             zip(
                 ["Over 1 min", "Over 5 min", "Over 15 min"],
-                os.getloadavg(),
+                psutil.getloadavg(),
             )
         ),
         "Memory": str(psutil.virtual_memory()),


### PR DESCRIPTION
## Bug / Requirement Description
os.getloadavg does not run on Windows. psutil.getloadavg emulates it.

## Solution description
Pin psutil version at least 5.6.7 and replace os.getloadavg with psutil analogue.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
