### PR TITLE
Feature/interactive filter

### DIFF
--- a/doc/en/interactive.rst
+++ b/doc/en/interactive.rst
@@ -31,13 +31,6 @@ automatic code-reloading feature which allows testcases to be tweaked, added or
 rewritten and then run without having to restart the main Testplan process or
 interrupt processes started as part of the test environment.
 
-.. note::
-
-    The interactive mode is currently in a beta stage and under active development.
-    There are still a few features yet to be implemented, for example the filter
-    box, tree view navigation and timing view, etc. Please bear with us while we
-    work through these, and feel free to raise an issue for any bugs you may find.
-
 .. _Interactive_Reload:
 
 How code reloading works

--- a/doc/newsfragments/2277_new.interactive_mode_filter_run.rst
+++ b/doc/newsfragments/2277_new.interactive_mode_filter_run.rst
@@ -1,0 +1,1 @@
+Interactive UI now runs only cases matching the filter pattern, provided it is present.

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -936,6 +936,17 @@ class TestCaseReport(Report):
         if new_status == RuntimeStatus.FINISHED:
             self._status = Status.PASSED  # passed if case report has no entry
 
+    def set_runtime_status_filtered(self, new_status, entries):
+        for entry in self:
+            if entry.name in entries.keys():
+                if isinstance(entry, TestCaseReport):
+                    entry.runtime_status = new_status
+                else:
+                    entry.set_runtime_status_filtered(
+                        new_status, entries[entry.name]
+                    )
+        self._runtime_status = new_status
+
     def _assertions_status(self):
         for entry in self:
             if entry.get(Status.PASSED) is False:

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -1,5 +1,42 @@
 """
 Report classes that will store the test results.
+
+Assuming we have a Testplan setup like this:
+.. code-block:: python
+  Testplan MyPlan
+    Multitest A
+      Suite A-1
+        TestCase test_method_a_1_x
+        TestCase test_method_a_1_y
+        TestCase (parametrized, with 3 scenarios) test_method_a_1_z
+      Suite A-2
+        Testcase test_method_a_2_x
+    Multitest B
+      Suite B-1
+        Testcase test_method_b_1_x
+    GTest C
+We will have a report tree like:
+.. code-block:: python
+  TestReport(name='MyPlan')
+    TestGroupReport(name='A', category='Multitest')
+      TestGroupReport(name='A-1', category='TestSuite')
+        TestCaseReport(name='test_method_a_1_x')
+        TestCaseReport(name='test_method_a_1_y')
+        TestGroupReport(name='test_method_a_1_z', category='parametrization')
+          TestCaseReport(name='test_method_a_1_z_1')
+          TestCaseReport(name='test_method_a_1_z_2')
+          TestCaseReport(name='test_method_a_1_z_3')
+      TestGroupReport(name='A-2', category='TestSuite')
+        TestCaseReport(name='test_method_a_2_x')
+    TestGroupReport(name='B', category='MultiTest')
+      TestGroupReport(name='B-1', category='TestSuite')
+        TestCaseReport(name='test_method_b_1_x')
+    TestGroupReport(name='C', category='GTest')
+      TestCaseReport(name='<first test of Gtest>') -> can only be retrieved
+                                                      after GTest is run
+      TestCaseReport(name='<second test of Gtest>') -> can only be retrieved
+                                                       after GTest is run
+    ...
 """
 import copy
 import getpass

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -1,47 +1,5 @@
 """
 Report classes that will store the test results.
-
-Assuming we have a Testplan setup like this:
-
-.. code-block:: python
-
-  Testplan MyPlan
-    Multitest A
-      Suite A-1
-        TestCase test_method_a_1_x
-        TestCase test_method_a_1_y
-        TestCase (parametrized, with 3 scenarios) test_method_a_1_z
-      Suite A-2
-        Testcase test_method_a_2_x
-    Multitest B
-      Suite B-1
-        Testcase test_method_b_1_x
-    GTest C
-
-We will have a report tree like:
-
-.. code-block:: python
-
-  TestReport(name='MyPlan')
-    TestGroupReport(name='A', category='Multitest')
-      TestGroupReport(name='A-1', category='TestSuite')
-        TestCaseReport(name='test_method_a_1_x')
-        TestCaseReport(name='test_method_a_1_y')
-        TestGroupReport(name='test_method_a_1_z', category='parametrization')
-          TestCaseReport(name='test_method_a_1_z_1')
-          TestCaseReport(name='test_method_a_1_z_2')
-          TestCaseReport(name='test_method_a_1_z_3')
-      TestGroupReport(name='A-2', category='TestSuite')
-        TestCaseReport(name='test_method_a_2_x')
-    TestGroupReport(name='B', category='MultiTest')
-      TestGroupReport(name='B-1', category='TestSuite')
-        TestCaseReport(name='test_method_b_1_x')
-    TestGroupReport(name='C', category='GTest')
-      TestCaseReport(name='<first test of Gtest>') -> can only be retrieved
-                                                      after GTest is run
-      TestCaseReport(name='<second test of Gtest>') -> can only be retrieved
-                                                       after GTest is run
-    ...
 """
 import copy
 import getpass
@@ -52,7 +10,7 @@ import platform
 import sys
 import traceback
 from collections import Counter
-from typing import Callable, Optional
+from typing import Callable, Optional, Dict
 
 from typing_extensions import Self
 
@@ -326,7 +284,18 @@ class BaseReportGroup(ReportGroup):
             entry.runtime_status = new_status
         self._runtime_status = new_status
 
-    def set_runtime_status_filtered(self, new_status, entries):
+    def set_runtime_status_filtered(
+        self,
+        new_status: str,
+        entries: Dict,
+    ) -> None:
+        """
+        Alternative setter for the runtime status of an entry. Propagates only
+          to the specified entries.
+
+        :param new_status: new runtime status to be set
+        :param entries: tree-like structure of entries names
+        """
         for entry in self:
             if entry.name in entries.keys():
                 if isinstance(entry, TestCaseReport):

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -326,6 +326,17 @@ class BaseReportGroup(ReportGroup):
             entry.runtime_status = new_status
         self._runtime_status = new_status
 
+    def set_runtime_status_filtered(self, new_status, entries):
+        for entry in self:
+            if entry.name in entries.keys():
+                if isinstance(entry, TestCaseReport):
+                    entry.runtime_status = new_status
+                else:
+                    entry.set_runtime_status_filtered(
+                        new_status, entries[entry.name]
+                    )
+        self._runtime_status = new_status
+
     def merge_children(self, report, strict=True):
         """
         For report groups, we call `merge` on each child report
@@ -935,17 +946,6 @@ class TestCaseReport(Report):
             self._status = Status.UNKNOWN
         if new_status == RuntimeStatus.FINISHED:
             self._status = Status.PASSED  # passed if case report has no entry
-
-    def set_runtime_status_filtered(self, new_status, entries):
-        for entry in self:
-            if entry.name in entries.keys():
-                if isinstance(entry, TestCaseReport):
-                    entry.runtime_status = new_status
-                else:
-                    entry.set_runtime_status_filtered(
-                        new_status, entries[entry.name]
-                    )
-        self._runtime_status = new_status
 
     def _assertions_status(self):
         for entry in self:

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -270,7 +270,11 @@ class TestRunnerIHandler(entity.Entity):
             )
         else:
             self.logger.debug('Run test ["%s"]', test_uid)
-            self._update_reports(self.test(test_uid).run_testcases_iter())
+            self._update_reports(
+                self.test(test_uid).run_testcases_iter(
+                    shallow_report=shallow_report
+                )
+            )
 
     def run_test_suite(
         self, test_uid, suite_uid, shallow_report=None, await_results=True
@@ -312,7 +316,7 @@ class TestRunnerIHandler(entity.Entity):
             self.logger.debug('Run suite ["%s" / "%s"]', test_uid, suite_uid)
             self._update_reports(
                 self.test(test_uid).run_testcases_iter(
-                    testsuite_pattern=suite_uid
+                    testsuite_pattern=suite_uid, shallow_report=shallow_report
                 )
             )
 
@@ -368,7 +372,9 @@ class TestRunnerIHandler(entity.Entity):
             )
             self._update_reports(
                 self.test(test_uid).run_testcases_iter(
-                    testsuite_pattern=suite_uid, testcase_pattern=case_uid
+                    testsuite_pattern=suite_uid,
+                    testcase_pattern=case_uid,
+                    shallow_report=shallow_report,
                 )
             )
 
@@ -428,7 +434,9 @@ class TestRunnerIHandler(entity.Entity):
             )
             self._update_reports(
                 self.test(test_uid).run_testcases_iter(
-                    testsuite_pattern=suite_uid, testcase_pattern=param_uid
+                    testsuite_pattern=suite_uid,
+                    testcase_pattern=param_uid,
+                    shallow_report=shallow_report,
                 )
             )
 

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -1,26 +1,27 @@
 """
 Interactive handler for TestRunner runnable class.
 """
-
-import os
-import re
 import numbers
+import re
 import threading
 from concurrent import futures
+from typing import Union, Awaitable, Dict, Optional
 
-from testplan.common import entity
-from testplan.common import config
-from testplan.common.utils import networking
+from testplan.common import config, entity
 from testplan.common.report import Report
+from testplan.common.utils import networking
 
-from testplan.runnable.interactive import http
-from testplan.runnable.interactive import reloader
-from testplan.runnable.interactive import resource_loader
+from testplan.runnable.interactive import http, reloader, resource_loader
 
-from testplan.report import TestReport, TestGroupReport, Status, RuntimeStatus
+from testplan.report import (
+    TestReport,
+    TestGroupReport,
+    Status,
+    RuntimeStatus,
+)
 
 
-def _exclude_assertions_filter(obj):
+def _exclude_assertions_filter(obj: object) -> bool:
     try:
         return obj["meta_type"] not in ("entry", "assertion")
     except Exception:
@@ -225,9 +226,11 @@ class TestRunnerIHandler(entity.Entity):
             # After reset the runtime_status will be 'READY'
             self._update_reports([(self.test(test_uid).dry_run().report, [])])
 
-    def run_all_tests(self, await_results=True):
+    def run_all_tests(
+        self, await_results: bool = True
+    ) -> Union[TestReport, Awaitable]:
         """
-        Run all tests.
+        Runs all tests.
 
         :param await_results: Whether to block until tests are finished,
             defaults to True.
@@ -243,11 +246,17 @@ class TestRunnerIHandler(entity.Entity):
         for test_uid in self.all_tests():
             self.run_test(test_uid)
 
-    def run_test(self, test_uid, shallow_report=None, await_results=True):
+    def run_test(
+        self,
+        test_uid: str,
+        shallow_report: Optional[Dict] = None,
+        await_results: bool = True,
+    ) -> Union[TestReport, Awaitable]:
         """
         Run a single Test instance.
 
         :param test_uid: UID of test to run.
+        :param shallow_report: shallow report entry, optional
         :param await_results: Whether to block until the test is finished,
             defaults to True.
         :return: If await_results is True, returns a test report.
@@ -277,13 +286,18 @@ class TestRunnerIHandler(entity.Entity):
             )
 
     def run_test_suite(
-        self, test_uid, suite_uid, shallow_report=None, await_results=True
-    ):
+        self,
+        test_uid: str,
+        suite_uid: str,
+        shallow_report: Optional[Dict] = None,
+        await_results: bool = True,
+    ) -> Union[TestReport, Awaitable]:
         """
         Run a single test suite.
 
         :param test_uid: UID of the test that owns the suite.
         :param suite_uid: UID of the suite to run.
+        :param shallow_report: shallow report entry, optional
         :param await_results: Whether to block until the suite is finished,
             defaults to True.
         :return: If await_results is True, returns a testsuite report.
@@ -322,18 +336,19 @@ class TestRunnerIHandler(entity.Entity):
 
     def run_test_case(
         self,
-        test_uid,
-        suite_uid,
-        case_uid,
-        shallow_report=None,
-        await_results=True,
-    ):
+        test_uid: str,
+        suite_uid: str,
+        case_uid: str,
+        shallow_report: Optional[Dict] = None,
+        await_results: bool = True,
+    ) -> Union[TestReport, Awaitable]:
         """
         Run a single testcase.
 
         :param test_uid: UID of the test that owns the testcase.
         :param suite_uid: UID of the suite that owns the testcase.
         :param case_uid: UID of the testcase to run.
+        :param shallow_report: shallow report entry, optional
         :param await_results: Whether to block until the testcase is finished,
             defaults to True.
         :return: If await_results is True, returns a testcase report.
@@ -380,12 +395,12 @@ class TestRunnerIHandler(entity.Entity):
 
     def run_test_case_param(
         self,
-        test_uid,
-        suite_uid,
-        case_uid,
-        param_uid,
-        shallow_report=None,
-        await_results=True,
+        test_uid: str,
+        suite_uid: str,
+        case_uid: str,
+        param_uid: str,
+        shallow_report: Optional[Dict] = None,
+        await_results: bool = True,
     ):
         """
         Run a single parametrization of a testcase.
@@ -394,6 +409,7 @@ class TestRunnerIHandler(entity.Entity):
         :param suite_uid: UID of the suite that owns the testcase.
         :param case_uid: UID of the testcase to run.
         :param param_uid: UID of the parametrization to run.
+        :param shallow_report: shallow report entry, optional
         :param await_results: Whether to block until the testcase is finished,
             defaults to True.
         :return: If await_results is True, returns a testcase report.
@@ -918,7 +934,7 @@ class TestRunnerIHandler(entity.Entity):
             test_report.logs.clear()
             test_report.status_override = None
 
-    def _run_async(self, func, *args, **kwargs):
+    def _run_async(self, func, *args, **kwargs) -> Awaitable:
         """
         Schedule a function to run asynchronously in our task pool. We add a
         callback to ensure that all async exceptions are logged, for debugging

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -243,7 +243,7 @@ class TestRunnerIHandler(entity.Entity):
         for test_uid in self.all_tests():
             self.run_test(test_uid)
 
-    def run_test(self, test_uid, await_results=True):
+    def run_test(self, test_uid, shallow_report=None, await_results=True):
         """
         Run a single Test instance.
 
@@ -255,7 +255,9 @@ class TestRunnerIHandler(entity.Entity):
             ready.
         """
         if not await_results:
-            return self._run_async(self.run_test, test_uid)
+            return self._run_async(
+                self.run_test, test_uid, shallow_report=shallow_report
+            )
 
         try:
             self._auto_start_environment(test_uid)
@@ -270,7 +272,9 @@ class TestRunnerIHandler(entity.Entity):
             self.logger.debug('Run test ["%s"]', test_uid)
             self._update_reports(self.test(test_uid).run_testcases_iter())
 
-    def run_test_suite(self, test_uid, suite_uid, await_results=True):
+    def run_test_suite(
+        self, test_uid, suite_uid, shallow_report=None, await_results=True
+    ):
         """
         Run a single test suite.
 
@@ -283,7 +287,12 @@ class TestRunnerIHandler(entity.Entity):
             when ready.
         """
         if not await_results:
-            return self._run_async(self.run_test_suite, test_uid, suite_uid)
+            return self._run_async(
+                self.run_test_suite,
+                test_uid,
+                suite_uid,
+                shallow_report=shallow_report,
+            )
 
         try:
             self._auto_start_environment(test_uid)
@@ -307,7 +316,14 @@ class TestRunnerIHandler(entity.Entity):
                 )
             )
 
-    def run_test_case(self, test_uid, suite_uid, case_uid, await_results=True):
+    def run_test_case(
+        self,
+        test_uid,
+        suite_uid,
+        case_uid,
+        shallow_report=None,
+        await_results=True,
+    ):
         """
         Run a single testcase.
 
@@ -326,6 +342,7 @@ class TestRunnerIHandler(entity.Entity):
                 test_uid,
                 suite_uid,
                 case_uid,
+                shallow_report=shallow_report,
             )
 
         try:
@@ -361,6 +378,7 @@ class TestRunnerIHandler(entity.Entity):
         suite_uid,
         case_uid,
         param_uid,
+        shallow_report=None,
         await_results=True,
     ):
         """
@@ -383,6 +401,7 @@ class TestRunnerIHandler(entity.Entity):
                 suite_uid,
                 case_uid,
                 param_uid,
+                shallow_report=shallow_report,
             )
 
         try:

--- a/testplan/runnable/interactive/http.py
+++ b/testplan/runnable/interactive/http.py
@@ -578,7 +578,6 @@ def generate_interactive_api(ihandler):
             """Update the state of a specific parametrized testcase."""
             shallow_report = flask.request.json
             _validate_json_body(shallow_report)
-            filtered = "entries" in shallow_report
 
             with ihandler.report_mutex:
                 try:
@@ -611,30 +610,14 @@ def generate_interactive_api(ihandler):
                         case_uid=case_uid,
                         param_uid=param_uid,
                     )
-                    if filtered:
-                        entries = _extract_entries(shallow_report)
-                        current_case.set_runtime_status_filtered(
-                            RuntimeStatus.WAITING,
-                            entries,
-                        )
-                        # NOTE: placeholder for identical behavior in dev stage
-                        ihandler.run_test_case_param(
-                            test_uid,
-                            suite_uid,
-                            case_uid,
-                            param_uid,
-                            shallow_report=shallow_report,
-                            await_results=False,
-                        )
-                    else:
-                        current_case.runtime_status = RuntimeStatus.WAITING
-                        ihandler.run_test_case_param(
-                            test_uid,
-                            suite_uid,
-                            case_uid,
-                            param_uid,
-                            await_results=False,
-                        )
+                    current_case.runtime_status = RuntimeStatus.WAITING
+                    ihandler.run_test_case_param(
+                        test_uid,
+                        suite_uid,
+                        case_uid,
+                        param_uid,
+                        await_results=False,
+                    )
 
                 return _serialize_report_entry(current_case)
 

--- a/testplan/runnable/interactive/http.py
+++ b/testplan/runnable/interactive/http.py
@@ -276,6 +276,12 @@ def generate_interactive_api(ihandler):
                     _check_execution_order(ihandler.report, test_uid=test_uid)
                     if filtered:
                         entries = _extract_entries(json_body)
+                        current_test.set_runtime_status_filtered(
+                            RuntimeStatus.WAITING,
+                            entries,
+                        )
+                        ihandler.run_test(test_uid, await_results=False)
+                        # NOTE: placeholder for identical behavior in dev stage
                     else:
                         current_test.runtime_status = RuntimeStatus.WAITING
                         ihandler.run_test(test_uid, await_results=False)
@@ -392,6 +398,14 @@ def generate_interactive_api(ihandler):
                     )
                     if filtered:
                         entries = _extract_entries(json_body)
+                        current_suite.set_runtime_status_filtered(
+                            RuntimeStatus.WAITING,
+                            entries,
+                        )
+                        # NOTE: placeholder for identical behavior in dev stage
+                        ihandler.run_test_suite(
+                            test_uid, suite_uid, await_results=False
+                        )
                     else:
                         current_suite.runtime_status = RuntimeStatus.WAITING
                         ihandler.run_test_suite(
@@ -482,6 +496,14 @@ def generate_interactive_api(ihandler):
                     )
                     if filtered:
                         entries = _extract_entries(json_body)
+                        current_case.set_runtime_status_filtered(
+                            RuntimeStatus.WAITING,
+                            entries,
+                        )
+                        # NOTE: placeholder for identical behavior in dev stage
+                        ihandler.run_test_case(
+                            test_uid, suite_uid, case_uid, await_results=False
+                        )
                     else:
                         current_case.runtime_status = RuntimeStatus.WAITING
                         ihandler.run_test_case(
@@ -577,6 +599,18 @@ def generate_interactive_api(ihandler):
                     )
                     if filtered:
                         entries = _extract_entries(json_body)
+                        current_case.set_runtime_status_filtered(
+                            RuntimeStatus.WAITING,
+                            entries,
+                        )
+                        # NOTE: placeholder for identical behavior in dev stage
+                        ihandler.run_test_case_param(
+                            test_uid,
+                            suite_uid,
+                            case_uid,
+                            param_uid,
+                            await_results=False,
+                        )
                     else:
                         current_case.runtime_status = RuntimeStatus.WAITING
                         ihandler.run_test_case_param(

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import sys
 import warnings
-from typing import List, Optional
+from typing import List, Optional, Dict, Generator
 
 from schema import And, Or, Use
 
@@ -18,7 +18,6 @@ from testplan.common.entity import (
 )
 from testplan.common.remote.remote_driver import RemoteDriver
 from testplan.common.utils import strings
-from testplan.common.utils.logger import TESTPLAN_LOGGER
 from testplan.common.utils.process import (
     enforce_timeout,
     kill_process,
@@ -898,7 +897,12 @@ class ProcessRunnerTest(Test):
 
         return result
 
-    def run_testcases_iter(self, testsuite_pattern="*", testcase_pattern="*"):
+    def run_testcases_iter(
+        self,
+        testsuite_pattern: str = "*",
+        testcase_pattern: str = "*",
+        shallow_report: Dict = None,
+    ) -> Generator:
         """
         Runs testcases as defined by the given filter patterns and yields
         testcase reports. A single testcase report is made for general checks
@@ -912,13 +916,10 @@ class ProcessRunnerTest(Test):
         reports will not be generated until all testcases have finished
         running.
 
-        :param testsuite_pattern: Filter pattern for testsuite level.
-        :type testsuite_pattern: ``str``
-        :param testcase_pattern: Filter pattern for testcase level.
-        :type testsuite_pattern: ``str``
-        :yield: generate tuples containing testcase reports and a list of the
-            UIDs required to merge this into the main report tree, starting
-            with the UID of this test.
+        :param testsuite_pattern: pattern to match for testsuite names
+        :param testcase_pattern: pattern to match for testcase names
+        :param shallow_report: shallow report entry
+        :return: generator yielding testcase reports and UIDs for merge step
         """
         self.make_runpath_dirs()
 

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -451,7 +451,12 @@ class MultiTest(testing_base.Test):
 
         return report
 
-    def run_testcases_iter(self, testsuite_pattern="*", testcase_pattern="*"):
+    def run_testcases_iter(
+        self,
+        testsuite_pattern="*",
+        testcase_pattern="*",
+        shallow_report=None,
+    ):
         """Run all testcases and yield testcase reports."""
         test_filter = filtering.Pattern(
             pattern="*:{}:{}".format(testsuite_pattern, testcase_pattern),

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -522,7 +522,7 @@ class MultiTest(testing_base.Test):
         :param testsuite_pattern: pattern to match for testsuite names
         :param testcase_pattern: pattern to match for testcase names
         :param shallow_report: shallow report entry
-        :return:
+        :return: generator yielding testcase reports and UIDs for merge steps
         """
         if shallow_report is None:
             test_filter = filtering.Pattern(

--- a/testplan/testing/py_test.py
+++ b/testplan/testing/py_test.py
@@ -1,11 +1,10 @@
 """PyTest test runner."""
 import collections
-import copy
 import inspect
 import os
 import re
-import sys
 import traceback
+from typing import Dict, Generator
 
 import pytest
 from schema import Or
@@ -190,17 +189,19 @@ class PyTest(testing.Test):
 
         return self.result
 
-    def run_testcases_iter(self, testsuite_pattern="*", testcase_pattern="*"):
+    def run_testcases_iter(
+        self,
+        testsuite_pattern: str = "*",
+        testcase_pattern: str = "*",
+        shallow_report: Dict = None,
+    ) -> Generator:
         """
-        Run testcases matching the given patterns and yield testcase reports.
+        Run all testcases and yield testcase reports.
 
-        :param testsuite_pattern: Filter pattern for testsuite level.
-        :type testsuite_pattern: ``str``
-        :param testcase_pattern: Filter pattern for testcase level.
-        :type testsuite_pattern: ``str``
-        :yield: generate tuples containing testcase reports and a list of the
-            UIDs required to merge this into the main report tree, starting
-            with the UID of this test.
+        :param testsuite_pattern: pattern to match for testsuite names
+        :param testcase_pattern: pattern to match for testcase names
+        :param shallow_report: shallow report entry
+        :return: generator yielding testcase reports and UIDs for merge step
         """
         if not self._nodeids:
             # Need to collect the tests so we know the nodeids for each

--- a/testplan/testing/pyunit.py
+++ b/testplan/testing/pyunit.py
@@ -1,6 +1,7 @@
 """PyUnit test runner."""
 
 import unittest
+from typing import Generator, Dict
 
 from testplan.testing import base as testing
 from testplan.testing.multitest.entries import assertions
@@ -89,8 +90,20 @@ class PyUnit(testing.Test):
 
         return self.result
 
-    def run_testcases_iter(self, testsuite_pattern="*", testcase_pattern="*"):
-        """Run testcases and yield testcase report and parent UIDs."""
+    def run_testcases_iter(
+        self,
+        testsuite_pattern: str = "*",
+        testcase_pattern: str = "*",
+        shallow_report: Dict = None,
+    ) -> Generator:
+        """
+        Run all testcases and yield testcase reports.
+
+        :param testsuite_pattern: pattern to match for testsuite names
+        :param testcase_pattern: pattern to match for testcase names
+        :param shallow_report: shallow report entry
+        :return: generator yielding testcase reports and UIDs for merge step
+        """
         if testsuite_pattern == "*":
             yield {"runtime_status": RuntimeStatus.RUNNING}, [self.uid()]
             for testsuite_report in self._run_tests():

--- a/testplan/web_ui/testing/src/Report/InteractiveReport.js
+++ b/testplan/web_ui/testing/src/Report/InteractiveReport.js
@@ -453,12 +453,41 @@ class InteractiveReport extends BaseReport {
   }
 
   /**
+   * Prunes the report entry recursively so that only name, category, and
+   * entries attributes are preserved.
+   */
+  pruneReportEntry(reportEntry) {
+    const {name, category, entries, ..._} = reportEntry;
+    const pruneEntry = {
+      name: name,
+      category: category,
+    };
+
+    if ((entries.length !== 0) && (category !== "testcase")) {
+      pruneEntry.entries = entries.map(
+        (entry) => this.pruneReportEntry(entry)
+      );
+    };
+
+    return pruneEntry;
+  }
+
+  /**
    * Shallow copy of a report entry, by replacing the "entries" attribute
-   * with an array of entry UIDs.
+   * with an array of entry UIDs if not filter is present.
+   * In case there is a non-empty filter text, the entries attribute is pruned.
    */
   shallowReportEntry(reportEntry) {
     const { entries, ...shallowEntry } = reportEntry;
     shallowEntry.entry_uids = entries.map((entry) => entry.uid);
+
+    // the filter text is either "null" or an empty string, use truthy-falsy
+    if (this.state.filteredReport.filter.text) {
+      shallowEntry.entries = entries.map(
+        (entry) => this.pruneReportEntry(entry)
+      );
+    };
+
     return shallowEntry;
   }
 

--- a/tests/functional/testplan/runnable/interactive/test_api.py
+++ b/tests/functional/testplan/runnable/interactive/test_api.py
@@ -886,6 +886,8 @@ def test_run_testcase(plan):
         # Trigger testcase to run by updating the report status to RUNNING
         # and PUTting back the data.
         testcase_json["runtime_status"] = RuntimeStatus.RUNNING
+        if "entries" in testcase_json:
+            del testcase_json["entries"]
         rsp = requests.put(testcase_url, json=testcase_json)
         assert rsp.status_code == 200
         updated_json = rsp.json()
@@ -1095,6 +1097,8 @@ def test_run_testcases_sequentially(plan3):
         assert rsp.status_code == 200
         testcase_json = rsp.json()
         testcase_json["runtime_status"] = RuntimeStatus.RUNNING
+        if "entries" in testcase_json:
+            del testcase_json["entries"]
         rsp = requests.put(testcase_url, json=testcase_json)
         assert rsp.status_code == 200
         updated_json = rsp.json()
@@ -1138,6 +1142,8 @@ def test_run_testcases_sequentially(plan3):
         assert rsp.status_code == 200
         testcase_json = rsp.json()
         testcase_json["runtime_status"] = RuntimeStatus.RUNNING
+        if "entries" in testcase_json:
+            del testcase_json["entries"]
         rsp = requests.put(testcase_url, json=testcase_json)
         assert rsp.status_code == 200
         updated_json = rsp.json()

--- a/tests/unit/testplan/runnable/interactive/test_api.py
+++ b/tests/unit/testplan/runnable/interactive/test_api.py
@@ -268,19 +268,6 @@ class TestSingleTest:
             "/api/v1/interactive/report/tests/MTest1", json=json_test
         )
         assert rsp.status_code == 200
-        json_rsp = rsp.get_json()
-        assert json_rsp["runtime_status"] == report.RuntimeStatus.WAITING
-        compare_json(
-            json_rsp,
-            json_test,
-            ignored_keys=[
-                "runtime_status",
-                "entries",
-                "status_reason",
-                "type",
-            ],
-        )
-
         ihandler.run_test.assert_called_once_with(
             "MTest1", shallow_report=json_test, await_results=False
         )
@@ -438,19 +425,6 @@ class TestSingleSuite:
             json=suite_json,
         )
         assert rsp.status_code == 200
-        json_rsp = rsp.get_json()
-        assert json_rsp["runtime_status"] == report.RuntimeStatus.WAITING
-        compare_json(
-            json_rsp,
-            suite_json,
-            ignored_keys=[
-                "runtime_status",
-                "type",
-                "status_reason",
-                "entries",
-            ],
-        )
-
         ihandler.run_test_suite.assert_called_once_with(
             "MTest1",
             "MT1Suite1",
@@ -582,19 +556,6 @@ class TestSingleTestcase:
             json=testcase_json,
         )
         assert rsp.status_code == 200
-        json_rsp = rsp.get_json()
-        assert json_rsp["runtime_status"] == report.RuntimeStatus.WAITING
-        compare_json(
-            json_rsp,
-            testcase_json,
-            ignored_keys=[
-                "runtime_status",
-                "entries",
-                "status_reason",
-                "type",
-            ],
-        )
-
         ihandler.run_test_case.assert_called_once_with(
             "MTest1",
             "MT1Suite1",

--- a/tests/unit/testplan/runnable/interactive/test_api.py
+++ b/tests/unit/testplan/runnable/interactive/test_api.py
@@ -491,6 +491,8 @@ class TestSingleTestcase:
             raise TypeError("Unexpected report type")
 
         testcase_json["runtime_status"] = report.RuntimeStatus.RUNNING
+        if "entries" in testcase_json:
+            del testcase_json["entries"]
         rsp = client.put(
             "/api/v1/interactive/report/tests/MTest1/suites/MT1Suite1/"
             "testcases/{}".format(testcase_uid),
@@ -587,6 +589,8 @@ class TestParametrizedTestCase:
             "MT1S1TC2_0"
         ]
         testcase_json = report_entry.serialize()
+        if "entries" in testcase_json:
+            del testcase_json["entries"]
 
         testcase_json["runtime_status"] = report.RuntimeStatus.RUNNING
         rsp = client.put(

--- a/tests/unit/testplan/runnable/interactive/test_api.py
+++ b/tests/unit/testplan/runnable/interactive/test_api.py
@@ -255,7 +255,7 @@ class TestSingleTest:
         compare_json(json_rsp, json_test, ignored_keys=["runtime_status"])
 
         ihandler.run_test.assert_called_once_with(
-            "MTest1", await_results=False
+            "MTest1", shallow_report=None, await_results=False
         )
 
     def test_put_reset(self, api_env):
@@ -397,7 +397,7 @@ class TestSingleSuite:
         compare_json(json_rsp, suite_json, ignored_keys=["runtime_status"])
 
         ihandler.run_test_suite.assert_called_once_with(
-            "MTest1", "MT1Suite1", await_results=False
+            "MTest1", "MT1Suite1", shallow_report=None, await_results=False
         )
 
     def test_put_validation(self, api_env):
@@ -504,7 +504,11 @@ class TestSingleTestcase:
         compare_json(json_rsp, testcase_json, ignored_keys=["runtime_status"])
 
         ihandler.run_test_case.assert_called_once_with(
-            "MTest1", "MT1Suite1", testcase_uid, await_results=False
+            "MTest1",
+            "MT1Suite1",
+            testcase_uid,
+            shallow_report=None,
+            await_results=False,
         )
 
     def test_put_validation(self, api_env):

--- a/tests/unit/testplan/testing/multitest/test_multitest.py
+++ b/tests/unit/testplan/testing/multitest/test_multitest.py
@@ -19,6 +19,18 @@ MTEST_DEFAULT_PARAMS = {
 }
 
 
+@pytest.fixture
+def dummy_mtest():
+    mtest = multitest.MultiTest(
+        name="MTest",
+        suites=[Suite()],
+        thread_pool_size=3,
+        **MTEST_DEFAULT_PARAMS,
+    )
+    mtest.dry_run()
+    return mtest
+
+
 def test_iterable_suites():
     @multitest.testsuite
     class TestSuite:
@@ -360,17 +372,9 @@ def test_run_tests_parallel():
     _check_parallel_param(suite_report["parametrized"])
 
 
-def test_run_testcases_iter():
+def test_run_testcases_iter(dummy_mtest):
     """Test running tests iteratively."""
-    mtest = multitest.MultiTest(
-        name="MTest",
-        suites=[Suite()],
-        thread_pool_size=3,
-        **MTEST_DEFAULT_PARAMS,
-    )
-    mtest.dry_run()
-
-    results = list(mtest.run_testcases_iter())
+    results = list(dummy_mtest.run_testcases_iter())
     assert len(results) == 8
 
     attributes, parent_uids = results[0]
@@ -395,6 +399,48 @@ def test_run_testcases_iter():
         assert parent_uids == ["MTest", "Suite", "parametrized"]
         assert testcase_report.runtime_status == report.RuntimeStatus.FINISHED
         _check_param_testcase_report(testcase_report, i)
+
+
+def test_run_testcases_iter_filtered(dummy_mtest):
+    """Test running tests iteratively."""
+    """Test running tests iteratively."""
+    shallow_report = dummy_mtest.report.shallow_serialize()
+    shallow_report["entries"] = [
+        {
+            "name": "Suite",
+            "category": "testsuite",
+            "entries": [
+                {
+                    "name": "parametrized",
+                    "category": "parametrization",
+                    "entries": [
+                        {
+                            "name": "parametrized <val=1>",
+                            "category": "testcase",
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+    results = list(
+        dummy_mtest.run_testcases_iter(shallow_report=shallow_report)
+    )
+    assert len(results) == 2
+
+    attributes, parent_uids = results[0]
+    assert parent_uids == [
+        "MTest",
+        "Suite",
+        "parametrized",
+        "parametrized__val_1",
+    ]
+    assert attributes["runtime_status"] == report.RuntimeStatus.RUNNING
+
+    testcase_report, parent_uids = results[1]
+    assert parent_uids == ["MTest", "Suite", "parametrized"]
+    assert testcase_report.runtime_status == report.RuntimeStatus.FINISHED
+    _check_param_testcase_report(testcase_report, 0)
 
 
 def _check_parallel_testcase(testcase_report, i):


### PR DESCRIPTION
## Bug / Requirement Description
Interactive UI mode now support filters but does not reflect it when running report entries.

## Solution description
We modified the shallow report entry concept to preserve a pruned tree of entries with name, category, and nested entries.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [x] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
