### PR TITLE
Improve pull files traversal

### DIFF
--- a/doc/newsfragments/2572_changed.pull_files_traversal.rst
+++ b/doc/newsfragments/2572_changed.pull_files_traversal.rst
@@ -1,0 +1,1 @@
+All RemoteResource types now handle file transfer errors more gracefully and continue the traversal.

--- a/testplan/common/remote/remote_resource.py
+++ b/testplan/common/remote/remote_resource.py
@@ -29,6 +29,7 @@ from testplan.common.utils.remote import (
     IS_WIN,
     rm_cmd,
 )
+from testplan.runnable import TestRunner
 
 
 class WorkerSetupMetadata:
@@ -636,7 +637,7 @@ class RemoteResource(Entity):
 
         return sys_path
 
-    def _get_plan(self) -> Optional[testplan.runnable.TestRunner]:
+    def _get_plan(self) -> Optional[TestRunner]:
         """traverse upwards to find TestRunner"""
 
         parent = getattr(self, "parent", None)

--- a/testplan/common/remote/remote_resource.py
+++ b/testplan/common/remote/remote_resource.py
@@ -29,7 +29,6 @@ from testplan.common.utils.remote import (
     IS_WIN,
     rm_cmd,
 )
-from testplan.runnable import TestRunner
 
 
 class WorkerSetupMetadata:
@@ -637,7 +636,7 @@ class RemoteResource(Entity):
 
         return sys_path
 
-    def _get_plan(self) -> Optional[TestRunner]:
+    def _get_plan(self):
         """traverse upwards to find TestRunner"""
 
         parent = getattr(self, "parent", None)

--- a/testplan/common/remote/remote_resource.py
+++ b/testplan/common/remote/remote_resource.py
@@ -2,7 +2,7 @@ import getpass
 import itertools
 import os
 import sys
-from typing import Callable, Iterator, List, Tuple, Union, Dict
+from typing import Callable, Iterator, List, Tuple, Union, Dict, Optional
 
 from schema import Or
 
@@ -491,13 +491,17 @@ class RemoteResource(Entity):
 
         return push_files, push_dirs
 
-    def _build_push_dests(self, push_sources):
+    def _build_push_dests(
+        self,
+        push_sources: Union[List[str], List[Tuple[str, str]]]
+    ) -> Union[List[str], List[Tuple [str, str]]]:
         """
         When the destination paths have not been explicitly specified, build
         them automatically. If an absolute path is given on Linux, we will push
-        to the same path on remote. If on windows or a relative path is given on
+        to the same path on remote. If on Windows or a relative path is given on
         Linux, we will push to the save relative path in respect to working
         directory.
+
         """
         push_locations = []
 
@@ -542,7 +546,7 @@ class RemoteResource(Entity):
 
         return push_locations
 
-    def _push_files_to_dst(self, push_files: List, push_dirs: List):
+    def _push_files_to_dst(self, push_files: List, push_dirs: List) -> None:
         """
         Push files and directories to the remote host. Both the source and
         destination paths should be specified.
@@ -563,7 +567,7 @@ class RemoteResource(Entity):
                 exclude=self.cfg.push_exclude,
             )
 
-    def _fetch_results(self):
+    def _fetch_results(self) -> None:
         """Fetch back to local host the results generated remotely."""
         if not self.cfg.fetch_runpath:
             self.logger.debug(
@@ -581,12 +585,11 @@ class RemoteResource(Entity):
             if self.cfg.pull:
                 self._pull_files()
         except Exception as exc:
-            # TODO: This is so confusing to the user I think it is enough on debug log
             self.logger.debug(
                 "While fetching result from worker [%s]: %s", self, exc
             )
 
-    def _clean_remote(self):
+    def _clean_remote(self) -> None:
         if self.cfg.clean_remote:
             self.logger.debug(
                 "Clean root runpath on remote host - %s", self.ssh_cfg["host"]
@@ -597,21 +600,26 @@ class RemoteResource(Entity):
                 label="Clean remote root runpath",
             )
 
-    def _pull_files(self):
+    def _pull_files(self) -> None:
         """Pull custom files from remote host."""
 
         pull_dst = os.path.join(self.runpath, "pulled_files")
         makedirs(pull_dst)
 
         for entry in self.cfg.pull:
-            self._transfer_data(
-                source=entry,
-                remote_source=True,
-                target=pull_dst,
-                exclude=self.cfg.pull_exclude,
-            )
+            try:
+                self._transfer_data(
+                    source=entry,
+                    remote_source=True,
+                    target=pull_dst,
+                    exclude=self.cfg.pull_exclude,
+                )
+            except Exception as exc:
+                self.logger.debug(
+                    "While fetching result from worker [%s]: %s", self, exc
+                )
 
-    def _remote_sys_path(self):
+    def _remote_sys_path(self) -> List[str]:
 
         sys_path = [self._testplan_import_path.remote]
 
@@ -629,7 +637,7 @@ class RemoteResource(Entity):
 
         return sys_path
 
-    def _get_plan(self):
+    def _get_plan(self) -> Optional[testplan.runnable.TestRunner]:
         """traverse upwards to find TestRunner"""
 
         parent = getattr(self, "parent", None)

--- a/testplan/common/remote/remote_resource.py
+++ b/testplan/common/remote/remote_resource.py
@@ -492,9 +492,8 @@ class RemoteResource(Entity):
         return push_files, push_dirs
 
     def _build_push_dests(
-        self,
-        push_sources: Union[List[str], List[Tuple[str, str]]]
-    ) -> Union[List[str], List[Tuple [str, str]]]:
+        self, push_sources: Union[List[str], List[Tuple[str, str]]]
+    ) -> Union[List[str], List[Tuple[str, str]]]:
         """
         When the destination paths have not been explicitly specified, build
         them automatically. If an absolute path is given on Linux, we will push


### PR DESCRIPTION
## Bug / Requirement Description
RemoteResource types exit traversal of pull files entries upon first exception. We need to make it so that it continues to next item.

## Solution description
Wrap the transfer of data inside the loop in a try-except, logging the exception, but progressing to the next item.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
