### PR TITLE
MultiTest fast fail

### DIFF
--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -1320,6 +1320,10 @@ To enable this feature, instantiate MultiTest with a non-zero ``thread_pool_size
 and define ``execution_group`` for testcases you would like to run in parallel.
 Testcases in the same group will be executed concurrently.
 
+.. warning::
+    When either the `stop_on_error` or `stop_on_failure` parameters are set to
+    `True`, the earliest abort of the execution happens with the next execution group.
+
 .. code-block:: python
 
     @testsuite

--- a/doc/newsfragments/2540_new.stop_on_failure.rst
+++ b/doc/newsfragments/2540_new.stop_on_failure.rst
@@ -1,0 +1,1 @@
+Added `stop_on_failure` as a parameter to :py:class:`MultiTest <testplan.testing.multitest.base.MultiTest>`. Setting it to `True` will cause the entire MultiTest abort execution upon the first testcase failure. Execution groups will wait for the completion of all pending futures. Default value is `False`.


### PR DESCRIPTION
Added fast fail feature to MultiTest. Added associated unit test and newsfragment.

## Bug / Requirement Description
MultiTest lacks an option to abort upon first failed testcase.

## Solution description
Add a similar logic as for stop on error, however, we want to abort the entire MultiTest not just current suite.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
