### PR TITLE
fix change_directory to restore PWD properly

### DIFF
--- a/testplan/common/utils/path.py
+++ b/testplan/common/utils/path.py
@@ -65,6 +65,9 @@ def default_runpath(entity):
     )
 
 
+PWD = "PWD"
+
+
 @contextlib.contextmanager
 def change_directory(directory):
     """
@@ -74,19 +77,23 @@ def change_directory(directory):
     :param directory: Directory to change into.
     :type directory: ``str``
     """
+
     if directory:  # in case we get a None directory, do nothing
         old_directory = os.getcwd()
+        old_pwd = os.environ.get(PWD, None)
         directory = fix_home_prefix(directory)
         os.chdir(directory)
-        if "PWD" in os.environ:
-            os.environ["PWD"] = directory
+        if old_pwd:
+            os.environ[PWD] = directory
     try:
         yield
     finally:
         if directory:
             os.chdir(old_directory)
-            if "PWD" in os.environ:
-                os.environ["PWD"] = old_directory
+            if old_pwd:
+                os.environ[PWD] = old_pwd
+            elif PWD in os.environ:
+                del os.environ[PWD]
 
 
 def makedirs(path):

--- a/testplan/runners/local.py
+++ b/testplan/runners/local.py
@@ -1,8 +1,6 @@
 """Basic local executor."""
-import os
 import time
 
-from testplan.common.utils.path import is_subdir, pwd, change_directory
 from .base import Executor
 from testplan.runners.pools import tasks
 from testplan.testing.base import Test, TestResult

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -14,7 +14,6 @@ from schema import And, Or
 from testplan.common import entity
 from testplan.common.config import ConfigOption
 from testplan.common.utils import strings
-from testplan.common.utils.path import change_directory, is_subdir, pwd
 from testplan.common.utils.thread import interruptible_join
 from testplan.common.utils.timing import wait_until_predicate
 from testplan.report import ReportCategories

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -17,7 +17,6 @@ from testplan.common.entity import (
     RunnableConfig,
 )
 from testplan.common.utils import strings
-from testplan.common.utils.path import change_directory
 from testplan.common.utils.process import subprocess_popen
 from testplan.common.utils.timing import parse_duration, format_duration
 from testplan.common.utils.process import enforce_timeout, kill_process


### PR DESCRIPTION
## Bug / Requirement Description
Change Directory was not setting back PWD to it's original value, but set it to the previous actual working dir.

## Solution description
Now the previous value is restored
No specific test but this fixing some task related flaky testcases

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
