### PR TITLE
Message content for Fail assertion

### DIFF
--- a/doc/newsfragments/2303_new.fail_assertion_accepts_message.rst
+++ b/doc/newsfragments/2303_new.fail_assertion_accepts_message.rst
@@ -1,0 +1,1 @@
+Fail assertion now supports and renders message content.

--- a/examples/Assertions/Plotly/test_plan.py
+++ b/examples/Assertions/Plotly/test_plan.py
@@ -155,7 +155,7 @@ class SampleSuite:
             t = np.linspace(0, T, N)
             W = rs.standard_normal(size=N)
             W = np.cumsum(W) * np.sqrt(dt)  # standard brownian motion
-            X = (mu - 0.5 * sigma ** 2) * t + sigma * W
+            X = (mu - 0.5 * sigma**2) * t + sigma * W
             S = S0 * np.exp(X)  # geometric brownian motion
             return S
 

--- a/examples/Assertions/Plotly/test_plan.py
+++ b/examples/Assertions/Plotly/test_plan.py
@@ -155,7 +155,7 @@ class SampleSuite:
             t = np.linspace(0, T, N)
             W = rs.standard_normal(size=N)
             W = np.cumsum(W) * np.sqrt(dt)  # standard brownian motion
-            X = (mu - 0.5 * sigma**2) * t + sigma * W
+            X = (mu - 0.5 * sigma ** 2) * t + sigma * W
             S = S0 * np.exp(X)  # geometric brownian motion
             return S
 

--- a/testplan/testing/multitest/entries/assertions.py
+++ b/testplan/testing/multitest/entries/assertions.py
@@ -72,7 +72,7 @@ class Assertion(BaseEntry):
 
     meta_type = "assertion"
 
-    def __init__(self, description=None, category=None, flag=None):
+    def __init__(self, description=None, category=None, flag=None): 
         super(Assertion, self).__init__(
             description=description, category=category, flag=flag
         )
@@ -122,6 +122,24 @@ class IsFalse(IsTrue):
 
 
 class Fail(Assertion):
+    def __init__(self, description=None, category=None, flag=None, message=None):
+        if isinstance(message, str):
+            self.message = message
+        elif isinstance(message, bytes):
+            self.message = message.decode()
+        else:
+            self.message = pprint.pformat(message)
+
+        if not description:
+            description = next((l for l in self.message.split("\n") if l), "")
+        if len(description) > 80:
+            description = description[0:80] + "..."
+
+        super(Fail, self).__init__(
+            description=description, category=category, flag=flag
+        )
+        
+                
     def evaluate(self):
         return False
 

--- a/testplan/testing/multitest/entries/assertions.py
+++ b/testplan/testing/multitest/entries/assertions.py
@@ -72,7 +72,7 @@ class Assertion(BaseEntry):
 
     meta_type = "assertion"
 
-    def __init__(self, description=None, category=None, flag=None): 
+    def __init__(self, description=None, category=None, flag=None):
         super(Assertion, self).__init__(
             description=description, category=category, flag=flag
         )
@@ -122,7 +122,9 @@ class IsFalse(IsTrue):
 
 
 class Fail(Assertion):
-    def __init__(self, description=None, category=None, flag=None, message=None):
+    def __init__(
+        self, description=None, category=None, flag=None, message=None
+    ):
         if isinstance(message, str):
             self.message = message
         elif isinstance(message, bytes):
@@ -138,8 +140,7 @@ class Fail(Assertion):
         super(Fail, self).__init__(
             description=description, category=category, flag=flag
         )
-        
-                
+
     def evaluate(self):
         return False
 

--- a/testplan/testing/multitest/entries/assertions.py
+++ b/testplan/testing/multitest/entries/assertions.py
@@ -12,8 +12,7 @@ import decimal
 import numbers
 import operator
 import os
-
-impor
+import pprint
 import re
 import subprocess
 import sys

--- a/testplan/testing/multitest/entries/assertions.py
+++ b/testplan/testing/multitest/entries/assertions.py
@@ -12,6 +12,8 @@ import decimal
 import numbers
 import operator
 import os
+
+impor
 import re
 import subprocess
 import sys

--- a/testplan/testing/multitest/entries/schemas/assertions.py
+++ b/testplan/testing/multitest/entries/schemas/assertions.py
@@ -45,6 +45,9 @@ class EqualSchema(FuncAssertionSchema):
     type_actual = fields.String()
     type_expected = fields.String()
 
+@registry.bind(asr.Fail)
+class FailSchema(AssertionSchema):
+    message = fields.Raw()
 
 @registry.bind(asr.IsClose)
 class ApproximateEqualitySchema(AssertionSchema):

--- a/testplan/testing/multitest/entries/schemas/assertions.py
+++ b/testplan/testing/multitest/entries/schemas/assertions.py
@@ -45,9 +45,11 @@ class EqualSchema(FuncAssertionSchema):
     type_actual = fields.String()
     type_expected = fields.String()
 
+
 @registry.bind(asr.Fail)
 class FailSchema(AssertionSchema):
     message = fields.Raw()
+
 
 @registry.bind(asr.IsClose)
 class ApproximateEqualitySchema(AssertionSchema):

--- a/testplan/testing/multitest/entries/stdout/assertions.py
+++ b/testplan/testing/multitest/entries/stdout/assertions.py
@@ -1,5 +1,6 @@
 """Loggers for assertion objects"""
 import os
+import pprint
 import re
 
 from terminaltables import AsciiTable

--- a/testplan/testing/multitest/entries/stdout/assertions.py
+++ b/testplan/testing/multitest/entries/stdout/assertions.py
@@ -480,6 +480,7 @@ class FailRenderer(AssertionRenderer):
         else:
             return pprint.pformat(entry.message)
 
+
 @registry.bind(assertions.EqualSlices)
 class EqualSlicesRenderer(AssertionRenderer):
     """

--- a/testplan/testing/multitest/entries/stdout/assertions.py
+++ b/testplan/testing/multitest/entries/stdout/assertions.py
@@ -463,10 +463,22 @@ class XMLCheckRenderer(AssertionRenderer):
 
 @registry.bind(assertions.Fail)
 class FailRenderer(AssertionRenderer):
-    def get_header_text(self, entry):
-        """Always return text in red as it is an explicit failure."""
-        return Color.red(entry.description)
+    def get_header(self, entry):
+        if entry.description:
+            return Color.red(entry.description)
+        elif isinstance(entry.message, str):
+            return Color.red(str(entry.message))
+        else:
+            return self.get_default_header(entry)
 
+    def get_assertion_details(self, entry):
+        if isinstance(entry.message, str):
+            if entry.description:
+                return Color.red(str(entry.message))
+            else:
+                return None
+        else:
+            return pprint.pformat(entry.message)
 
 @registry.bind(assertions.EqualSlices)
 class EqualSlicesRenderer(AssertionRenderer):

--- a/testplan/testing/multitest/entries/stdout/assertions.py
+++ b/testplan/testing/multitest/entries/stdout/assertions.py
@@ -465,12 +465,7 @@ class XMLCheckRenderer(AssertionRenderer):
 @registry.bind(assertions.Fail)
 class FailRenderer(AssertionRenderer):
     def get_header(self, entry):
-        if entry.description:
-            return Color.red(entry.description)
-        elif isinstance(entry.message, str):
-            return Color.red(str(entry.message))
-        else:
-            return self.get_default_header(entry)
+        return Color.red(entry.description)
 
     def get_assertion_details(self, entry):
         if isinstance(entry.message, str):

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -1608,7 +1608,7 @@ class Result:
         return entry
 
     @assertion
-    def fail(self, message, description, category=None, flag=None):
+    def fail(self, message, description=None, category=None, flag=None):
         """
         Failure assertion, can be used for explicitly failing a testcase.
         The message will be included by email exporter. Most common usage is

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -1629,7 +1629,12 @@ class Result:
         :return: ``False``
         :rtype: ``bool``
         """
-        entry = assertions.Fail(message=message, description=description, category=category, flag=flag)
+        entry = assertions.Fail(
+            message=message,
+            description=description,
+            category=category,
+            flag=flag,
+        )
 
         return entry
 

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -1608,7 +1608,13 @@ class Result:
         return entry
 
     @assertion
-    def fail(self, message, description=None, category=None, flag=None):
+    def fail(
+        self,
+        description: str,
+        message: str = None,
+        category: str = None,
+        flag: bool = None
+    ) -> assertions.Fail:
         """
         Failure assertion, can be used for explicitly failing a testcase.
         The message will be included by email exporter. Most common usage is
@@ -1620,18 +1626,13 @@ class Result:
                 result.fail('Unexpected failure: {}'.format(...))
 
         :param description: Text description of the failure.
-        :type description: ``str``
         :param category: Custom category that will be used for summarization.
-        :type category: ``str``
-        :param flag: Custom flag of the assertion which is reserved and can
-            be used for some special purpose.
-        :param flag: ``str`` or ``NoneType``
+        :param flag: custom flag - reserved parameter
         :return: ``False``
-        :rtype: ``bool``
         """
         entry = assertions.Fail(
-            message=message,
             description=description,
+            message=message,
             category=category,
             flag=flag,
         )

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -1613,7 +1613,7 @@ class Result:
         description: str,
         message: str = None,
         category: str = None,
-        flag: bool = None
+        flag: bool = None,
     ) -> assertions.Fail:
         """
         Failure assertion, can be used for explicitly failing a testcase.

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -1608,7 +1608,7 @@ class Result:
         return entry
 
     @assertion
-    def fail(self, description, category=None, flag=None):
+    def fail(self, message, description, category=None, flag=None):
         """
         Failure assertion, can be used for explicitly failing a testcase.
         The message will be included by email exporter. Most common usage is
@@ -1629,7 +1629,7 @@ class Result:
         :return: ``False``
         :rtype: ``bool``
         """
-        entry = assertions.Fail(description, category=category, flag=flag)
+        entry = assertions.Fail(message=message, description=description, category=category, flag=flag)
 
         return entry
 

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/__snapshots__/BasicAssertion.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/__snapshots__/BasicAssertion.test.js.snap
@@ -1787,7 +1787,9 @@ exports[`BasicAssertion shallow renders the Fail assertion 1`] = `
           "xl",
         ]
       }
-    />
+    >
+      <pre />
+    </Col>
   </Row>
   <Row
     tag="div"

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/basicAssertionUtils.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/basicAssertionUtils.js
@@ -270,7 +270,6 @@ function prepareFailContent(assertion, defaultContent) {
       );
     }
   }
-    
 
   const preContent = (
     <pre>

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/basicAssertionUtils.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/basicAssertionUtils.js
@@ -247,8 +247,40 @@ function prepareIsFalseContent(assertion, defaultContent) {
  * @private
  */
 function prepareFailContent(assertion, defaultContent) {
+
+  let decodedMsg = null;
+
+  if (assertion.message !== undefined) {
+    let bytearray;
+    if(typeof assertion.message === 'object' 
+      && typeof (bytearray = assertion.message['_BYTES_KEY']) !== 'undefined' 
+      && Array.isArray(bytearray)
+      ) {
+      decodedMsg = bytearray.length ? String.fromCodePoint(...bytearray) : "";
+    } else {
+      decodedMsg = (
+      <Linkify options={{
+        target: "_blank",
+        validate: {
+          url: (value) => /^https?:\/\//.test(value),
+        },
+      }}>
+        {assertion.message}
+      </Linkify>
+      );
+    }
+  }
+    
+
+  const preContent = (
+    <pre>
+      {decodedMsg}
+    </pre>
+  );
+
   return {
     ...defaultContent,
+    preContent: preContent,
     leftTitle: null,
     rightTitle: null,
     leftContent: null,

--- a/tests/functional/testplan/runnable/interactive/interactive_executable.py
+++ b/tests/functional/testplan/runnable/interactive/interactive_executable.py
@@ -128,8 +128,8 @@ TEST_SUITE_MODULES = [
                 "meta_type": "assertion",
                 "category": "DEFAULT",
                 "description": "Save a message into report",
-                "message": None,
                 "passed": False,
+                "message": "None",
                 "flag": "DEFAULT",
             },
             {

--- a/tests/functional/testplan/runnable/interactive/interactive_executable.py
+++ b/tests/functional/testplan/runnable/interactive/interactive_executable.py
@@ -128,6 +128,7 @@ TEST_SUITE_MODULES = [
                 "meta_type": "assertion",
                 "category": "DEFAULT",
                 "description": "Save a message into report",
+                "message": None,
                 "passed": False,
                 "flag": "DEFAULT",
             },


### PR DESCRIPTION
## Bug / Requirement Description
Fail assertion only carries content in the form of description which can become unaesthetic in case of longer explanation for the intended failure.

## Solution description
Added message attribute and associated rendering to fail assertion in the likeness of log.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
