### PR TITLE
Fix missing __skip__ attribute exception in interactive reload

### DIFF
--- a/doc/newsfragments/2557_changed.skip_if_reload_fix.rst
+++ b/doc/newsfragments/2557_changed.skip_if_reload_fix.rst
@@ -1,0 +1,1 @@
+Fixed the problem where `skip_if` with a `True` predicate would cause interactive mode reloader to raise an exception on missing `__skip__` attribute.

--- a/testplan/testing/multitest/suite.py
+++ b/testplan/testing/multitest/suite.py
@@ -233,6 +233,9 @@ def _gen_skipped_case(skip_reason, orig_case):
     _f.__tags__ = orig_case.__tags__
     _f.__tags_index__ = orig_case.__tags_index__
     _f.__should_skip__ = True
+    # NOTE: interactive reloader will regenerate the skipped testcase
+    #             so it will need the __skip__ attribute.
+    _f.__skip__ = orig_case.__skip__
     _mark_function_as_testcase(_f)
     return _f
 


### PR DESCRIPTION
Updated skipped testcase generator to retain __skip__ attribute. Updated unit test and added newsfragment.

## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
