### PR TITLE
Feature/allow user to specify which host to bind to for Kafka & Zookeeper drivers

### DIFF
--- a/doc/en/drivers_build_in.rst
+++ b/doc/en/drivers_build_in.rst
@@ -35,3 +35,9 @@ Built-in drivers
     * :py:class:`Sqlite3 <testplan.testing.multitest.driver.sqlite.Sqlite3>`
       to connect to a database and perform sql queries etc. Examples can be
       found :ref:`here <example_sqlite3>`.
+
+    * :py:class:`ZookeeperStandalone <testplan.testing.multitest.driver.zookeeper.ZookeeperStandalone>`
+      to start one standalone Zookeeper instance. Examples can be found :ref:`here <example_zookeeper>`.
+
+    * :py:class:`KafkaStandalone <testplan.testing.multitest.driver.kafka.KafkaStandalone>`
+      to start one standalone Kafka instance. Examples can be found :ref:`here <example_kafka>`.

--- a/doc/newsfragments/2318_changed.zookeeper_kafka_allow_host.rst
+++ b/doc/newsfragments/2318_changed.zookeeper_kafka_allow_host.rst
@@ -1,0 +1,1 @@
+Allow user to specify host to bind to for driver :py:class:`KafkaStandalone <testplan.testing.multitest.driver.kafka.KafkaStandalone>` and :py:class:`ZookeeperStandalone <testplan.testing.multitest.driver.zookeeper.ZookeeperStandalone>`.

--- a/testplan/testing/multitest/driver/kafka.py
+++ b/testplan/testing/multitest/driver/kafka.py
@@ -3,14 +3,14 @@ Driver for Kafka server
 """
 import os
 import re
+import socket
+from typing import Optional
+
+from schema import Or
 
 from testplan.common.config import ConfigOption
 from testplan.common.utils.documentation_helper import emphasized
-from testplan.common.utils.path import (
-    makeemptydirs,
-    makedirs,
-    instantiate,
-)
+from testplan.common.utils.path import instantiate, makedirs, makeemptydirs
 from testplan.testing.multitest.driver import app
 
 KAFKA_START = "/opt/kafka/bin/kafka-server-start.sh"
@@ -26,6 +26,7 @@ class KafkaStandaloneConfig(app.AppConfig):
     def get_options(cls):
         return {
             ConfigOption("cfg_template"): str,
+            ConfigOption("host"): Or(str, None),
             ConfigOption("port"): int,
         }
 
@@ -49,7 +50,13 @@ class KafkaStandalone(app.App):
     CONFIG = KafkaStandaloneConfig
 
     def __init__(
-        self, name, cfg_template, binary=KAFKA_START, port=0, **options
+        self,
+        name: str,
+        cfg_template: str,
+        binary: str = KAFKA_START,
+        host: Optional[str] = None,
+        port: int = 0,
+        **options
     ):
         stdout_regexps = [
             re.compile(
@@ -61,25 +68,33 @@ class KafkaStandalone(app.App):
             name=name,
             cfg_template=cfg_template,
             binary=binary,
+            host=host,
             port=port,
             stdout_regexps=stdout_regexps,
             **options
         )
 
-        self.zookeeper_connect = None
         self.log_path = None
         self.etc_path = None
         self.config = None
+        self._host = host
         self._port = port
 
     @emphasized
     @property
-    def port(self):
+    def host(self) -> Optional[str]:
+        """Host to bind to."""
+        return self._host
+
+    @emphasized
+    @property
+    def port(self) -> int:
         """Port to listen on."""
         return self._port
 
     def pre_start(self):
         super(KafkaStandalone, self).pre_start()
+        self._host = self._host or socket.getfqdn()
         self.log_path = os.path.join(self.runpath, "log")
         self.etc_path = os.path.join(self.runpath, "etc")
         for directory in (self.log_path, self.etc_path):

--- a/testplan/testing/multitest/driver/zookeeper.py
+++ b/testplan/testing/multitest/driver/zookeeper.py
@@ -64,7 +64,7 @@ class ZookeeperStandalone(Driver):
         host: Optional[str] = None,
         port: int = 2181,
         env: Optional[dict] = None,
-        **options
+        **options,
     ):
         super(ZookeeperStandalone, self).__init__(
             name=name,
@@ -73,7 +73,7 @@ class ZookeeperStandalone(Driver):
             host=host,
             port=port,
             env=env,
-            **options
+            **options,
         )
         self._host = host
         self._port = port

--- a/testplan/testing/multitest/driver/zookeeper.py
+++ b/testplan/testing/multitest/driver/zookeeper.py
@@ -2,20 +2,21 @@
 Driver for Zookeeper server
 """
 import os
+import socket
+from typing import Optional
 
 from schema import Or
 
 from testplan.common.config import ConfigOption
 from testplan.common.utils.documentation_helper import emphasized
 from testplan.common.utils.path import (
-    makeemptydirs,
-    makedirs,
-    instantiate,
     StdFiles,
+    instantiate,
+    makedirs,
+    makeemptydirs,
 )
 from testplan.common.utils.process import execute_cmd
-from testplan.testing.multitest.driver.base import DriverConfig, Driver
-
+from testplan.testing.multitest.driver.base import Driver, DriverConfig
 
 ZK_SERVER = "/usr/share/zookeeper/bin/zkServer.sh"
 
@@ -31,6 +32,7 @@ class ZookeeperStandaloneConfig(DriverConfig):
         return {
             ConfigOption("cfg_template"): str,
             ConfigOption("binary"): str,
+            ConfigOption("host"): Or(None, str),
             ConfigOption("port"): int,
             ConfigOption("env", default=None): Or(None, dict),
         }
@@ -56,21 +58,24 @@ class ZookeeperStandalone(Driver):
 
     def __init__(
         self,
-        name,
-        cfg_template,
-        binary=ZK_SERVER,
-        port=2181,
-        env=None,
+        name: str,
+        cfg_template: str,
+        binary: str = ZK_SERVER,
+        host: Optional[str] = None,
+        port: int = 2181,
+        env: Optional[dict] = None,
         **options
     ):
         super(ZookeeperStandalone, self).__init__(
             name=name,
             cfg_template=cfg_template,
             binary=binary,
+            host=host,
             port=port,
             env=env,
             **options
         )
+        self._host = host
         self._port = port
         self.env = self.cfg.env.copy() if self.cfg.env else {}
         self.config = None
@@ -82,19 +87,26 @@ class ZookeeperStandalone(Driver):
 
     @emphasized
     @property
-    def port(self):
-        """Port to listen on."""
-        return self._port
-
-    @port.setter
-    def port(self, port):
-        self._port = port
+    def host(self) -> Optional[str]:
+        """Host to bind to."""
+        return self._host
 
     @emphasized
     @property
-    def connection_str(self):
+    def port(self) -> int:
+        """Port to listen on."""
+        return self._port
+
+    @emphasized
+    @property
+    def connection_str(self) -> str:
         """Connection string."""
-        return "{}:{}".format("localhost", self.port)
+        if self._host is None:
+            raise RuntimeError(
+                "Host not resolved yet, should only be accessed "
+                "after driver is started."
+            )
+        return "{}:{}".format(self._host, self._port)
 
     def pre_start(self):
         """
@@ -112,6 +124,7 @@ class ZookeeperStandalone(Driver):
             else:
                 makeemptydirs(directory)
         self.config = os.path.join(self.runpath, "etc", "zookeeper.cfg")
+        self._host = self._host or socket.getfqdn()
         if self._port == 0:
             raise RuntimeError("Zookeeper doesn't support random port")
         instantiate(self.cfg.cfg_template, self.context_input(), self.config)

--- a/tests/unit/testplan/testing/multitest/driver/mykafka/server_template.properties
+++ b/tests/unit/testplan/testing/multitest/driver/mykafka/server_template.properties
@@ -32,7 +32,7 @@ delete.topic.enable=true
 #   EXAMPLE:
 #     listeners = PLAINTEXT://your.host.name:9092
 
-listeners=PLAINTEXT://localhost:{{port}}
+listeners=PLAINTEXT://{{host}}:{{port}}
 
 # Hostname and port the broker will advertise to producers and consumers. If not set, 
 # it uses the value for "listeners" if configured.  Otherwise, it will use the value

--- a/tests/unit/testplan/testing/multitest/driver/mykafka/test_kafka.py
+++ b/tests/unit/testplan/testing/multitest/driver/mykafka/test_kafka.py
@@ -32,7 +32,10 @@ kafka_cfg_template = os.path.join(
 @pytest.fixture(scope="module")
 def zookeeper_server(runpath_module):
     server = zookeeper.ZookeeperStandalone(
-        "zk", cfg_template=zk_cfg_template, runpath=runpath_module
+        "zk",
+        cfg_template=zk_cfg_template,
+        runpath=runpath_module,
+        host="localhost",
     )
     with server:
         yield server
@@ -41,7 +44,10 @@ def zookeeper_server(runpath_module):
 @pytest.fixture(scope="module")
 def kafka_server(zookeeper_server, runpath_module):
     server = kafka.KafkaStandalone(
-        "kafka", cfg_template=kafka_cfg_template, runpath=runpath_module
+        "kafka",
+        cfg_template=kafka_cfg_template,
+        runpath=runpath_module,
+        host="localhost",
     )
 
     testplan = TestplanMock("KafkaTest", parse_cmdline=False)
@@ -56,14 +62,18 @@ def kafka_server(zookeeper_server, runpath_module):
 def test_kafka(kafka_server):
     producer = Producer(
         {
-            "bootstrap.servers": "localhost:{}".format(kafka_server.port),
+            "bootstrap.servers": "{}:{}".format(
+                kafka_server.host, kafka_server.port
+            ),
             "max.in.flight": 1,
             "broker.address.family": "v4",
         }
     )
     consumer = Consumer(
         {
-            "bootstrap.servers": "localhost:{}".format(kafka_server.port),
+            "bootstrap.servers": "{}:{}".format(
+                kafka_server.host, kafka_server.port
+            ),
             "group.id": uuid.uuid4(),
             "default.topic.config": {"auto.offset.reset": "smallest"},
             "enable.auto.commit": True,


### PR DESCRIPTION
## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [x] Test
- [x] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
