### PR TITLE
Added regular expression support to FilterBox

### DIFF
--- a/doc/newsfragments/2576_new.regexp_filterbox.rst
+++ b/doc/newsfragments/2576_new.regexp_filterbox.rst
@@ -1,0 +1,1 @@
+The search bar a.k.a filter box now support regular expressions both in interactive and in batch modes. See UI tooltip for usage.

--- a/testplan/web_ui/testing/src/Parser/SearchFieldParser.pegjs
+++ b/testplan/web_ui/testing/src/Parser/SearchFieldParser.pegjs
@@ -32,11 +32,12 @@ SENTENCE = word:WORD words:WWORD* {return word + words.join("")}
 WWORD = ws:_ word:WORD {return ws+word}
 WORD = !KEYWORDS str:[^ \t\n\r\"(){}]+ {return str.join("")}
 
-KEYWORDS = _ kw:(TEST_W/SUITE_W/CASE_W/TAG_W) ":" {return kw}
+KEYWORDS = _ kw:(TEST_W/SUITE_W/CASE_W/TAG_W/RE_W) ":" {return kw}
 TEST_W = ("multitest"/"mt") {return "test"}
 SUITE_W = ("testsuite"/"s") {return "suite"}
 CASE_W = ("testcase"/"c") {return "case" }
 TAG_W = "tag"
+RE_W = ("regexp"/"re") {return "regexp"}
 
 DOUBLE_QUOTE = "\""
 

--- a/testplan/web_ui/testing/src/Report/reportFilter.js
+++ b/testplan/web_ui/testing/src/Report/reportFilter.js
@@ -23,6 +23,19 @@ const tag_filter = (entry, filter) => {
   return _(filter).every((tag) => tags.includes(tag.toLowerCase()));
 };
 
+const regexp_filter = (entry, filter) => {
+  if (filter === "") {
+    return true;
+  }
+
+  const regexp = new RegExp(filter);
+
+  const names = (entry.name_type_index)
+    .map((name_type) => name_type.split("|")[0]);
+
+  return names.some((name) => name.match(regexp));
+};
+
 const free_text_filter = (entry, filter) => {
   if (filter === "") return true;
 
@@ -69,6 +82,7 @@ const or_filter = (entry, filters) => {
 
 const filter_processors = {
   "free-text": free_text_filter,
+  regexp: regexp_filter,
   tag: tag_filter,
   test: _.partial(name_filter, "multitest"),
   suite: _.partial(name_filter, "testsuite"),

--- a/testplan/web_ui/testing/src/Toolbar/FilterBox.js
+++ b/testplan/web_ui/testing/src/Toolbar/FilterBox.js
@@ -31,8 +31,10 @@ class FilterBox extends Component {
       <>
         <p>
           Just start typing in the search bar. The test items are filtered
-          automatically. The current selection if available in the serach are
-          maintained. All the search are <b>case insensitive</b>.
+          automatically. The current selection if available in the search are
+          maintained. All searches are <b>case insensitive</b>, except
+          for the regular expression search where case sensitivity is driven
+          by the expression itself.
         </p>
         <p>
           You can search by <b>free text</b>, then each word will be matched
@@ -134,6 +136,15 @@ class FilterBox extends Component {
 
   operatorsTable() {
     const descriptions = [
+      [
+        <>
+          Specify a regular expression
+          <br />
+          <small>(search for any matches)</small>
+        </>,
+        ["regexp", "r"],
+        ["regexp:^addition.*_[0-9]+$", "r:^addition.*_[0-9]+$"],
+      ],
       [
         <>
           Specify a multitest

--- a/testplan/web_ui/testing/src/Toolbar/__tests__/__snapshots__/FilterBox.test.js.snap
+++ b/testplan/web_ui/testing/src/Toolbar/__tests__/__snapshots__/FilterBox.test.js.snap
@@ -120,11 +120,11 @@ exports[`FilterBox shallow renders the correct HTML structure 1`] = `
         tag="div"
       >
         <p>
-          Just start typing in the search bar. The test items are filtered automatically. The current selection if available in the serach are maintained. All the search are 
+          Just start typing in the search bar. The test items are filtered automatically. The current selection if available in the search are maintained. All searches are 
           <b>
             case insensitive
           </b>
-          .
+          , except for the regular expression search where case sensitivity is driven by the expression itself.
         </p>
         <p>
           You can search by 
@@ -159,6 +159,67 @@ exports[`FilterBox shallow renders the correct HTML structure 1`] = `
           <tbody>
             <tr
               key="0"
+            >
+              <td
+                style={
+                  Object {
+                    "maxWidth": "250px",
+                  }
+                }
+              >
+                Specify a regular expression
+                <br />
+                <small>
+                  (search for any matches)
+                </small>
+              </td>
+              <td>
+                <p>
+                  <span
+                    key="0"
+                  >
+                    <code>
+                      regexp
+                    </code>
+                    <br />
+                  </span>
+                  <span
+                    key="1"
+                  >
+                    <code>
+                      r
+                    </code>
+                    <br />
+                  </span>
+                </p>
+                <p>
+                  <span
+                    key="0"
+                  >
+                    <b>
+                      Example: 
+                    </b>
+                    <code>
+                      regexp:^addition.*_[0-9]+$
+                    </code>
+                    <br />
+                  </span>
+                  <span
+                    key="1"
+                  >
+                    <b>
+                      Example: 
+                    </b>
+                    <code>
+                      r:^addition.*_[0-9]+$
+                    </code>
+                    <br />
+                  </span>
+                </p>
+              </td>
+            </tr>
+            <tr
+              key="1"
             >
               <td
                 style={
@@ -219,7 +280,7 @@ exports[`FilterBox shallow renders the correct HTML structure 1`] = `
               </td>
             </tr>
             <tr
-              key="1"
+              key="2"
             >
               <td
                 style={
@@ -280,7 +341,7 @@ exports[`FilterBox shallow renders the correct HTML structure 1`] = `
               </td>
             </tr>
             <tr
-              key="2"
+              key="3"
             >
               <td
                 style={
@@ -341,7 +402,7 @@ exports[`FilterBox shallow renders the correct HTML structure 1`] = `
               </td>
             </tr>
             <tr
-              key="3"
+              key="4"
             >
               <td
                 style={
@@ -394,7 +455,7 @@ exports[`FilterBox shallow renders the correct HTML structure 1`] = `
               </td>
             </tr>
             <tr
-              key="4"
+              key="5"
             >
               <td
                 style={
@@ -443,7 +504,7 @@ exports[`FilterBox shallow renders the correct HTML structure 1`] = `
               </td>
             </tr>
             <tr
-              key="5"
+              key="6"
             >
               <td
                 style={
@@ -472,7 +533,7 @@ exports[`FilterBox shallow renders the correct HTML structure 1`] = `
               </td>
             </tr>
             <tr
-              key="6"
+              key="7"
             >
               <td
                 style={
@@ -529,7 +590,7 @@ exports[`FilterBox shallow renders the correct HTML structure 1`] = `
               </td>
             </tr>
             <tr
-              key="7"
+              key="8"
             >
               <td
                 style={


### PR DESCRIPTION
## Bug / Requirement Description
The search bar on the UI does not support fully-fledged regular expressions at the moment.

## Solution description
Added a new keyword pair (regexp/re) to identify regular expressions in the search bar. A new filter processor is added to handle the instantiation of the regular expression object and to check for a match under the entry.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
