### PR TITLE
Fix reloader selection login

### DIFF
--- a/doc/newsfragments/2371_changed.fix_reloade.rst
+++ b/doc/newsfragments/2371_changed.fix_reloade.rst
@@ -1,0 +1,1 @@
+Fixed an issue with interactive mode reload that might skip some affected modules if a dependency is changed.

--- a/examples/Interactive/Basic/my_tests/tcp.py
+++ b/examples/Interactive/Basic/my_tests/tcp.py
@@ -19,4 +19,5 @@ class TCPSuite:
 
         bytes_sent = env.server.send_text(str(VALUE))
         received = env.client.receive_text(size=bytes_sent)
-        result.equal(received, str(VALUE), "Client received")
+        result.equal(received, "1", "Client received")
+

--- a/examples/Interactive/Basic/my_tests/tcp.py
+++ b/examples/Interactive/Basic/my_tests/tcp.py
@@ -20,4 +20,3 @@ class TCPSuite:
         bytes_sent = env.server.send_text(str(VALUE))
         received = env.client.receive_text(size=bytes_sent)
         result.equal(received, "1", "Client received")
-

--- a/testplan/runnable/interactive/reloader.py
+++ b/testplan/runnable/interactive/reloader.py
@@ -295,11 +295,20 @@ class ModuleReloader(logger.Loggable):
         for dep in self._dep_graph.dependencies:
             if dep not in visited_nodes:
                 self._reload_recur(
-                    dep, modified_modules, suite_instances, visited_nodes, reloaded_nodes
+                    dep,
+                    modified_modules,
+                    suite_instances,
+                    visited_nodes,
+                    reloaded_nodes,
                 )
 
     def _reload_recur(
-        self, mod_node, modified_modules, suite_instances, visited_nodes, reloaded_nodes
+        self,
+        mod_node,
+        modified_modules,
+        suite_instances,
+        visited_nodes,
+        reloaded_nodes,
     ):
         """
         Recursively walk the graph of dependencies, reloading all modified
@@ -320,9 +329,9 @@ class ModuleReloader(logger.Loggable):
         """
 
         if mod_node in reloaded_nodes:
-            return True # we already reloaded this
+            return True  # we already reloaded this
         if mod_node in visited_nodes:
-            return False # we already decided not need reload
+            return False  # we already decided not need reload
 
         visited_nodes.add(mod_node)
 
@@ -335,7 +344,11 @@ class ModuleReloader(logger.Loggable):
         dep_reloaded = any(
             [
                 self._reload_recur(
-                    dep, modified_modules, suite_instances, visited_nodes, reloaded_nodes
+                    dep,
+                    modified_modules,
+                    suite_instances,
+                    visited_nodes,
+                    reloaded_nodes,
                 )
                 for dep in mod_node.dependencies
             ]


### PR DESCRIPTION

## Bug / Requirement Description
If multiple module depends on the same changed module in interactive mode, the reload will just reload one of them.

## Solution description
- now take into account if a dependency was already reloaded on a different path of the graph and consider it as a reloaded
- updated testcase to have this scenario
- updated example to show this scenario

## Checklist:
- [X] Test
- [X] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
