### PR TITLE
Added UTC time to Group and GroupSchema

### DIFF
--- a/doc/newsfragments/2212_changed.fixed_blank_page_on_time_information.rst
+++ b/doc/newsfragments/2212_changed.fixed_blank_page_on_time_information.rst
@@ -1,0 +1,1 @@
+Fixed the problem when time information on UI turned the page blank due to missing UTC time field of Group objects.

--- a/testplan/testing/multitest/entries/base.py
+++ b/testplan/testing/multitest/entries/base.py
@@ -75,6 +75,7 @@ class Group:
     meta_type = "assertion"
 
     def __init__(self, entries, description=None):
+        self.utc_time = utcnow()
         self.description = description
         self.entries = entries
 

--- a/testplan/testing/multitest/entries/schemas/base.py
+++ b/testplan/testing/multitest/entries/schemas/base.py
@@ -42,6 +42,7 @@ class BaseSchema(Schema):
 @registry.bind(base.Group, base.Summary)
 class GroupSchema(Schema):
     type = custom_fields.ClassName()
+    utc_time = custom_fields.UTCDateTime()
     passed = fields.Boolean()
     meta_type = fields.String()
     description = custom_fields.Unicode(allow_none=True)


### PR DESCRIPTION
## Bug / Requirement Description
In Summary example, turning on time information turns the page blank. Reason is missing UTC time field in the Group objects.

## Solution description
Added UTC time to both Group and GroupSchema objects.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
