### PR TITLE
Enabled port resolution with port aliases

### DIFF
--- a/doc/newsfragments/2398_new.enable_port_resolution_by_service_name.rst
+++ b/doc/newsfragments/2398_new.enable_port_resolution_by_service_name.rst
@@ -1,0 +1,1 @@
+Enabled TCPServer and TCPClient to accept service names as ports

--- a/testplan/testing/multitest/driver/tcp/server.py
+++ b/testplan/testing/multitest/driver/tcp/server.py
@@ -3,15 +3,15 @@ TCPServer driver classes.
 """
 
 import socket
-from typing import Union, Optional
+from typing import Optional, Union
 
-from schema import Use
-
+from schema import Or
 from testplan.common.config import ConfigOption
-from testplan.common.utils.context import ContextValue
+from testplan.common.utils import networking
+from testplan.common.utils.context import ContextValue, expand
 from testplan.common.utils.documentation_helper import emphasized
-from testplan.common.utils.timing import TimeoutException, TimeoutExceptionInfo
 from testplan.common.utils.sockets import Server
+from testplan.common.utils.timing import TimeoutException, TimeoutExceptionInfo
 
 from ..base import Driver, DriverConfig
 
@@ -29,7 +29,7 @@ class TCPServerConfig(DriverConfig):
         """
         return {
             ConfigOption("host", default="localhost"): str,
-            ConfigOption("port", default=0): Use(int),
+            ConfigOption("port", default=0): Or(int, str, ContextValue),
         }
 
 
@@ -61,7 +61,7 @@ class TCPServer(Driver):
         self,
         name: str,
         host: Optional[Union[str, ContextValue]] = "localhost",
-        port: Optional[Union[int, ContextValue]] = 0,
+        port: Optional[Union[int, str, ContextValue]] = 0,
         **options
     ):
         options.update(self.filter_locals(locals()))
@@ -152,7 +152,10 @@ class TCPServer(Driver):
     def starting(self):
         """Starts the TCP server."""
         super(TCPServer, self).starting()
-        self._server = Server(host=self.cfg.host, port=self.cfg.port)
+        self._server = Server(
+            host=self.cfg.host,
+            port=networking.port_to_int(expand(self.cfg.port, self.context)),
+        )
         self._server.bind()
         self._server.serve()
         self._host = self.cfg.host


### PR DESCRIPTION
## Bug / Requirement Description
TCPServer/Client does not support resolution of port alias. Further, this type of resolution may be needed across more drivers.

## Solution description
TCPServer and TCPClient have been enhanced to accept a port alias 'str' which will be resolved into a valid port `int`

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
