### PR TITLE
Updated metadata collecting in PDFExporter

### DIFF
--- a/testplan/common/exporters/pdf.py
+++ b/testplan/common/exporters/pdf.py
@@ -597,16 +597,22 @@ class RowStyle:
             for key in sorted(self._style_props.keys())
         )
 
-        return tuple(
-            (
+        commands = []
+
+        for key, val in props:
+            command = [
                 key.upper().replace("_", ""),
                 (self.start_column, self.start_row),
                 (self.end_column, self.end_row),
-            )
-            + (val if isinstance(val, tuple) else (val,))
-            for key, val in props
-            if val is not None
-        )
+            ]
+            if val is not None:
+                if isinstance(val, tuple):
+                    command.extend(val)
+                else:
+                    command.append(val)
+            commands.append(tuple(command))
+
+        return tuple(commands)
 
 
 class RowData:

--- a/testplan/common/exporters/pdf.py
+++ b/testplan/common/exporters/pdf.py
@@ -489,12 +489,12 @@ class RowStyle:
 
     def __init__(
         self,
-        start_column=0,
-        end_column=-1,
-        start_row=None,
-        end_row=None,
+        start_column: int = 0,
+        end_column: int = -1,
+        start_row: int = None,
+        end_row: int = None,
         **style_props
-    ):
+    ) -> None:
 
         if not style_props:
             raise ValueError(
@@ -508,23 +508,23 @@ class RowStyle:
         self._style_props = style_props
 
     @property
-    def start_column(self):
+    def start_column(self) -> int:
         return self._start_column
 
     @property
-    def end_column(self):
+    def end_column(self) -> int:
         return self._end_column
 
     @property
-    def start_row(self):
+    def start_row(self) -> int:
         return self._start_row
 
     @property
-    def end_row(self):
+    def end_row(self) -> int:
         return self._end_row
 
     @start_row.setter
-    def start_row(self, value):
+    def start_row(self, value: int) -> None:
         if self._start_row is not None:
             raise ValueError(
                 (
@@ -534,7 +534,7 @@ class RowStyle:
         self._start_row = value
 
     @end_row.setter
-    def end_row(self, value):
+    def end_row(self, value: int) -> None:
         if self._end_row is not None:
             raise ValueError(
                 ("Cannot override existing value " "for end row ({})").format(
@@ -543,7 +543,7 @@ class RowStyle:
             )
         self._end_row = value
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         tmp = (
             "{class_name}(start_column={start_column}, "
             "end_column={end_column}, start_row={start_row}, "
@@ -563,7 +563,7 @@ class RowStyle:
             ),
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         attrs = (
             "start_column",
             "end_column",
@@ -573,7 +573,7 @@ class RowStyle:
         )
         return all(getattr(self, att) == getattr(other, att) for att in attrs)
 
-    def get_commands(self):
+    def get_commands(self) -> tuple:
         """
         Return Reportlab compliant styling commands.
 
@@ -599,18 +599,19 @@ class RowStyle:
 
         commands = []
 
+        # We want to skip commands with False or None values
         for key, val in props:
-            command = [
-                key.upper().replace("_", ""),
-                (self.start_column, self.start_row),
-                (self.end_column, self.end_row),
-            ]
-            if val is not None:
+            if not (val is None or val is False):
+                command = [
+                    key.upper().replace("_", ""),
+                    (self.start_column, self.start_row),
+                    (self.end_column, self.end_row),
+                ]
                 if isinstance(val, tuple):
                     command.extend(val)
-                else:
+                elif not isinstance(val, bool):
                     command.append(val)
-            commands.append(tuple(command))
+                commands.append(tuple(command))
 
         return tuple(commands)
 

--- a/testplan/common/utils/registry.py
+++ b/testplan/common/utils/registry.py
@@ -98,13 +98,6 @@ class Registry(logger.Loggable):
 
     def __setitem__(self, key, value):
         key = self.get_record_key(key)
-        if key in self.data:
-            raise ValueError(
-                "Cannot overwrite registry for {key},"
-                " it already has the value: {value}".format(
-                    key=key, value=self[key]
-                )
-            )
         self.data[key] = value
 
     def bind(self, *classes):

--- a/testplan/exporters/testing/pdf/renderers/base.py
+++ b/testplan/exporters/testing/pdf/renderers/base.py
@@ -136,10 +136,11 @@ class MetadataMixin:
         Return metadata context to be rendered
         on the PDF with readable labels.
         """
+        metadata = dict(source.information)
         return collections.OrderedDict(
             [
-                (label, dict(source.information)[key])
+                (label, metadata[key])
                 for key, label in self.get_metadata_labels()
-                if dict(source.information).get(key)
+                if key in metadata
             ]
         )

--- a/testplan/exporters/testing/pdf/renderers/base.py
+++ b/testplan/exporters/testing/pdf/renderers/base.py
@@ -138,8 +138,8 @@ class MetadataMixin:
         """
         return collections.OrderedDict(
             [
-                (label, source.meta[key])
+                (label, dict(source.information)[key])
                 for key, label in self.get_metadata_labels()
-                if source.meta.get(key)
+                if dict(source.information).get(key)
             ]
         )

--- a/testplan/exporters/testing/pdf/renderers/reports.py
+++ b/testplan/exporters/testing/pdf/renderers/reports.py
@@ -57,6 +57,9 @@ class TestReportRenderer(BaseRowRenderer, MetadataMixin):
         ("project", "Project"),
         ("git_url", "Git URL"),
         ("git_commit", "Git commit"),
+        ("hostname", "Host"),
+        ("command_line_string", "Command line string"),
+        ("python_version", "Python version"),
         # These two will be set via `get_tag_pdf_ctx`
         ("report_tags_all", "Report tags (all)"),
         ("report_tags_any", "Report tags (any)"),

--- a/testplan/exporters/testing/pdf/renderers/reports.py
+++ b/testplan/exporters/testing/pdf/renderers/reports.py
@@ -2,6 +2,8 @@
 PDF Renderer classes for test report objects.
 """
 import logging
+from collections import OrderedDict
+from typing import Optional, Tuple
 
 from reportlab.lib import colors, styles
 from reportlab.platypus import Paragraph
@@ -16,6 +18,7 @@ from testplan.report import (
     TestCaseReport,
     ReportCategories,
 )
+from testplan.report.testing.styles import StyleFlag
 from testplan.testing import tagging
 from . import constants as const
 from .base import format_duration, RowData, BaseRowRenderer, MetadataMixin
@@ -35,7 +38,7 @@ class ReportRendererRegistry(Registry):
 registry = ReportRendererRegistry()
 
 
-def format_status(report_status):
+def format_status(report_status: Status) -> str:
     """
     For readability purposes, both failed and
     erroneous tests will be displayed as failed.
@@ -66,9 +69,11 @@ class TestReportRenderer(BaseRowRenderer, MetadataMixin):
         ("report_tags_any", "Report tags (any)"),
     )
 
-    def get_metadata_context(self, source):
+    def get_metadata_context(self, source: TestReport) -> OrderedDict:
         """
         Enriched meta context with test counts, run times etc.
+
+        :param source: Source object for the renderer. Report for a Testplan test run.
         """
         ctx = super(TestReportRenderer, self).get_metadata_context(source)
 
@@ -97,8 +102,19 @@ class TestReportRenderer(BaseRowRenderer, MetadataMixin):
             )
         return ctx
 
-    def get_row_data(self, source, depth, row_idx):
-        """Render Testplan header & metadata"""
+    def get_row_data(
+        self,
+        source: TestReport,
+        depth: int,
+        row_idx: int,
+    ) -> RowData:
+        """
+        Render Testplan header & metadata
+
+        :param source: Source object for the renderer. Report for a Testplan test run.
+        :param depth: Depth of the source object on report tree. Used for indentation.
+        :param row_idx: Index of the current table row to be rendered.
+        """
         row_data = RowData(
             start=row_idx,
             content=[source.name, "", "", format_status(source.status)],
@@ -116,10 +132,6 @@ class TestReportRenderer(BaseRowRenderer, MetadataMixin):
         )
 
         samplestyles = styles.getSampleStyleSheet()
-        metadata = [
-            [key, Paragraph(value, samplestyles["Normal"]), "", ""]
-            for key, value in self.get_metadata_context(source).items()
-        ]
 
         # Metadata
         for key, value in self.get_metadata_context(source).items():
@@ -148,7 +160,7 @@ class TestReportRenderer(BaseRowRenderer, MetadataMixin):
                         end_column=1,
                     ),
                     RowStyle(
-                        span=None,
+                        span=True,
                         start_column=1,
                         end_column=3,
                     ),
@@ -162,10 +174,21 @@ class TestReportRenderer(BaseRowRenderer, MetadataMixin):
 
         return row_data
 
-    def get_logs(self, source, depth, row_idx, lvl=logging.ERROR):
+    def get_logs(
+        self,
+        source: TestReport,
+        depth: int,
+        row_idx: int,
+        lvl: int = logging.ERROR,
+    ) -> Optional[RowData]:
         """
         Get logs created by the `report.logger` object.
         Only select the logs with severity level equal to or higher than `lvl`.
+
+        :param source: Source object for the renderer. Report for a Testplan test run.
+        :param depth: Depth of the source object on report tree. Used for indentation.
+        :param row_idx: Index of the current table row to be rendered.
+        :param lvl: Log severity level.
         """
         font_size = const.FONT_SIZE_SMALL
         width = const.WRAP_LIMITS[font_size]
@@ -193,9 +216,18 @@ class TestReportRenderer(BaseRowRenderer, MetadataMixin):
 class TestRowRenderer(BaseRowRenderer, MetadataMixin):
     """Common logic for rendering test report objects."""
 
-    def get_row_data(self, source, depth, row_idx):
+    def get_row_data(
+        self,
+        source: TestGroupReport,
+        depth: int,
+        row_idx: int,
+    ) -> RowData:
         """
         Display test name/description, passed status & logs (if enabled).
+
+        :param source: Source object for the renderer. Report for a Testplan test run.
+        :param depth: Depth of the source object on report tree. Used for indentation.
+        :param row_idx: Index of the current table row to be rendered.
         """
         row_data = self.get_header(source, depth, row_idx)
 
@@ -213,15 +245,24 @@ class TestRowRenderer(BaseRowRenderer, MetadataMixin):
 
         return row_data
 
-    def get_header_linestyle(self):
+    def get_header_linestyle(self) -> Tuple[int, colors.HexColor]:
         """Styling for the line below test header."""
         return 1, colors.lightgrey
 
-    def get_header(self, source, depth, row_idx):
+    def get_header(
+        self,
+        source: TestGroupReport,
+        depth: int,
+        row_idx: int,
+    ) -> RowData:
         """
         Assuming we have 4 columns per row, render the header in the format:
 
         [<TEST_NAME> - <NATIVE TAGS>][][][<TEST_STATUS>]
+
+        :param source: Source object for the renderer.
+        :param depth: Depth of the source object on report tree. Used for indentation.
+        :param row_idx: Index of the current table row to be rendered.
         """
         passed = source.passed
         font_size = const.FONT_SIZE if depth == 0 else const.FONT_SIZE_SMALL
@@ -259,10 +300,19 @@ class TestRowRenderer(BaseRowRenderer, MetadataMixin):
             style=styles,
         )
 
-    def get_description(self, description, depth, row_idx):
+    def get_description(
+        self,
+        description: str,
+        depth: int,
+        row_idx: int,
+    ) -> RowData:
         """
         Description for a test object,
         this will generally be docstring text.
+
+        :param description: Description for a test object. Report for a Testplan test run.
+        :param depth: Depth of the source object on report tree. Used for indentation.
+        :param row_idx: Index of the current table row to be rendered.
         """
         return RowData(
             start=row_idx,
@@ -280,10 +330,21 @@ class TestRowRenderer(BaseRowRenderer, MetadataMixin):
             ),
         )
 
-    def get_logs(self, source, depth, row_idx, lvl=logging.ERROR):
+    def get_logs(
+        self,
+        source: TestGroupReport,
+        depth: int,
+        row_idx: int,
+        lvl: int = logging.ERROR,
+    ) -> Optional[RowData]:
         """
         Get logs created by the `report.logger` object.
         Only select the logs with severity level equal to or higher than `lvl`.
+
+        :param source: Source object for the renderer.
+        :param depth: Depth of the source object on report tree. Used for indentation.
+        :param row_idx: Index of the current table row to be rendered.
+        :param lvl: Log severity level.
         """
         font_size = const.FONT_SIZE_SMALL
         width = const.WRAP_LIMITS[font_size]
@@ -306,14 +367,16 @@ class TestRowRenderer(BaseRowRenderer, MetadataMixin):
             else None
         )
 
-    def get_style(self, source):
+    def get_style(self, source) -> StyleFlag:
         if source.passed:
             return self.style.passing
         return self.style.failing
 
-    def should_display(self, source):
+    def should_display(self, source: TestGroupReport) -> bool:
         """
         Filter out passing rows if `failing_tests` is `True`.
+
+        :param source: Source object for the renderer.
         """
         style = self.get_style(source)
         if source.category == ReportCategories.TESTSUITE:
@@ -330,14 +393,14 @@ class TestCaseRowBuilder(TestRowRenderer):
     to a testcase method / function.
     """
 
-    def get_header_linestyle(self):
+    def get_header_linestyle(self) -> Tuple[int, colors.HexColor]:
         """
         Testcase line separators are a little bit
         thinner, as there are many testcases per test run.
         """
         return 0.5, colors.lightgrey
 
-    def should_display(self, source):
+    def should_display(self, source: TestCaseReport) -> bool:
         return self.get_style(source).display_testcase
 
 
@@ -345,15 +408,26 @@ class TestCaseRowBuilder(TestRowRenderer):
 class MultiTestRowBuilder(TestRowRenderer):
     """Multitests get special treatment with extra formatting & summary."""
 
-    def get_header_linestyle(self):
+    def get_header_linestyle(self) -> Tuple[int, colors.HexColor]:
         """
         More distinctive line separator for Multitests,
         as they are high level test containers.
         """
         return 1, colors.black
 
-    def get_header(self, source, depth, row_idx):
-        """Display short summary & run times along with pass/fail status."""
+    def get_header(
+        self,
+        source: TestCaseReport,
+        depth: int,
+        row_idx: int,
+    ) -> RowData:
+        """
+        Display short summary & run times along with pass/fail status.
+
+        :param source: Source object for the renderer.
+        :param depth: Depth of the source object on report tree. Used for indentation.
+        :param row_idx: Index of the current table row to be rendered.
+        """
         row_data = RowData(
             start=row_idx,
             content=const.EMPTY_ROW,

--- a/testplan/exporters/testing/pdf/renderers/reports.py
+++ b/testplan/exporters/testing/pdf/renderers/reports.py
@@ -3,7 +3,8 @@ PDF Renderer classes for test report objects.
 """
 import logging
 
-from reportlab.lib import colors
+from reportlab.lib import colors, styles
+from reportlab.platypus import Paragraph
 
 from testplan.common.exporters.pdf import RowStyle
 from testplan.common.utils.registry import Registry
@@ -114,31 +115,45 @@ class TestReportRenderer(BaseRowRenderer, MetadataMixin):
             ],
         )
 
+        samplestyles = styles.getSampleStyleSheet()
+        metadata = [
+            [key, Paragraph(value, samplestyles["Normal"]), "", ""]
+            for key, value in self.get_metadata_context(source).items()
+        ]
+
         # Metadata
-        row_data.append(
-            content=[
-                [key, value, "", ""]
-                for key, value in self.get_metadata_context(source).items()
-            ],
-            style=[
-                RowStyle(
-                    bottom_padding=0,
-                    left_padding=0,
-                    top_padding=0,
-                    valign="TOP",
-                ),
-                RowStyle(
-                    font=(const.FONT_BOLD, const.FONT_SIZE_SMALL),
-                    start_column=0,
-                    end_column=0,
-                ),
-                RowStyle(
-                    font=(const.FONT, const.FONT_SIZE_SMALL),
-                    start_column=1,
-                    end_column=1,
-                ),
-            ],
-        )
+        for key, value in self.get_metadata_context(source).items():
+            row_data.append(
+                content=[
+                    key,
+                    Paragraph(value, samplestyles["Normal"]),
+                    "",
+                    "",
+                ],
+                style=[
+                    RowStyle(
+                        bottom_padding=0,
+                        left_padding=0,
+                        top_padding=0,
+                        valign="TOP",
+                    ),
+                    RowStyle(
+                        font=(const.FONT_BOLD, const.FONT_SIZE_SMALL),
+                        start_column=0,
+                        end_column=0,
+                    ),
+                    RowStyle(
+                        font=(const.FONT, const.FONT_SIZE_SMALL),
+                        start_column=1,
+                        end_column=1,
+                    ),
+                    RowStyle(
+                        span=None,
+                        start_column=1,
+                        end_column=3,
+                    ),
+                ],
+            )
 
         # Error logs that are higher than ERROR level
         log_data = self.get_logs(source, depth=depth + 1, row_idx=row_data.end)


### PR DESCRIPTION
## Bug / Requirement Description
PDFExporter failed to export metadata.

## Solution description
Fixed metadata collecting in PDFExporter and added new fields and also fixed text wrapping.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
