### PR TITLE
Use full class name during  junit testcase import.

### DIFF
--- a/doc/newsfragments/2332-changed.full_classname_in_junit_importer.rst
+++ b/doc/newsfragments/2332-changed.full_classname_in_junit_importer.rst
@@ -1,0 +1,1 @@
+The report tool now use the full class name from the junit testcase during import.

--- a/testplan/importers/junit.py
+++ b/testplan/importers/junit.py
@@ -74,9 +74,7 @@ class JUnitResultImporter(ThreePhaseFileImporter):
                     else:
                         case_report_name = case_name
                 else:
-                    case_report_name = (
-                        f"{case_class.split('.')[-1]}::{case_name}"
-                    )
+                    case_report_name = f"{case_class}::{case_name}"
 
                 case_report = TestCaseReport(name=case_report_name)
 

--- a/testplan/runners/pools/connection.py
+++ b/testplan/runners/pools/connection.py
@@ -185,6 +185,7 @@ class ZMQClient(Client):
 
     def connect(self):
         """Connect to a ZMQ Server"""
+        # pylint: disable=abstract-class-instantiated
         self._context = zmq.Context()
         self._sock = self._context.socket(zmq.REQ)
         self._sock.connect("tcp://{}".format(self._address))
@@ -385,6 +386,7 @@ class ZMQServer(Server):
         if self.parent is None:
             raise RuntimeError("Parent pool was not set - cannot start.")
 
+        # pylint: disable=abstract-class-instantiated
         self._zmq_context = zmq.Context()
         self._sock = self._zmq_context.socket(zmq.REP)
         if self.parent.cfg.port == 0:

--- a/testplan/testing/multitest/driver/zmq/client.py
+++ b/testplan/testing/multitest/driver/zmq/client.py
@@ -195,6 +195,7 @@ class ZMQClient(Driver):
         Start the ZMQ client.
         """
         super(ZMQClient, self).starting()
+        # pylint: disable=abstract-class-instantiated
         self._zmq_context = zmq.Context()
         self._socket = self._zmq_context.socket(self.cfg.message_pattern)
         if self.cfg.connect_at_start:

--- a/testplan/testing/multitest/driver/zmq/server.py
+++ b/testplan/testing/multitest/driver/zmq/server.py
@@ -127,6 +127,7 @@ class ZMQServer(Driver):
         Start the ZMQServer.
         """
         super(ZMQServer, self).starting()
+        # pylint: disable=abstract-class-instantiated
         self._zmq_context = zmq.Context()
         self._socket = self._zmq_context.socket(self.cfg.message_pattern)
         if self.cfg.port == 0:


### PR DESCRIPTION
## Bug / Requirement Description
Use full class name during junit testcase import.

## Solution description
removed the split logic, and provide fully qualified classname

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
