### PR TITLE
Revamped logging levels in exporters in preparation to remove exporter_info

### DIFF
--- a/examples/Test Output/Exporters/Custom Exporters/Basic/test_plan.py
+++ b/examples/Test Output/Exporters/Custom Exporters/Basic/test_plan.py
@@ -6,7 +6,9 @@ how to integrate it with your test plan.
 """
 import os
 import sys
+from typing import Union
 
+from testplan.report import TestReport
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 
 from testplan import test_plan
@@ -73,14 +75,16 @@ class TextFileExporter(Exporter):
     def get_text_content(self, source):
         raise NotImplementedError
 
-    def export(self, source):
+    def export(self, source: TestReport) -> Union[None, str]:
         with open(self.file_path, "w+") as report_file:
             report_file.write(self.get_text_content(source))
-            TESTPLAN_LOGGER.exporter_info(
+            TESTPLAN_LOGGER.user_info(
                 "%s output generated at %s",
                 self.__class__.__name__,
                 self.file_path,
             )
+
+        return self.file_path
 
 
 class ReprExporter(TextFileExporter):

--- a/examples/Test Output/Exporters/Custom Exporters/Basic/test_plan.py
+++ b/examples/Test Output/Exporters/Custom Exporters/Basic/test_plan.py
@@ -6,14 +6,13 @@ how to integrate it with your test plan.
 """
 import os
 import sys
-from typing import Union
-
-from testplan.report import TestReport
-from testplan.testing.multitest import MultiTest, testsuite, testcase
+from typing import Optional
 
 from testplan import test_plan
-from testplan.exporters.testing import Exporter
 from testplan.common.utils.logger import TESTPLAN_LOGGER
+from testplan.exporters.testing import Exporter
+from testplan.report import TestReport
+from testplan.testing.multitest import MultiTest, testsuite, testcase
 
 
 @testsuite
@@ -75,7 +74,7 @@ class TextFileExporter(Exporter):
     def get_text_content(self, source):
         raise NotImplementedError
 
-    def export(self, source: TestReport) -> Union[None, str]:
+    def export(self, source: TestReport) -> Optional[str]:
         with open(self.file_path, "w+") as report_file:
             report_file.write(self.get_text_content(source))
             TESTPLAN_LOGGER.user_info(

--- a/testplan/common/exporters/__init__.py
+++ b/testplan/common/exporters/__init__.py
@@ -1,6 +1,6 @@
 """TODO."""
 import traceback
-from typing import Union
+from typing import Optional
 
 from testplan.common.config import Config, Configurable
 from testplan.report import TestReport
@@ -58,5 +58,5 @@ class BaseExporter(Configurable):
         """Exporter configuration."""
         return self._cfg
 
-    def export(self, source: TestReport) -> Union[None, str]:
+    def export(self, source: TestReport) -> Optional[str]:
         raise NotImplementedError("Exporter must define export().")

--- a/testplan/common/exporters/__init__.py
+++ b/testplan/common/exporters/__init__.py
@@ -1,7 +1,9 @@
 """TODO."""
 import traceback
+from typing import Union
 
 from testplan.common.config import Config, Configurable
+from testplan.report import TestReport
 
 
 class ExporterResult:
@@ -45,7 +47,7 @@ class BaseExporter(Configurable):
         if name is None:
             name = self.__class__.__name__
         self._cfg = self.CONFIG(name=name, **options)
-        super(BaseExporter, self).__init__()
+        super().__init__()
 
     @property
     def name(self):
@@ -56,5 +58,5 @@ class BaseExporter(Configurable):
         """Exporter configuration."""
         return self._cfg
 
-    def export(self, report):
+    def export(self, source: TestReport) -> Union[None, str]:
         raise NotImplementedError("Exporter must define export().")

--- a/testplan/common/utils/logger.py
+++ b/testplan/common/utils/logger.py
@@ -226,7 +226,7 @@ class Loggable:
         super(Loggable, self).__init__()
 
     @property
-    def logger(self):
+    def logger(self) -> TestplanLogger:
         """logger object"""
         # Define logger as a property instead of self.logger directly.
         # This is to workaround a python2 issue that logger object cannot be

--- a/testplan/exporters/testing/base.py
+++ b/testplan/exporters/testing/base.py
@@ -121,10 +121,8 @@ class TagFilteredExporter(Exporter):
         :return: string message to be displayed on skipped export operations
         """
         return (
-            "Empty report for tags: `{tag_label}`, filter_type:"
-            " `{filter_type}`, skipping export operation."
-        ).format(
-            tag_label=tagging.tag_label(tag_dict), filter_type=filter_type
+            f"Empty report for tags: `{tagging.tag_label(tag_dict)}`, filter_type:"
+            f" `{filter_type}`, skipping export operation."
         )
 
     def export_clones(
@@ -153,7 +151,7 @@ class TagFilteredExporter(Exporter):
                 exporter = self.get_exporter(**params)
                 exporter.export(clone)
             else:
-                TESTPLAN_LOGGER.exporter_info(
+                TESTPLAN_LOGGER.user_info(
                     self.get_skip_message(
                         source=clone,
                         tag_dict=tag_dict,

--- a/testplan/exporters/testing/coverage/__init__.py
+++ b/testplan/exporters/testing/coverage/__init__.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 from collections import OrderedDict
 from contextlib import contextmanager
-from typing import Generator, Mapping, TextIO, Tuple, Union
+from typing import Generator, Mapping, TextIO, Tuple, Optional
 
 from testplan.common.exporters import ExporterConfig
 from testplan.exporters.testing.base import Exporter
@@ -28,7 +28,7 @@ class CoveredTestsExporter(Exporter):
     def __init__(self, name: str = "Covered Tests Exporter", **options):
         super(CoveredTestsExporter, self).__init__(name=name, **options)
 
-    def export(self, report: TestReport) -> Union[None, str]:
+    def export(self, report: TestReport) -> Optional[str]:
         if len(report):
             # here we use an OrderedDict as an ordered set
             results = OrderedDict()

--- a/testplan/exporters/testing/coverage/__init__.py
+++ b/testplan/exporters/testing/coverage/__init__.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 from collections import OrderedDict
 from contextlib import contextmanager
-from typing import Generator, Mapping, TextIO, Tuple
+from typing import Generator, Mapping, TextIO, Tuple, Union
 
 from testplan.common.exporters import ExporterConfig
 from testplan.exporters.testing.base import Exporter
@@ -28,7 +28,7 @@ class CoveredTestsExporter(Exporter):
     def __init__(self, name: str = "Covered Tests Exporter", **options):
         super(CoveredTestsExporter, self).__init__(name=name, **options)
 
-    def export(self, report: TestReport):
+    def export(self, report: TestReport) -> Union[None, str]:
         if len(report):
             # here we use an OrderedDict as an ordered set
             results = OrderedDict()
@@ -40,13 +40,11 @@ class CoveredTestsExporter(Exporter):
                     f,
                     fn,
                 ):
-                    self.logger.exporter_info(
-                        f"Impacted tests output to {fn}."
-                    )
+                    self.logger.user_info(f"Impacted tests output to {fn}.")
                     for k in results.keys():
                         f.write(":".join(k) + "\n")
                 return self.cfg.tracing_tests_output
-            self.logger.exporter_info("No impacted tests found.")
+            self.logger.user_info("No impacted tests found.")
             return None
         return None
 

--- a/testplan/exporters/testing/http/__init__.py
+++ b/testplan/exporters/testing/http/__init__.py
@@ -4,7 +4,7 @@ must be able to handle POST request and receive data in JSON format.
 """
 
 import json
-from typing import Any, Tuple, Union
+from typing import Any, Tuple, Union, Optional
 
 import requests
 from schema import Or, And, Use
@@ -93,7 +93,7 @@ class HTTPExporter(Exporter):
 
         return response, errmsg
 
-    def export(self, source: TestReport) -> Union[None, str]:
+    def export(self, source: TestReport) -> Optional[str]:
         http_url = self.cfg.http_url
         test_plan_schema = TestReportSchema()
         data = test_plan_schema.dump(source)

--- a/testplan/exporters/testing/http/__init__.py
+++ b/testplan/exporters/testing/http/__init__.py
@@ -12,6 +12,7 @@ from schema import Or, And, Use
 from testplan.common.config import ConfigOption
 from testplan.common.exporters import ExporterConfig
 from testplan.common.utils.validation import is_valid_url
+from testplan.report import TestReport
 from testplan.report.testing.schemas import TestReportSchema
 from ..base import Exporter
 
@@ -92,16 +93,15 @@ class HTTPExporter(Exporter):
 
         return response, errmsg
 
-    def export(self, source) -> Union[None, str]:
-        """TODO"""
+    def export(self, source: TestReport) -> Union[None, str]:
         http_url = self.cfg.http_url
         test_plan_schema = TestReportSchema()
         data = test_plan_schema.dump(source)
         _, errmsg = self._upload_report(http_url, data)
 
         if errmsg:
-            self.logger.exporter_info(errmsg)
+            self.logger.error(errmsg)
             return None
         else:
-            self.logger.exporter_info("Test report posted to %s", http_url)
+            self.logger.user_info("Test report posted to %s", http_url)
             return http_url

--- a/testplan/exporters/testing/json/__init__.py
+++ b/testplan/exporters/testing/json/__init__.py
@@ -7,7 +7,7 @@ import hashlib
 import json
 import os
 import pathlib
-from typing import Union
+from typing import Optional
 
 from testplan import defaults
 from testplan.common.config import ConfigOption
@@ -69,7 +69,7 @@ class JSONExporter(Exporter):
     def __init__(self, name="JSON exporter", **options):
         super(JSONExporter, self).__init__(name=name, **options)
 
-    def export(self, source: TestReport) -> Union[None, str]:
+    def export(self, source: TestReport) -> Optional[str]:
 
         json_path = pathlib.Path(self.cfg.json_path).resolve()
 

--- a/testplan/exporters/testing/json/__init__.py
+++ b/testplan/exporters/testing/json/__init__.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import pathlib
+from typing import Union
 
 from testplan import defaults
 from testplan.common.config import ConfigOption
@@ -68,7 +69,7 @@ class JSONExporter(Exporter):
     def __init__(self, name="JSON exporter", **options):
         super(JSONExporter, self).__init__(name=name, **options)
 
-    def export(self, source: TestReport):
+    def export(self, source: TestReport) -> Union[None, str]:
 
         json_path = pathlib.Path(self.cfg.json_path).resolve()
 
@@ -120,10 +121,10 @@ class JSONExporter(Exporter):
                 with open(json_path, "w") as json_file:
                     json.dump(data, json_file)
 
-            self.logger.exporter_info("JSON generated at %s", json_path)
+            self.logger.user_info("JSON generated at %s", json_path)
             return self.cfg.json_path
         else:
-            self.logger.exporter_info(
+            self.logger.user_info(
                 "Skipping JSON creation for empty report: %s", source.name
             )
             return None

--- a/testplan/exporters/testing/pdf/__init__.py
+++ b/testplan/exporters/testing/pdf/__init__.py
@@ -8,7 +8,7 @@ import time
 import traceback
 import uuid
 import warnings
-from typing import Union
+from typing import Optional
 from urllib.request import pathname2url
 
 from schema import Or
@@ -228,7 +228,7 @@ class PDFExporter(Exporter):
         template.build(tables)
         return str(pdf_path)
 
-    def export(self, source: TestReport) -> Union[None, str]:
+    def export(self, source: TestReport) -> Optional[str]:
         if len(source):
             pdf_path = self.create_pdf(source)
             self.logger.user_info("PDF generated at %s", pdf_path)

--- a/testplan/exporters/testing/pdf/__init__.py
+++ b/testplan/exporters/testing/pdf/__init__.py
@@ -8,9 +8,12 @@ import time
 import traceback
 import uuid
 import warnings
+from typing import Union
 from urllib.request import pathname2url
 
 from schema import Or
+
+from testplan.report import TestReport
 
 try:
     from reportlab.platypus import SimpleDocTemplate
@@ -204,7 +207,7 @@ class PDFExporter(Exporter):
             pdf_path = pdf_path.with_name(
                 f"{pdf_path.stem}_{int(time.time())}{pdf_path.suffix}"
             )
-            self.logger.exporter_info("File %s exists!", self.cfg.pdf_path)
+            self.logger.error("File %s exists!", self.cfg.pdf_path)
 
         template = SimpleDocTemplate(
             filename=str(pdf_path),
@@ -225,15 +228,15 @@ class PDFExporter(Exporter):
         template.build(tables)
         return str(pdf_path)
 
-    def export(self, source):
+    def export(self, source: TestReport) -> Union[None, str]:
         if len(source):
             pdf_path = self.create_pdf(source)
-            self.logger.exporter_info("PDF generated at %s", pdf_path)
+            self.logger.user_info("PDF generated at %s", pdf_path)
 
             self.url = f"file:{pathname2url(pdf_path)}"
             return pdf_path
         else:
-            self.logger.exporter_info(
+            self.logger.user_info(
                 "Skipping PDF creation for empty report: %s", source.name
             )
             return None

--- a/testplan/exporters/testing/webserver/base.py
+++ b/testplan/exporters/testing/webserver/base.py
@@ -2,14 +2,13 @@
 Web server exporter for test reports, it opens a local http web server
 which can display the test result.
 """
-from typing import Union
+from typing import Optional
 
 from testplan import defaults
 from testplan.common.config import ConfigOption
 from testplan.common.exporters import ExporterConfig
 from testplan.report.testing.base import TestReport
 from testplan.web_ui.server import WebUIServer
-
 from ..base import Exporter
 from ..json import JSONExporter
 
@@ -66,7 +65,7 @@ class WebServerExporter(Exporter):
             return self._server.web_server_thread
         return None
 
-    def export(self, source: TestReport) -> Union[None, str]:
+    def export(self, source: TestReport) -> Optional[str]:
 
         if len(source):
             exporter = JSONExporter(

--- a/testplan/exporters/testing/webserver/base.py
+++ b/testplan/exporters/testing/webserver/base.py
@@ -2,6 +2,7 @@
 Web server exporter for test reports, it opens a local http web server
 which can display the test result.
 """
+from typing import Union
 
 from testplan import defaults
 from testplan.common.config import ConfigOption
@@ -65,7 +66,7 @@ class WebServerExporter(Exporter):
             return self._server.web_server_thread
         return None
 
-    def export(self, source: TestReport):
+    def export(self, source: TestReport) -> Union[None, str]:
 
         if len(source):
             exporter = JSONExporter(
@@ -82,7 +83,7 @@ class WebServerExporter(Exporter):
 
             return self.cfg.json_path
         else:
-            self.logger.exporter_info(
+            self.logger.user_info(
                 "Skipping starting web server for empty report: %s",
                 source.name,
             )

--- a/testplan/exporters/testing/xml/__init__.py
+++ b/testplan/exporters/testing/xml/__init__.py
@@ -313,7 +313,7 @@ class XMLExporter(Exporter):
                     encoding="utf-8",
                 )
 
-        self.logger.exporter_info(
+        self.logger.user_info(
             "%s XML files created at %s", len(source), xml_dir
         )
         return str(xml_dir)


### PR DESCRIPTION
## Bug / Requirement Description
exporter_info will be retired soon need to use new user_info loglevel

## Solution description
changed all occurences,
added some typehints

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
