### PR TITLE
Configurable driver log collector

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -76,6 +76,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: [3.7, 3.8, '3.10', 3.11]
+      fail-fast: false
 
     steps:
       - run: echo "BUILD ${{ matrix.os }} ${{ matrix.python-version }} ${{needs.is_source_changed.outputs.is_source_changed}}"

--- a/doc/en/download/Best Practice.rst
+++ b/doc/en/download/Best Practice.rst
@@ -20,6 +20,7 @@ Example:
     .. code-block:: python
 
       from testplan.common.utils import helper
+
       log_collector = helper.DriverLogCollector(
           name="custom_log_collector",
           file_pattern=["*.log"],

--- a/doc/en/download/Best Practice.rst
+++ b/doc/en/download/Best Practice.rst
@@ -6,11 +6,29 @@ Best Practice
 .. _example_common_utilities:
 
 Helper Utilities
-----------------
+================
 
 Testplan provides helper functions and a predefined testsuite that make it
 easy for the user to add common testplan execution infomation - such as
 env var, pwd, log file, driver metadata - to the test report.
+
+DriverLogCollector
+------------------
+You can specify your custom log collector using :py:class:`~testplan.common.utils.helper.DriverLogCollector`.
+It will attach the specified log files to the report for each driver.
+Example:
+    .. code-block:: python
+
+      from testplan.common.utils import helper
+      log_collector = helper.DriverLogCollector(
+          name="custom_log_collector",
+          file_pattern=["*.log"],
+          description="Driver log files",
+          ignore="not_important.log",
+          recursive=True,
+          failure_only=False,
+      )
+      log_collector(env, result)
 
 Required files:
     - :download:`test_plan.py <../../../examples/Best Practice/Common Utilities/test_plan.py>`

--- a/doc/newsfragments/2094_new.DriverLogCollector.rst
+++ b/doc/newsfragments/2094_new.DriverLogCollector.rst
@@ -1,0 +1,1 @@
+Allow users to customize logfile collecting for drivers with new :py:class:`DriverLogCollector <testplan.common.utils.helper.DriverLogCollector>` class. Also added a new function wrapper for combining multiple callable objects (like logfile collectors and testcases) together: :py:meth:`callable_wrapper <testplan.common.utils.helper.callable_wrapper>`.

--- a/doc/newsfragments/2094_new.DriverLogCollector.rst
+++ b/doc/newsfragments/2094_new.DriverLogCollector.rst
@@ -1,1 +1,1 @@
-Allow users to customize logfile collecting for drivers with new :py:class:`DriverLogCollector <testplan.common.utils.helper.DriverLogCollector>` class. Also added a new function wrapper for combining multiple callable objects (like logfile collectors and testcases) together: :py:meth:`callable_wrapper <testplan.common.utils.helper.callable_wrapper>`.
+Allow users to customize logfile collecting for drivers with new :py:class:`DriverLogCollector <testplan.common.utils.helper.DriverLogCollector>` class.

--- a/examples/Best Practice/Common Utilities/test_plan.py
+++ b/examples/Best Practice/Common Utilities/test_plan.py
@@ -51,10 +51,20 @@ def before_start_fn(env, result):
 
 def after_stop_fn(env, result):
     # Attach drivers' log files if the multitest failed.
-    helper.attach_driver_logs_if_failed(env, result)
+    stdout_logger = helper.DriverLogCollector(
+        file_pattern=["stdout*"], description="stdout"
+    )
+    stderr_logger = helper.DriverLogCollector(
+        file_pattern=["stderr*"], description="stderr"
+    )
+
+    stdout_logger(env, result)
+    stderr_logger(env, result)
 
     # Delete Multitest level runpath if the multitest passed.
-    helper.clean_runpath_if_passed(env, result)
+    # This function cleans the the runpath before the exporters
+    # have chance collecting the files, hence commented out.
+    # helper.clean_runpath_if_passed(env, result)
 
 
 @test_plan(name="Example using helper")

--- a/testplan/common/utils/helper.py
+++ b/testplan/common/utils/helper.py
@@ -29,7 +29,7 @@ import psutil
 import shutil
 import socket
 import sys
-from typing import Dict
+from typing import Dict, List
 
 from testplan.common.entity import Environment
 from testplan.common.utils.logger import TESTPLAN_LOGGER
@@ -58,8 +58,8 @@ class DriverLogCollector:
         self,
         name: str = "DriverLogCollector",
         description: str = "logs",
-        ignore: list = None,
-        file_pattern: list = None,
+        ignore: List[str] = None,
+        file_pattern: List[str] = None,
         recursive: bool = True,
         failure_only: bool = True,
     ) -> None:

--- a/testplan/common/utils/helper.py
+++ b/testplan/common/utils/helper.py
@@ -1,10 +1,12 @@
 """
 This module provides helper functions that will add common information of
- Testplan execution to test report.
+Testplan execution to test report.
+
 They could be used directly in testcases or provided to
- pre/pose_start/stop hooks.
+pre/pose_start/stop hooks.
+
 Also provided is a predefined testsuite that can be included in user's
- Multitest directly.
+Multitest directly.
 """
 
 __all__ = [
@@ -27,7 +29,7 @@ import psutil
 import shutil
 import socket
 import sys
-from typing import Dict, Callable
+from typing import Dict
 
 from testplan.common.entity import Environment
 from testplan.common.utils.logger import TESTPLAN_LOGGER
@@ -37,37 +39,31 @@ from testplan.testing.multitest.result import Result
 
 
 class DriverLogCollector:
+
     """
     Customizable file collector class used for collecting driver logs.
+
+    :param name: Name of the object shown in the report.
+    :param description: Text description for the assertion.
+    :param ignore: List of patterns of file name to ignore when
+        attaching a directory.
+    :param file_pattern: List of patterns of file name to include when
+        attaching a directory. (Defaults: "stdout*", "stderr*")
+    :param recursive: Recursively traverse sub-directories and attach
+        all files, default is to only attach files in top directory.
+    :param failure_only: Only collect files on failure.
     """
 
     def __init__(
         self,
         name: str = "DriverLogCollector",
-        path: str = None,
         description: str = "logs",
         ignore: list = None,
         file_pattern: list = None,
         recursive: bool = True,
         failure_only: bool = True,
     ) -> None:
-        """
-        Attaches a file to the report.
-
-        :param name: Name of the object shown in the report.
-        :param path: Path to the file or directory be to attached.
-        :param description: Text description for the assertion.
-        :param ignore: List of patterns of file name to ignore when
-            attaching a directory.
-        :param file_pattern: List of patterns of file name to include when
-            attaching a directory. (Defaults: "stdout*", "stderr*")
-        :param recursive: Recursively traverse sub-directories and attach
-            all files, default is to only attach files in top directory.
-        :param failure_only: Only collect files on failure.
-        """
-
         self.__name__ = name
-        self.path = path
         self.description = description
         self.ignore = ignore
         self.file_pattern = file_pattern or ["stdout*", "stderr*"]
@@ -86,7 +82,7 @@ class DriverLogCollector:
         if not env.parent.report.passed or not self.failure_only:
             for driver in env:
                 result.attach(
-                    path=self.path or driver.runpath,
+                    path=driver.runpath,
                     description=f"Driver: {driver.name} - {self.description}",
                     only=self.file_pattern,
                     recursive=self.recursive,
@@ -199,10 +195,10 @@ def attach_driver_logs_if_failed(
 ) -> None:
     """
     Attaches stdout and stderr files to the report for each driver.
+
     :param env: environment
     :param result: testcase result
     """
-
     stdout_logger = DriverLogCollector(
         file_pattern=["stdout*"], description="stdout"
     )

--- a/testplan/common/utils/interface.py
+++ b/testplan/common/utils/interface.py
@@ -1,7 +1,7 @@
 """Validates methods signature."""
 
-from typing import Union, Optional
 from inspect import signature
+from typing import Union, Optional
 
 
 class NoSuchMethodInClass(Exception):
@@ -20,16 +20,15 @@ class MethodSignatureMismatch(Exception):
     pass
 
 
-def check_signature(
-    func: callable, args_list: Union[list, str]
-) -> Optional[bool]:
+def check_signature(func: callable, args_list: Union[list, str]) -> bool:
     """
     Checks if the given function's signature matches the given list of args
 
     :param func: function whose signature to check
     :param args_list: list of arg names to match as signature
 
-    :return: ``None`` or ``True``
+    :return: ``True`` if the signature is matching
+    :raises MethodSignatureMismatch: if the given function's signature differs from the provided
     """
     funcparams = list(signature(func).parameters.keys())
     if funcparams != args_list:

--- a/testplan/common/utils/interface.py
+++ b/testplan/common/utils/interface.py
@@ -35,6 +35,6 @@ def check_signature(
     funcparams = list(signature(func).parameters.keys())
     if funcparams != args_list:
         raise MethodSignatureMismatch(
-            f"Expected {args_list}, not {funcparams} with {func}"
+            f"Expected arguments for {func.__name__} are {args_list}, not {funcparams}"
         )
     return True

--- a/testplan/common/utils/interface.py
+++ b/testplan/common/utils/interface.py
@@ -31,7 +31,6 @@ def check_signature(
 
     :return: ``None`` or ``True``
     """
-
     funcparams = list(signature(func).parameters.keys())
     if funcparams != args_list:
         raise MethodSignatureMismatch(

--- a/testplan/common/utils/interface.py
+++ b/testplan/common/utils/interface.py
@@ -1,144 +1,7 @@
 """Validates methods signature."""
 
-from itertools import zip_longest
-
-from .callable import getargspec
-
-
-class MethodSignature:
-    """
-    Encapsulates a method signature
-    """
-
-    def __init__(self, name, args, varargs=None, keywords=None, defaults=None):
-        """
-        Construct a MethodSignature.
-
-        :param name: name
-        :type name: ``str``
-        :param args: list of argument names
-        :type args: ``List[str]``
-        :param varargs: name of * parameter
-        :type varargs: ``Optional[str]``
-        :param keywords: name of ** parameter
-        :type keywords: ``Optional[str]``
-        :param defaults: default arguments.
-        :type defaults: ``list`` or ``NoneType``
-        """
-        self.name = name
-        self.args = args
-        self.varargs = varargs
-        self.keywords = keywords
-
-        if defaults is None:
-            self.defaults = []
-        else:
-            self.defaults = defaults
-
-    @classmethod
-    def from_callable(cls, func):
-        """
-        Construct a MethodSignature from a callable.
-
-        :param func: any callable object (function, method, class etc.)
-        :return: new MethodSignature instance
-        """
-        argspec = getargspec(func)
-        return cls(
-            func.__name__,
-            argspec.args,
-            argspec.varargs,
-            argspec.keywords,
-            argspec.defaults,
-        )
-
-    def __eq__(self, rhs):
-        """
-        Equality match, name and argspec should match
-
-        :param rhs: argspec to compare against
-        :type rhs: :py:class:`MethodSignature`
-
-        :return: True if self and rhs are equivalent, False otherwise
-        :rtype: ``bool``
-        """
-        return (
-            (self.name == rhs.name)
-            and (self.args == rhs.args)
-            and (self.varargs == rhs.varargs)
-            and (self.keywords == rhs.keywords)
-        )
-
-    def __ne__(self, rhs):
-        """
-        Non equality match, name or argspec should differ
-
-        :param rhs: argspec to compare against
-        :type rhs: :py:class:`MethodSignature`
-
-        :return: False if self and rhs are equivalent, True otherwise
-        :rtype: ``bool``
-        """
-        return not self.__eq__(rhs)
-
-    def __str__(self):
-        """
-        String representation, useful when mismatches occur
-
-        :return: string representation for the MethodSignature
-        :rtype: ``str``
-        """
-
-        def args_with_defaults(args, defaults):
-            """
-            Args to string, with defaults inserted where appropriate
-
-            :param args: arguments
-            :type args: ``list``
-            :param defaults: default value of arguments
-            :type defaults: ``list``
-
-            :return: string representation of the signature arguments
-            :rtype: ``str``
-            """
-
-            def argument(arg, default):
-                """
-                Arg=Default pair if Default is present
-
-                :param arg: argument name
-                :type arg: ``str``
-                :param default: default value for argument
-                :type default: ``object``
-
-                :return: string representation
-                :rtype: ``str``
-                """
-                return "{0}={1}".format(arg, default) if default else arg
-
-            return ", ".join(
-                reversed(
-                    [
-                        argument(arg, default)
-                        for arg, default in zip_longest(
-                            reversed(args), reversed(defaults)
-                        )
-                    ]
-                )
-            )
-
-        args = "".join(
-            [
-                args_with_defaults(self.args, self.defaults),
-                ", *{0}".format(self.varargs) if self.varargs else "",
-                ", **{0}".format(self.keywords) if self.keywords else "",
-            ]
-        )
-
-        return "{0}({1})".format(self.name, args)
-
-    def __repr__(self):
-        return "<{}> - {}".format(self.__class__.__name__, self.__str__())
+from typing import Union, Optional
+from inspect import signature
 
 
 class NoSuchMethodInClass(Exception):
@@ -157,22 +20,21 @@ class MethodSignatureMismatch(Exception):
     pass
 
 
-def check_signature(func, args_list):
+def check_signature(
+    func: callable, args_list: Union[list, str]
+) -> Optional[bool]:
     """
     Checks if the given function's signature matches the given list of args
 
     :param func: function whose signature to check
-    :type func: ``callable``
     :param args_list: list of arg names to match as signature
-    :type args_list: ``list`` of ``str``
 
     :return: ``None`` or ``True``
-    :rtype: ``NoneType`` or ``bool``
     """
-    refsig = MethodSignature(func.__name__, args_list)
-    actualsig = MethodSignature.from_callable(func)
-    if refsig != actualsig:
+
+    funcparams = list(signature(func).parameters.keys())
+    if funcparams != args_list:
         raise MethodSignatureMismatch(
-            "Expected {0}, not {1}".format(refsig, actualsig)
+            f"Expected {args_list}, not {funcparams} with {func}"
         )
     return True

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -979,12 +979,10 @@ class MultiTest(testing_base.Test):
         )
 
         try:
-            interface.check_signature(
-                testsuite_method, ["self", "env", "result"]
-            )
+            interface.check_signature(testsuite_method, ["env", "result"])
             method_args = (self.resources, case_result)
         except interface.MethodSignatureMismatch:
-            interface.check_signature(testsuite_method, ["self", "env"])
+            interface.check_signature(testsuite_method, ["env"])
             method_args = (self.resources,)
 
         with method_report.timer.record("run"):
@@ -1017,13 +1015,11 @@ class MultiTest(testing_base.Test):
         case_result: result.Result,
     ):
         try:
-            interface.check_signature(
-                method, ["self", "name", "env", "result"]
-            )
+            interface.check_signature(method, ["name", "env", "result"])
             method_args = (testcase.name, resources, case_result)
         except interface.MethodSignatureMismatch:
             interface.check_signature(
-                method, ["self", "name", "env", "result", "kwargs"]
+                method, ["name", "env", "result", "kwargs"]
             )
             method_args = (
                 testcase.name,

--- a/tests/unit/testplan/testing/multitest/test_suite.py
+++ b/tests/unit/testplan/testing/multitest/test_suite.py
@@ -188,8 +188,8 @@ def incorrect_case_signature2():
 def test_testcase_signature():
     pattern = re.compile(
         (
-            r".*Expected case1\(self, env, result\), "
-            r"not case1\(self, envs, result\).*"
+            r".*Expected arguments for case1 are \['self', 'env', 'result'\], "
+            r"not \['self', 'envs', 'result'\].*"
         )
     )
     should_raise(
@@ -197,8 +197,8 @@ def test_testcase_signature():
     )
     pattern = re.compile(
         (
-            r".*Expected case1\(self, env, result\), "
-            r"not case1\(self, env, results\).*"
+            r".*Expected arguments for case1 are \['self', 'env', 'result'\], "
+            r"not \['self', 'env', 'results'\].*"
         )
     )
     should_raise(
@@ -217,7 +217,7 @@ def incorrent_skip_if_signature1():
 
 def test_skip_if_signature():
     pattern = re.compile(
-        r".*Expected <lambda>\(testsuite\), not <lambda>\(_\).*"
+        r".*Expected arguments for <lambda> are \['testsuite'\], not \['_'\].*"
     )
     try:
         should_raise(


### PR DESCRIPTION
## Bug / Requirement Description
Need a way to customize driver log collecting.

## Solution description
Implemented a callable class that can be configured with certain filename patterns to collect.

## Checklist:
- [x] Test
- [x] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
