### PR TITLE
Misc/add a missing news fragment

### DIFF
--- a/doc/newsfragments/2291_changed.fix_filter_serialization.rst
+++ b/doc/newsfragments/2291_changed.fix_filter_serialization.rst
@@ -1,0 +1,1 @@
+Fix a bug that certain configuration object cannot be serialized and makes remote execution fail.


### PR DESCRIPTION
## Bug / Requirement Description
News frag missing in #882 .

## Solution description
Add it here.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
