### PR TITLE
Fix/fix a module path resolution in functional tests

### DIFF
--- a/testplan/common/utils/watcher.py
+++ b/testplan/common/utils/watcher.py
@@ -13,10 +13,11 @@ except ImportError:
 
 from coverage import Coverage, CoverageData
 
+from testplan.common.utils.logger import Loggable
 from testplan.report.testing.base import TestCaseReport, TestGroupReport
 
 
-class Watcher:
+class Watcher(Loggable):
     """
     Utility class for testcase execution tracing.
 
@@ -32,6 +33,7 @@ class Watcher:
     """
 
     def __init__(self):
+        super().__init__()
         self._disabled: bool = False
         self._watching_lines: Optional[
             Dict[str, Union[List[int], Literal["*"]]]
@@ -43,6 +45,9 @@ class Watcher:
     ):
         if watching_lines:
             self._watching_lines = watching_lines
+            self.logger.debug(
+                f"Now tracing following files: {list(self._watching_lines.keys())}"
+            )
             # we explicitly disable writing coverage data to file
             self._tracer = Coverage(
                 data_file=None,

--- a/tests/functional/testplan/coverage/test_trace_tests.py
+++ b/tests/functional/testplan/coverage/test_trace_tests.py
@@ -41,7 +41,9 @@ def temp_file_name():
 
 @pytest.fixture(scope="module")
 def subject_path():
-    yield os.path.join(os.path.dirname(__file__), "subject_module.py")
+    yield os.path.realpath(
+        os.path.join(os.path.dirname(__file__), "subject_module.py")
+    )
 
 
 @mt.testsuite


### PR DESCRIPTION
## Bug / Requirement Description
symlinks not resolved

## Solution description
use `os.path.realpath`

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
