### PR TITLE
Feature/allow marking testcases as xfail tests dynamically

### DIFF
--- a/doc/en/introduction.rst
+++ b/doc/en/introduction.rst
@@ -338,6 +338,7 @@ Command line
       --trace-tests         Enable the tracing tests feature. A JSON file containing file names and line numbers to be watched by the tracer must be specified.
       --trace-tests-output
                             Specify output file for tests impacted by change in Testplan pattern format (see --trace-tests). Will be ignored if --trace-tests is not specified. Default to standard output.
+      --xfail-tests         Read a list of known to fail testcases from a JSON file with each entry looks like: {"<Multitest>:<TestSuite>:<testcase>": {"reason": <value>, "strict": <value>} }
 
     Filtering:
       --patterns            Test filter, supports glob notation & multiple arguments.

--- a/doc/newsfragments/2217_new.xfail_tests_cmdline.rst
+++ b/doc/newsfragments/2217_new.xfail_tests_cmdline.rst
@@ -1,0 +1,1 @@
+Introduced a new command line argument ``--xfail-tests`` to allow users mark testcase as xfail dynamically. This argument accepts a JSON file containing names of testcases to mark as xfail (exact match) and their corresponding reasons and xfail strictness.

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -142,6 +142,16 @@ class TestplanParser:
             'if "--trace-tests" is not specified. Default to standard output.',
         )
 
+        general_group.add_argument(
+            "--xfail-tests",
+            metavar="PATH",
+            type=_read_json_file,
+            help="Read a list of known to fail testcases from a JSON file"
+            "each entry looks like: "
+            '{"<Multitest>:<TestSuite>:<testcase>": '
+            '{"reason": <value>, "strict": <value>} }',
+        )
+
         filter_group = parser.add_argument_group("Filtering")
 
         filter_group.add_argument(
@@ -374,6 +384,7 @@ that match ALL of the given tags.
             help="Specifies log level for file logs. Set to None to disable "
             "file logging.",
         )
+
         report_group.add_argument(
             "--label",
             default=None,

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -146,8 +146,8 @@ class TestplanParser:
             "--xfail-tests",
             metavar="PATH",
             type=_read_json_file,
-            help="Read a list of known to fail testcases from a JSON file"
-            "each entry looks like: "
+            help="Read a list of known to fail testcases from a JSON file "
+            "with each entry looks like: "
             '{"<Multitest>:<TestSuite>:<testcase>": '
             '{"reason": <value>, "strict": <value>} }',
         )

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -8,7 +8,6 @@ import time
 import uuid
 import webbrowser
 from collections import OrderedDict
-from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -198,6 +197,7 @@ class TestRunnerConfig(RunnableConfig):
             ConfigOption("reporting_filter", default=None): Or(
                 And(str, Use(ReportingFilter.parse)), None
             ),
+            ConfigOption("xfail_tests", default=None): Or(dict, None),
         }
 
 

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -4,6 +4,7 @@ import collections.abc
 import concurrent
 import functools
 import itertools
+import json
 import os
 from typing import Callable, Optional, Tuple
 
@@ -360,6 +361,24 @@ class MultiTest(testing_base.Test):
                 ]
 
             if testcases_to_run:
+                if hasattr(self.cfg, "xfail_tests") and self.cfg.xfail_tests:
+                    for testcase in testcases_to_run:
+                        testcase_instance = ":".join(
+                            [
+                                self.name,
+                                suite.__class__.__name__,
+                                testcase.name,
+                            ]
+                        )
+                        data = self.cfg.xfail_tests.get(
+                            testcase_instance, None
+                        )
+                        if data is not None:
+                            testcase.__xfail__ = {
+                                "reason": data["reason"],
+                                "strict": data["strict"],
+                            }
+
                 ctx.append((suite, testcases_to_run))
 
         return ctx

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -4,7 +4,6 @@ import collections.abc
 import concurrent
 import functools
 import itertools
-import json
 import os
 from typing import Callable, Optional, Tuple
 

--- a/tests/functional/testplan/testing/multitest/test_xfail.py
+++ b/tests/functional/testplan/testing/multitest/test_xfail.py
@@ -1,4 +1,5 @@
-from testplan.testing.multitest import MultiTest, testsuite, testcase, xfail
+from testplan import TestplanMock
+from testplan.testing.multitest import MultiTest, testcase, testsuite, xfail
 
 
 @testsuite
@@ -29,6 +30,42 @@ class NoStrictXfailedSuite:
     @xfail("Should be pass", strict=False)
     def test_pass(self, env, result, val):
         result.true(val < 100, description="Check if value is true")
+
+
+@testsuite
+class DynamicXfailSuite:
+    """A test suite to check dynamic allocation of xfail decorator"""
+
+    @testcase
+    def test_1(self, env, result):
+        result.equal(2, 3)
+
+    @testcase(parameters=(3,))
+    def test_2(self, env, result, n):
+        result.equal(2, n)
+
+
+def test_dynamic_xfail():
+    plan = TestplanMock(
+        name="dynamic_xfail_test",
+        xfail_tests={
+            "Dummy:DynamicXfailSuite:test_1": {
+                "reason": "known flaky",
+                "strict": False,
+            },
+            "Dummy:DynamicXfailSuite:test_2 <n=3>": {
+                "reason": "unknown non-flaky",
+                "strict": True,
+            },
+        },
+    )
+    plan.add(MultiTest(name="Dummy", suites=[DynamicXfailSuite()]))
+    result = plan.run()
+
+    dynamic_xfail_suite_report = result.report.entries[0].entries[0]
+
+    assert dynamic_xfail_suite_report.unstable is True
+    assert dynamic_xfail_suite_report.entries[0].unstable is True
 
 
 def test_xfail(mockplan):


### PR DESCRIPTION
Originally implemented by John Adzadogo.

## Bug / Requirement Description
To allow marking certain testcases as xfail tests dynamically.

## Solution description
Adding new cmdline argument accepting a JSON file including testcases to add xfail decorator before execution.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [x] For new cmdline arg: documentation
