### PR TITLE
Environment prestart in interactive mode

### DIFF
--- a/doc/en/introduction.rst
+++ b/doc/en/introduction.rst
@@ -335,6 +335,7 @@ Command line
       --runpath             Path under which all temp files and logs will be created.
       --timeout             Expiry timeout on test execution.
       -i, --interactive     Enable interactive mode. A port may be specified, otherwise the port defaults to 0.
+      --pre-start-environments     Enable pre-start of environments in interactive mode. MultiTest names are to be passed as whitespace separated list of strings. Defaults to no pre-start.
       --trace-tests         Enable the tracing tests feature. A JSON file containing file names and line numbers to be watched by the tracer must be specified.
       --trace-tests-output
                             Specify output file for tests impacted by change in Testplan pattern format (see --trace-tests). Will be ignored if --trace-tests is not specified. Default to standard output.

--- a/doc/newsfragments/2505_new.pre_start_interactive_env.rst
+++ b/doc/newsfragments/2505_new.pre_start_interactive_env.rst
@@ -1,0 +1,1 @@
+Added new command line option `--pre-start-environments` that accepts a whitespace separated list of MultiTest names for which environments are pre-started in interactive mode.

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -768,7 +768,9 @@ class RunnableConfig(EntityConfig):
         return {
             # IHandler explicitly enables interactive mode of runnable
             ConfigOption("interactive_port", default=None): Or(None, int),
-            ConfigOption("pre_start_environments", default=None): list,
+            ConfigOption("pre_start_environments", default=None): Or(
+                None, list
+            ),
             ConfigOption(
                 "interactive_block",
                 default=hasattr(sys.modules["__main__"], "__file__"),

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -768,6 +768,7 @@ class RunnableConfig(EntityConfig):
         return {
             # IHandler explicitly enables interactive mode of runnable
             ConfigOption("interactive_port", default=None): Or(None, int),
+            ConfigOption("pre_start_environments", default=None): list,
             ConfigOption(
                 "interactive_block",
                 default=hasattr(sys.modules["__main__"], "__file__"),
@@ -1106,7 +1107,9 @@ class Runnable(Entity):
 
                 self.logger.user_info("Starting %s in interactive mode", self)
                 self._ihandler = self.cfg.interactive_handler(
-                    target=self, http_port=self.cfg.interactive_port
+                    target=self,
+                    http_port=self.cfg.interactive_port,
+                    pre_start_environments=self.cfg.pre_start_environments,
                 )
                 thread = threading.Thread(target=self._ihandler)
                 # Testplan should exit even if interactive handler thread stuck

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -123,6 +123,16 @@ class TestplanParser:
         )
 
         general_group.add_argument(
+            "--pre-start-environments",
+            dest="pre_start_environments",
+            type=str,
+            default=None,
+            nargs="*",
+            help="Enables pre-start of environments corresponding to the "
+            "MultiTest names passed. Defaults to no environment pre-started.",
+        )
+
+        general_group.add_argument(
             "--trace-tests",
             metavar="PATH",
             type=_read_json_file,

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -52,7 +52,13 @@ class TestRunnerIHandler(entity.Entity):
     CONFIG = TestRunnerIHandlerConfig
     STATUS = entity.RunnableStatus
 
-    def __init__(self, target, startup_timeout=10, http_port=0):
+    def __init__(
+        self,
+        target,
+        startup_timeout=10,
+        http_port=0,
+        pre_start_environments=None,
+    ):
         super(TestRunnerIHandler, self).__init__(
             target=target, startup_timeout=startup_timeout, http_port=http_port
         )
@@ -63,6 +69,7 @@ class TestRunnerIHandler(entity.Entity):
         self._pool = None
         self._http_handler = None
         self._created_environments = {}
+        self.pre_start_environments = pre_start_environments
 
         try:
             self._reloader = reloader.ModuleReloader(
@@ -131,6 +138,9 @@ class TestRunnerIHandler(entity.Entity):
             raise RuntimeError("setup() not run")
 
         self.status.change(entity.RunnableStatus.RUNNING)
+        if self.pre_start_environments is not None:
+            for env in self.pre_start_environments:
+                self.start_test_resources(env, await_results=False)
         self._display_connection_info()
         with self._pool:
             self._http_handler.run()


### PR DESCRIPTION
## Bug / Requirement Description
Currently, there is no option in Testplan to prestart environments in interactive mode. We would like to add this feature.

## Solution description
There is a new command line option added to TestplanParser that allows pre-start of the environments specified in a whitespace separated list of names.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [x] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [x] For new cmdline arg: documentation
