### PR TITLE
execute_cmd can now log in case of success as well

### DIFF
--- a/doc/newsfragments/2273_changed.execute_cmd_log.rst
+++ b/doc/newsfragments/2273_changed.execute_cmd_log.rst
@@ -1,1 +1,1 @@
-:py:meth:`execute_cmd <testplan.common.utils.process.execute_cmd>` can log output in case of succes as well, driven by a parameter.
+:py:meth:`execute_cmd <testplan.common.utils.process.execute_cmd>` can log output in case of success as well, driven by a parameter.

--- a/doc/newsfragments/2273_changed.execute_cmd_log.rst
+++ b/doc/newsfragments/2273_changed.execute_cmd_log.rst
@@ -1,0 +1,1 @@
+:py:meth:`execute_cmd <testplan.common.utils.process.execute_cmd>` can log output in case of succes as well, driven by a parameter.


### PR DESCRIPTION
## Bug / Requirement Description
add possibility to log output from execute_cmd in case of succes as well

## Solution description
A new enum parameter introduced to controll that.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [X] Documentation (API)
- [X] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
