### PR TITLE
Feature/add patterns-file cmdline arg

### DIFF
--- a/doc/en/introduction.rst
+++ b/doc/en/introduction.rst
@@ -343,20 +343,22 @@ Command line
     Filtering:
       --patterns            Test filter, supports glob notation & multiple arguments.
 
-                            --pattern <Multitest Name>
+                            --patterns <Multitest Name>
 
-                            --pattern <Multitest Name 1> <Multitest Name 2>
+                            --patterns <Multitest Name 1> <Multitest Name 2>
 
-                            --pattern <Multitest Name 1> --pattern <Multitest Name 2>
+                            --patterns <Multitest Name 1> --patterns <Multitest Name 2>
 
-                            --pattern <Multitest Name>:<Suite Name>
+                            --patterns <Multitest Name>:<Suite Name>
 
-                            --pattern <Multitest Name>:<Suite Name>:<Testcase name>
+                            --patterns <Multitest Name>:<Suite Name>:<Testcase name>
 
-                            --pattern <Multitest Name>:\*:<Testcase name>
+                            --patterns <Multitest Name>:\*:<Testcase name>
 
-                            --pattern \*:<Suite Name>:<Testcase name>
+                            --patterns \*:<Suite Name>:<Testcase name>
+      --patterns-file       Test filter supplied in a file, with one pattern per line.
 
+                            --patterns-file <File>
       --tags                Test filter, runs tests that match ANY of the given tags.
 
                             --tags <tag_name_1> --tags <tag_name 2>

--- a/doc/newsfragments/2396_new.patterns_file_cmdline.rst
+++ b/doc/newsfragments/2396_new.patterns_file_cmdline.rst
@@ -1,0 +1,1 @@
+Introduced a new command line argument ``--patterns-file`` which accepts a file containing multiple lines of :py:class:`Pattern <testplan.testing.filtering.Pattern>` and uses them to filter tests.

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -6,7 +6,7 @@ import argparse
 import copy
 import json
 import sys
-from typing import Dict
+from typing import Dict, List
 
 from testplan import defaults
 from testplan.common.utils import logger
@@ -154,7 +154,9 @@ class TestplanParser:
 
         filter_group = parser.add_argument_group("Filtering")
 
-        filter_group.add_argument(
+        filter_pattern_group = filter_group.add_mutually_exclusive_group()
+
+        filter_pattern_group.add_argument(
             "--patterns",
             action=filtering.PatternAction,
             default=[],
@@ -164,13 +166,27 @@ class TestplanParser:
             help="""\
 Test filter, supports glob notation & multiple arguments.
 
---pattern <Multitest Name>
---pattern <Multitest Name 1> <Multitest Name 2>
---pattern <Multitest Name 1> --pattern <Multitest Name 2>
---pattern <Multitest Name>:<Suite Name>
---pattern <Multitest Name>:<Suite Name>:<Testcase name>
---pattern <Multitest Name>:*:<Testcase name>
---pattern *:<Suite Name>:<Testcase name>""",
+--patterns <Multitest Name>
+--patterns <Multitest Name 1> <Multitest Name 2>
+--patterns <Multitest Name 1> --pattern <Multitest Name 2>
+--patterns <Multitest Name>:<Suite Name>
+--patterns <Multitest Name>:<Suite Name>:<Testcase name>
+--patterns <Multitest Name>:*:<Testcase name>
+--patterns *:<Suite Name>:<Testcase name>""",
+        )
+
+        # NOTE: custom type is applied before custom action
+        filter_pattern_group.add_argument(
+            "--patterns-file",
+            metavar="FILE",
+            dest="patterns",
+            type=_read_text_file,
+            action=filtering.PatternAction,
+            help="""\
+Test filter supplied in a file, with one filter per line.
+
+--patterns-file <File>
+""",
         )
 
         filter_group.add_argument(
@@ -467,3 +483,8 @@ class LogLevelAction(argparse.Action):
 def _read_json_file(file: str) -> dict:
     with open(file, "r") as fp:
         return json.load(fp)
+
+
+def _read_text_file(file: str) -> List[str]:
+    with open(file, "r") as fp:
+        return fp.read().splitlines()

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -183,7 +183,7 @@ Test filter, supports glob notation & multiple arguments.
             type=_read_text_file,
             action=filtering.PatternAction,
             help="""\
-Test filter supplied in a file, with one filter per line.
+Test filter supplied in a file, with one pattern per line.
 
 --patterns-file <File>
 """,

--- a/testplan/testing/filtering.py
+++ b/testplan/testing/filtering.py
@@ -330,11 +330,15 @@ class PatternAction(argparse.Action):
 
     In:
 
-    --pattern foo bar --pattern baz
+    .. code-block:: bash
+
+        --pattern foo bar --pattern baz
 
     Out:
 
-    [Pattern('foo'), Pattern('bar'), Pattern('baz')]
+    .. code-block:: python
+
+        [Pattern('foo'), Pattern('bar'), Pattern('baz')]
     """
 
     def __call__(self, parser, namespace, values, option_string=None):

--- a/tests/functional/testplan/testing/test_filtering.py
+++ b/tests/functional/testplan/testing/test_filtering.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 
 import pytest
@@ -55,8 +56,14 @@ class Gamma:
 
 @pytest.fixture
 def filter_file():
-    with tempfile.NamedTemporaryFile("w+") as f:
-        yield f
+    f = tempfile.NamedTemporaryFile(delete=False)
+    f.close()
+    try:
+        fp = open(f.name, "w+")
+        yield fp
+    finally:
+        fp.close()
+        os.unlink(f.name)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Bug / Requirement Description
New cmdline arg `patterns-file`, which is basically `patterns` but contents in a certain file.

## Solution description
Reuses `PatternAction`

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [x] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [x] For new cmdline arg: documentation
