### PR TITLE
LogMatcher.get_between to support binary

### DIFF
--- a/doc/newsfragments/2637_changed.fix_get_between.rst
+++ b/doc/newsfragments/2637_changed.fix_get_between.rst
@@ -1,1 +1,1 @@
-:py:meth:`~testplan.common.utils.match.LogMatcher.get_between` would raise an exception upon binary configuration of the matcher.
+Fixed an issue where :py:meth:`~testplan.common.utils.match.LogMatcher.get_between` would raise an exception upon binary configuration of the matcher.

--- a/doc/newsfragments/2637_changed.fix_get_between.rst
+++ b/doc/newsfragments/2637_changed.fix_get_between.rst
@@ -1,0 +1,1 @@
+:py:meth:`~testplan.common.utils.match.LogMatcher.get_between` would raise an exception upon binary configuration of the matcher.

--- a/testplan/common/utils/match.py
+++ b/testplan/common/utils/match.py
@@ -398,4 +398,5 @@ class LogMatcher(logger.Loggable):
             while not self.log_stream.reached_position(end_pos):
                 line = log.readline()
                 lines_between.append(line)
-            return "".join(lines_between)
+            separator = b"" if self.binary else ""
+            return separator.join(lines_between)

--- a/tests/unit/testplan/common/utils/test_match.py
+++ b/tests/unit/testplan/common/utils/test_match.py
@@ -10,6 +10,13 @@ from testplan.common.utils import timing
 from testplan.common.utils.match import LogMatcher, match_regexps_in_file
 
 
+def binary_or_string(value, binary):
+    """
+    Utility to reuse b"..." if binary else "..." logic.
+    """
+    return value.encode() if binary else value
+
+
 @pytest.fixture(
     params=[True, False], ids=["With log rotation", "Without log rotation"]
 )
@@ -233,21 +240,22 @@ class TestLogMatcher:
         assert matcher.not_match_between(r"fifth", "start", "end")
         assert not matcher.not_match_between(r"third", "start", "end")
 
-    def test_get_between(self, basic_logfile):
+    @pytest.mark.parametrize("is_binary", [True, False])
+    def test_get_between(self, basic_logfile, is_binary):
         """Does the LogMatcher return the required content between marks."""
-        matcher = LogMatcher(log_path=basic_logfile)
-        matcher.match(regex=re.compile(r"second"))
-        matcher.mark("start")
-        matcher.match(regex=re.compile(r"fourth"))
-        matcher.mark("end")
+        matcher = LogMatcher(log_path=basic_logfile, binary=is_binary)
+        matcher.match(regex=re.compile(binary_or_string("second", is_binary)))
+        matcher.mark(binary_or_string("start", is_binary))
+        matcher.match(regex=re.compile(binary_or_string("fourth", is_binary)))
+        matcher.mark(binary_or_string("end", is_binary))
         content = matcher.get_between()
-        assert content == "first\nsecond\nthird\nfourth\nfifth\n"
-        content = matcher.get_between(None, "end")
-        assert content == "first\nsecond\nthird\nfourth\n"
-        content = matcher.get_between("start", None)
-        assert content == "third\nfourth\nfifth\n"
-        content = matcher.get_between("start", "end")
-        assert content == "third\nfourth\n"
+        assert content == binary_or_string("first\nsecond\nthird\nfourth\nfifth\n", is_binary)
+        content = matcher.get_between(None, binary_or_string("end", is_binary))
+        assert content == binary_or_string("first\nsecond\nthird\nfourth\n", is_binary)
+        content = matcher.get_between(binary_or_string("start", is_binary), None)
+        assert content == binary_or_string("third\nfourth\nfifth\n", is_binary)
+        content = matcher.get_between(binary_or_string("start", is_binary), binary_or_string("end", is_binary))
+        assert content == binary_or_string("third\nfourth\n", is_binary)
 
     def test_match_large_file(self, large_logfile):
         """

--- a/tests/unit/testplan/common/utils/test_match.py
+++ b/tests/unit/testplan/common/utils/test_match.py
@@ -252,14 +252,17 @@ class TestLogMatcher:
             for line in ["first", "second", "third", "fourth", "fifth"]
         ]
 
+        def construct_expected(slice):
+            return newline.join(slice) + newline
+
         content = matcher.get_between()
-        assert content == newline.join(lines) + newline
+        assert content == construct_expected(lines)
         content = matcher.get_between(None, "end")
-        assert content == newline.join(lines[:4]) + newline
+        assert content == construct_expected(lines[:4])
         content = matcher.get_between("start", None)
-        assert content == newline.join(lines[2:]) + newline
+        assert content == construct_expected(lines[2:])
         content = matcher.get_between("start", "end")
-        assert content == newline.join(lines[2:4]) + newline
+        assert content == construct_expected(lines[2:4])
 
     def test_match_large_file(self, large_logfile):
         """

--- a/tests/unit/testplan/common/utils/test_match.py
+++ b/tests/unit/testplan/common/utils/test_match.py
@@ -249,12 +249,21 @@ class TestLogMatcher:
         matcher.match(regex=re.compile(binary_or_string("fourth", is_binary)))
         matcher.mark(binary_or_string("end", is_binary))
         content = matcher.get_between()
-        assert content == binary_or_string("first\nsecond\nthird\nfourth\nfifth\n", is_binary)
+        assert content == binary_or_string(
+            "first\nsecond\nthird\nfourth\nfifth\n", is_binary
+        )
         content = matcher.get_between(None, binary_or_string("end", is_binary))
-        assert content == binary_or_string("first\nsecond\nthird\nfourth\n", is_binary)
-        content = matcher.get_between(binary_or_string("start", is_binary), None)
+        assert content == binary_or_string(
+            "first\nsecond\nthird\nfourth\n", is_binary
+        )
+        content = matcher.get_between(
+            binary_or_string("start", is_binary), None
+        )
         assert content == binary_or_string("third\nfourth\nfifth\n", is_binary)
-        content = matcher.get_between(binary_or_string("start", is_binary), binary_or_string("end", is_binary))
+        content = matcher.get_between(
+            binary_or_string("start", is_binary),
+            binary_or_string("end", is_binary),
+        )
         assert content == binary_or_string("third\nfourth\n", is_binary)
 
     def test_match_large_file(self, large_logfile):

--- a/tests/unit/testplan/common/utils/test_match.py
+++ b/tests/unit/testplan/common/utils/test_match.py
@@ -247,32 +247,19 @@ class TestLogMatcher:
         matcher.mark("end")
 
         newline = os.linesep.encode() if is_binary else "\n"
-        lines = ["first", "second", "third", "fourth", "fifth"]
+        lines = [
+            binary_or_string(line)
+            for line in ["first", "second", "third", "fourth", "fifth"]
+        ]
 
         content = matcher.get_between()
-        assert (
-            content
-            == newline.join([binary_or_string(line) for line in lines])
-            + newline
-        )
+        assert content == newline.join(lines) + newline
         content = matcher.get_between(None, "end")
-        assert (
-            content
-            == newline.join(binary_or_string(line) for line in lines[:4])
-            + newline
-        )
+        assert content == newline.join(lines[:4]) + newline
         content = matcher.get_between("start", None)
-        assert (
-            content
-            == newline.join([binary_or_string(line) for line in lines[2:]])
-            + newline
-        )
+        assert content == newline.join(lines[2:]) + newline
         content = matcher.get_between("start", "end")
-        assert (
-            content
-            == newline.join([binary_or_string(line) for line in lines[2:4]])
-            + newline
-        )
+        assert content == newline.join(lines[2:4]) + newline
 
     def test_match_large_file(self, large_logfile):
         """

--- a/tests/unit/testplan/common/utils/test_match.py
+++ b/tests/unit/testplan/common/utils/test_match.py
@@ -248,21 +248,31 @@ class TestLogMatcher:
         matcher.mark(binary_or_string("start", is_binary))
         matcher.match(regex=re.compile(binary_or_string("fourth", is_binary)))
         matcher.mark(binary_or_string("end", is_binary))
-        content = matcher.get_between()
+        content = matcher.get_between().replace(
+            binary_or_string("\r", is_binary), binary_or_string("", is_binary)
+        )
         assert content == binary_or_string(
             "first\nsecond\nthird\nfourth\nfifth\n", is_binary
         )
-        content = matcher.get_between(None, binary_or_string("end", is_binary))
+        content = matcher.get_between(
+            None, binary_or_string("end", is_binary)
+        ).replace(
+            binary_or_string("\r", is_binary), binary_or_string("", is_binary)
+        )
         assert content == binary_or_string(
             "first\nsecond\nthird\nfourth\n", is_binary
         )
         content = matcher.get_between(
             binary_or_string("start", is_binary), None
+        ).replace(
+            binary_or_string("\r", is_binary), binary_or_string("", is_binary)
         )
         assert content == binary_or_string("third\nfourth\nfifth\n", is_binary)
         content = matcher.get_between(
             binary_or_string("start", is_binary),
             binary_or_string("end", is_binary),
+        ).replace(
+            binary_or_string("\r", is_binary), binary_or_string("", is_binary)
         )
         assert content == binary_or_string("third\nfourth\n", is_binary)
 


### PR DESCRIPTION
## Bug / Requirement Description
LogMatcher.get_between throws an exception when configured for binary match due to explicit join on string literal.

## Solution description
Separator is now defined dependent on the match mode.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
