### PR TITLE
Bug/TextAttachment error handling

### DIFF
--- a/doc/newsfragments/2513_changed.fix_errorHandler_TextAttachment.rst
+++ b/doc/newsfragments/2513_changed.fix_errorHandler_TextAttachment.rst
@@ -1,0 +1,1 @@
+Fixed an issue in TextAttachment component when the server sent a non-text type response for a request caused unexpected WebUI crash.

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TextAttachment.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TextAttachment.js
@@ -75,7 +75,11 @@ function TextAttachment(props) {
   };
 
   const errorHandler = (error) => {
-    setError(error.response ? error.response.data : error.message);
+    setError(
+      error?.response?.data?.message 
+      ? error.response.data.message 
+      : error.message
+    );
     setLines(null);
   };
 

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TextAttachment.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/TextAttachment.js
@@ -75,11 +75,17 @@ function TextAttachment(props) {
   };
 
   const errorHandler = (error) => {
-    setError(
-      error?.response?.data?.message 
-      ? error.response.data.message 
-      : error.message
-    );
+    if (error.response) {
+      setError(
+        error.response.headers["content-type"] === "application/json"
+        ? error.response.data.message
+        : error.response.data
+      );
+    } else {
+      setError(
+        error.message
+      );
+    }
     setLines(null);
   };
 

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/TextAttachment.test.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/TextAttachment.test.js
@@ -52,6 +52,32 @@ describe("TextAttachment", () => {
     }, 100);
   });
 
+  it("displays error message if API request fails (JSON)", (done) => {
+    const renderedText = shallow(
+      <TextAttachment
+        src="/var/tmp/attachment.txt"
+        file_name="attachment.txt"
+      />
+    );
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request
+        .respondWith({
+          headers: {"content-type": "application/json"},
+          status: 503,
+          response: {message: "Service Unavailable"},
+        })
+        .then(() => {
+          renderedText.update();
+          const content = renderedText.find(CardContent);
+          expect(content).toHaveLength(1);
+          expect(content.text()).toEqual("Service Unavailable");
+          expect(renderedText).toMatchSnapshot();
+          done();
+        });
+    }, 100);
+  });
+
   it("displays error message if API request fails", (done) => {
     const renderedText = shallow(
       <TextAttachment
@@ -63,6 +89,7 @@ describe("TextAttachment", () => {
       const request = moxios.requests.mostRecent();
       request
         .respondWith({
+          headers: {"content-type": "application/txt"},
           status: 503,
           response: "Service Unavailable",
         })

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/__snapshots__/TextAttachment.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/__tests__/__snapshots__/TextAttachment.test.js.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TextAttachment displays error message if API request fails (JSON) 1`] = `
+<WithStyles(ForwardRef(Card))>
+  <AttachmentAssertionCardHeader
+    extra_action_items={null}
+    file_name="attachment.txt"
+    src="/var/tmp/attachment.txt"
+  />
+  <WithStyles(ForwardRef(CardContent))>
+    Service Unavailable
+  </WithStyles(ForwardRef(CardContent))>
+</WithStyles(ForwardRef(Card))>
+`;
+
 exports[`TextAttachment displays error message if API request fails 1`] = `
 <WithStyles(ForwardRef(Card))>
   <AttachmentAssertionCardHeader

--- a/testplan/web_ui/testing/src/Common/fakeReport.js
+++ b/testplan/web_ui/testing/src/Common/fakeReport.js
@@ -509,6 +509,21 @@ var fakeReportAssertionsError = {
                     "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
                   line_no: 165,
                 },
+                {
+                  "orig_filename": "missing_file.txt",
+                  "dst_path": "missing_file.txt",
+                  "filesize": 104000,
+                  "line_no": 93,
+                  "file_path": "C:\\Users\\Name\\testplan\\testplan\\web_ui\\testing\\src\\Common\\fakeReport.js",
+                  "source_path": "/some/invalid/path/missing_file.txt",
+                  "type": "Attachment",
+                  "category": "DEFAULT",
+                  "flag": "DEFAULT",
+                  "description": "A file failed to attach",
+                  "meta_type": "entry",
+                  "machine_time": "2020-01-10T03:06:59.957489+00:00",
+                  "utc_time": "2020-01-10T03:06:59.957489+00:00"
+                },
               ],
             },
             {


### PR DESCRIPTION
## Bug / Requirement Description
In special cases (eg. attachment is not available on the remote server) the TextAttachment gets an Object as an error and crashes the UI.

## Solution description
Store the correct error message based on the response type instead of the whole Object in errorHandler.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
