### PR TITLE
remove missed tls line from non tls example

### DIFF
--- a/examples/Transports/FIX/test_plan.py
+++ b/examples/Transports/FIX/test_plan.py
@@ -39,7 +39,6 @@ def main(plan):
     """
     plan.add(over_one_session.get_multitest())
     plan.add(over_two_sessions.get_multitest())
-    plan.add(over_one_session.get_tls_multitest())
 
 
 if __name__ == "__main__":

--- a/tests/functional/examples/test_examples.py
+++ b/tests/functional/examples/test_examples.py
@@ -41,6 +41,7 @@ SKIP = [
     os.path.join(
         "Multitest", "Listing", "Custom Listers", "test_plan_command_line.py"
     ),
+    os.path.join("Transports", "FIX", "test_plan_tls.py"),
 ]
 
 REMOTE_HOST = os.environ.get("TESTPLAN_REMOTE_HOST")
@@ -57,7 +58,6 @@ SKIP_ON_WINDOWS = [
     os.path.join("Cpp", "Cppunit", "test_plan.py"),
     os.path.join("Cpp", "HobbesTest", "test_plan.py"),
     os.path.join("Transports", "FIX", "test_plan.py"),
-    os.path.join("Transports", "FIX", "test_plan_tls.py"),
     os.path.join("App", "Basic", "test_plan.py"),
     os.path.join("App", "Autostart", "test_plan.py"),
     os.path.join("JUnit", "test_plan.py"),


### PR DESCRIPTION
## Bug / Requirement Description
access a non existent method from an example

## Solution description
removed referenece

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
