### PR TITLE
Fix pre/post step report reset

### DIFF
--- a/doc/newsfragments/2378_changed.pre_post_report_reset.rst
+++ b/doc/newsfragments/2378_changed.pre_post_report_reset.rst
@@ -1,0 +1,1 @@
+Fixed issue when the restart of test resources without report reset would break interactive run.

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -594,6 +594,13 @@ class MultiTest(testing_base.Test):
         this method handles running the before/after_start callables if
         required.
         """
+        # Need to clean up pre/post steps report in the following scenario:
+        #   - resources are started
+        #   - stopped
+        #   - started again
+        # Reason is that dry_run only applies for state reset while appending of
+        #   the report group happens only in static run we cannot capture
+        self._pre_post_step_report = None
         self.make_runpath_dirs()
         if self.cfg.before_start:
             self._wrap_run_step(


### PR DESCRIPTION
## Bug / Requirement Description
Pre/post step report is not reset properly upon the following scenario: resources are started in interactive mode, then stopped, then started again.

## Solution description
In case the report is not reset, the above can be mitigated by setting the pre/post step report to None just as in the case of the dry run.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
