### PR TITLE
Allow parenthesis in tags

### DIFF
--- a/doc/newsfragments/2328_changed.Allow_parentheses_in_tags.rst
+++ b/doc/newsfragments/2328_changed.Allow_parentheses_in_tags.rst
@@ -1,0 +1,1 @@
+Changed tag acceptance pattern to allow using parentheses in simple and named tags.

--- a/doc/newsfragments/2328_changed.Enabled_whitespace_and_parentheses_in_tags.rst
+++ b/doc/newsfragments/2328_changed.Enabled_whitespace_and_parentheses_in_tags.rst
@@ -1,1 +1,0 @@
-Enabled whitespace and parentheses in tags.

--- a/doc/newsfragments/2328_changed.Enabled_whitespace_and_parentheses_in_tags.rst
+++ b/doc/newsfragments/2328_changed.Enabled_whitespace_and_parentheses_in_tags.rst
@@ -1,0 +1,1 @@
+Enabled whitespace and parentheses in tags.

--- a/testplan/testing/tagging.py
+++ b/testplan/testing/tagging.py
@@ -14,7 +14,7 @@ SIMPLE = "simple"  # key for simple tags
 # (for readable URL params)
 
 # Currently allowing same patterns for tags and tag names
-TAG_VALUE_PATTERN = r"(?![\s\_-])[\w\s-]+(?<![\s\_-])"
+TAG_VALUE_PATTERN = r"(?![\s\_\-\)\(])[\w\s\-\(\)]+(?<![\s\_\-])"
 TAG_NAME_PATTERN = TAG_VALUE_PATTERN
 
 # Pattern for simple tag arguments e.g. `--tags foo bar baz`

--- a/tests/functional/testplan/testing/test_tagging.py
+++ b/tests/functional/testplan/testing/test_tagging.py
@@ -21,7 +21,7 @@ class AlphaSuite:
         pass
 
 
-@testsuite(tags={"color": "yellow"})
+@testsuite(tags={"color (-)_tag": "yellow (-)_tag"})
 class BetaSuite:
     @testcase
     def test_method_0(self, env, result):
@@ -76,7 +76,7 @@ report_for_multitest_without_tags = TestGroupReport(
         TestGroupReport(
             name="BetaSuite",
             category="testsuite",
-            tags={"color": {"yellow"}},
+            tags={"color (-)_tag": {"yellow (-)_tag"}},
             entries=[
                 TestCaseReport(name="test_method_0"),
                 TestCaseReport(name="test_method_1", tags={"simple": {"foo"}}),
@@ -140,7 +140,7 @@ report_for_multitest_with_tags = TestGroupReport(
         TestGroupReport(
             name="BetaSuite",
             category="testsuite",
-            tags={"color": {"yellow"}},
+            tags={"color (-)_tag": {"yellow (-)_tag"}},
             entries=[
                 TestCaseReport(name="test_method_0"),
                 TestCaseReport(name="test_method_1", tags={"simple": {"foo"}}),

--- a/tests/unit/testplan/testing/test_filtering.py
+++ b/tests/unit/testplan/testing/test_filtering.py
@@ -30,11 +30,11 @@ class Beta:
     def test_one(self, env, result):
         pass
 
-    @testcase(tags={"color": "blue", "speed": "slow"})
+    @testcase(tags={"color": "blue", "speed (-)_tag": "slow"})
     def test_two(self, env, result):
         pass
 
-    @testcase(tags={"color": "yellow", "speed": "fast"})
+    @testcase(tags={"color": "yellow (-)_tag", "speed (-)_tag": "fast"})
     def test_three(self, env, result):
         pass
 
@@ -45,7 +45,7 @@ class Gamma:
     def test_one(self, env, result):
         pass
 
-    @testcase(tags={"speed": "fast"})
+    @testcase(tags={"speed (-)_tag": "fast"})
     def test_two(self, env, result):
         pass
 
@@ -83,12 +83,16 @@ class TestTags:
             ({"color": "blue"}, multitest_A, True),
             (("bar", "baz"), multitest_F, True),
             (
-                {"color": "yellow", "simple": "bar", "speed": "slow"},
+                {
+                    "color": "yellow (-)_tag",
+                    "simple": "bar",
+                    "speed (-)_tag": "slow",
+                },
                 multitest_F,
                 True,
             ),
             (
-                {"color": "orange", "simple": "bat", "speed": "medium"},
+                {"color": "orange", "simple": "bat", "speed (-)_tag": "medium"},
                 multitest_F,
                 False,
             ),
@@ -104,12 +108,16 @@ class TestTags:
             ("foo", Alpha(), True),
             (("foo", "something", "else"), Alpha(), True),
             ("bar", Alpha(), False),
-            ({"color": ("blue", "yellow")}, Alpha(), True),
-            ({"color": ("blue", "yellow")}, Beta(), True),
+            ({"color": ("blue", "yellow (-)_tag")}, Alpha(), True),
+            ({"color": ("blue", "yellow (-)_tag")}, Beta(), True),
             ({"color": "blue"}, Alpha(), True),
             (("bar", "baz"), Gamma(), True),
             (
-                {"color": "yellow", "simple": "bar", "speed": "slow"},
+                {
+                    "color": "yellow (-)_tag",
+                    "simple": "bar",
+                    "speed (-)_tag": "slow",
+                },
                 Gamma(),
                 False,
             ),
@@ -127,7 +135,7 @@ class TestTags:
             ({"color": "blue"}, Alpha().test_two, False),
             (("foo", "baz"), Beta().test_one, False),
             (
-                {"simple": ("foo", "baz"), "speed": "slow"},
+                {"simple": ("foo", "baz"), "speed (-)_tag": "slow"},
                 Beta().test_two,
                 True,
             ),
@@ -157,12 +165,16 @@ class TestTagsAll:
             ({"color": "blue"}, multitest_A, True),
             (("bar", "baz"), multitest_F, True),
             (
-                {"color": "yellow", "simple": "bar", "speed": "slow"},
+                {
+                    "color": "yellow (-)_tag",
+                    "simple": "bar",
+                    "speed (-)_tag": "slow",
+                },
                 multitest_F,
                 True,
             ),
             (
-                {"color": "orange", "simple": "bat", "speed": "medium"},
+                {"color": "orange", "simple": "bat", "speed (-)_tag": "medium"},
                 multitest_F,
                 False,
             ),
@@ -178,12 +190,16 @@ class TestTagsAll:
             ("foo", Alpha(), True),
             (("foo", "something", "else"), Alpha(), False),
             ("bar", Alpha(), False),
-            ({"color": ("blue", "yellow")}, Alpha(), False),
-            ({"color": ("blue", "yellow")}, Beta(), True),
+            ({"color": ("blue", "yellow (-)_tag")}, Alpha(), False),
+            ({"color": ("blue", "yellow (-)_tag")}, Beta(), True),
             ({"color": "blue"}, Alpha(), True),
             (("bar", "baz"), Gamma(), False),
             (
-                {"color": "yellow", "simple": "bar", "speed": "slow"},
+                {
+                    "color": "yellow (-)_tag",
+                    "simple": "bar",
+                    "speed (-)_tag": "slow",
+                },
                 Gamma(),
                 False,
             ),
@@ -200,9 +216,9 @@ class TestTagsAll:
             ({"color": "red"}, Alpha().test_two, True),
             ({"color": "blue"}, Alpha().test_two, False),
             (("foo", "baz"), Beta().test_one, False),
-            ({"simple": "bar", "speed": "slow"}, Beta().test_two, True),
+            ({"simple": "bar", "speed (-)_tag": "slow"}, Beta().test_two, True),
             (
-                {"simple": ("foo", "baz"), "speed": "slow"},
+                {"simple": ("foo", "baz"), "speed (-)_tag": "slow"},
                 Beta().test_two,
                 False,
             ),

--- a/tests/unit/testplan/testing/test_filtering.py
+++ b/tests/unit/testplan/testing/test_filtering.py
@@ -92,7 +92,11 @@ class TestTags:
                 True,
             ),
             (
-                {"color": "orange", "simple": "bat", "speed (-)_tag": "medium"},
+                {
+                    "color": "orange",
+                    "simple": "bat",
+                    "speed (-)_tag": "medium",
+                },
                 multitest_F,
                 False,
             ),
@@ -174,7 +178,11 @@ class TestTagsAll:
                 True,
             ),
             (
-                {"color": "orange", "simple": "bat", "speed (-)_tag": "medium"},
+                {
+                    "color": "orange",
+                    "simple": "bat",
+                    "speed (-)_tag": "medium",
+                },
                 multitest_F,
                 False,
             ),
@@ -216,7 +224,11 @@ class TestTagsAll:
             ({"color": "red"}, Alpha().test_two, True),
             ({"color": "blue"}, Alpha().test_two, False),
             (("foo", "baz"), Beta().test_one, False),
-            ({"simple": "bar", "speed (-)_tag": "slow"}, Beta().test_two, True),
+            (
+                {"simple": "bar", "speed (-)_tag": "slow"},
+                Beta().test_two,
+                True,
+            ),
             (
                 {"simple": ("foo", "baz"), "speed (-)_tag": "slow"},
                 Beta().test_two,


### PR DESCRIPTION
## Bug / Requirement Description
Tags cannot contain some special characters which were required by clients.

## Solution description
Changed tag validator pattern to allow parentheses.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
