### PR TITLE
Minor changes in StdFiles and BaseExporter

### DIFF
--- a/testplan/common/exporters/__init__.py
+++ b/testplan/common/exporters/__init__.py
@@ -49,6 +49,9 @@ class BaseExporter(Configurable):
         self._cfg = self.CONFIG(name=name, **options)
         super().__init__()
 
+    def __str__(self):
+        return f"{self.__class__.__name__}[{self.name}]"
+
     @property
     def name(self):
         return self.cfg.name

--- a/testplan/common/utils/path.py
+++ b/testplan/common/utils/path.py
@@ -8,6 +8,7 @@ import getpass
 import contextlib
 import tempfile
 import hashlib
+from io import TextIOWrapper
 
 from testplan.common.utils.context import render
 from memoization import cached
@@ -150,7 +151,7 @@ class StdFiles:
     stderr and stdout file creation and management
     """
 
-    def __init__(self, directory):
+    def __init__(self, directory) -> None:
         """
         Create files and initialize fds
         """
@@ -160,15 +161,15 @@ class StdFiles:
         self.err = open(self.err_path, "w")
         self.out = open(self.out_path, "w")
 
-    def open_out(self):
-        """Open the stdout file with read access"""
-        return open(self.out_path, "r")
+    def open_out(self, mode: str = "r") -> TextIOWrapper:
+        """Open the stdout file with the defined access"""
+        return open(self.out_path, mode)
 
-    def open_err(self):
-        """Open the stderr file with read access"""
-        return open(self.err_path, "r")
+    def open_err(self, mode: str = "r") -> TextIOWrapper:
+        """Open the stderr file with the defined access"""
+        return open(self.err_path, mode)
 
-    def close(self):
+    def close(self) -> None:
         """
         Close fds
         """


### PR DESCRIPTION
## Bug / Requirement Description
Minor changes in StdFiles and BaseExporter

## Solution description
Changed stdout and stderr open mode to be customizable and added typedefs

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
