### PR TITLE
Align TPS report tool with new method names of 8.1.x

### DIFF
--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -25,6 +25,7 @@ rpyc
 coverage
 memoization
 typing_extensions
+click>=8.1.0
 
 # Documentation
 # ---------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ plotly
 pandas
 numpy
 sphinx-click
-click>=8.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ plotly
 pandas
 numpy
 sphinx-click
-click
+click>=8.1.0

--- a/testplan/cli/converter/__init__.py
+++ b/testplan/cli/converter/__init__.py
@@ -15,7 +15,7 @@ def convert() -> None:
     pass
 
 
-@convert.resultcallback()
+@convert.result_callback()
 def run_actions(
     actions: Sequence[Union[ParseSingleAction, ProcessResultAction]]
 ) -> None:

--- a/testplan/cli/display.py
+++ b/testplan/cli/display.py
@@ -19,7 +19,7 @@ display.help = display_command.help
 display.params = display_command.params
 
 
-@display.resultcallback()
+@display.result_callback()
 def run_actions(parse_action, **kwargs):
 
     result = parse_action()

--- a/testplan/cli/merger/__init__.py
+++ b/testplan/cli/merger/__init__.py
@@ -46,7 +46,7 @@ def is_parse_action(action: object) -> bool:
     return isinstance(action, (ParseSingleAction, ParseMultipleAction))
 
 
-@merge.resultcallback()
+@merge.result_callback()
 def run_actions(actions) -> None:
     """ """
     # phase1 read inputs


### PR DESCRIPTION
## Bug / Requirement Description
Newer version of click comes with a method rename we need to accomodate.

## Solution description
Renaming method calls.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
