### PR TITLE
limit pydantic <2.0 in releaseherald

### DIFF
--- a/releaseherald/requirements.txt
+++ b/releaseherald/requirements.txt
@@ -4,6 +4,6 @@ GitPython
 Jinja2
 toml
 parse
-pydantic
+pydantic<2.0
 pluggy
 typing_extensions

--- a/releaseherald/setup.cfg
+++ b/releaseherald/setup.cfg
@@ -14,7 +14,7 @@ install_requires =
     parse
     toml
     typing_extensions
-    pydantic
+    pydantic<2.0
     pluggy
 
 [options.package_data]


### PR DESCRIPTION
## Bug / Requirement Description
pydantic released 2.0 which having breaking changes 

## Solution description
require pydantic<2.0

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
