### PR TITLE
better way to skip kafka on windows

### DIFF
--- a/tests/helpers/pytest_test_filters.py
+++ b/tests/helpers/pytest_test_filters.py
@@ -4,3 +4,13 @@ from functools import partial
 import pytest
 
 skip_on_windows = partial(pytest.mark.skipif, sys.platform == "win32")
+
+
+def _skip_module_on(reason: str, predicate: bool):
+    if predicate:
+        pytest.skip(reason, allow_module_level=True)
+
+
+skip_module_on_windows = partial(
+    _skip_module_on, predicate=sys.platform == "win32"
+)

--- a/tests/unit/testplan/testing/multitest/driver/mykafka/test_kafka.py
+++ b/tests/unit/testplan/testing/multitest/driver/mykafka/test_kafka.py
@@ -1,5 +1,10 @@
 """Unit tests for the Zookeeper drivers."""
 
+from pytest_test_filters import skip_module_on_windows
+
+skip_module_on_windows("Kafka not available on windows")
+
+
 import os
 import uuid
 import pytest


### PR DESCRIPTION
## Bug / Requirement Description
The current way of kafka test skip is not explicit

## Solution description
Make it explicit why we skip the test

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
