### PR TITLE
Fix Attribute Errors

### DIFF
--- a/doc/newsfragments/2630_changed.fix_attribute_error.rst
+++ b/doc/newsfragments/2630_changed.fix_attribute_error.rst
@@ -1,0 +1,1 @@
+Fixed an `AttributeError` raised by running a single testcase on interactive UI with an active filter.

--- a/doc/newsfragments/2630_changed.fix_attribute_error.rst
+++ b/doc/newsfragments/2630_changed.fix_attribute_error.rst
@@ -1,1 +1,1 @@
-Fixed an `AttributeError` raised by running a single testcase on interactive UI with an active filter.
+Fixed both a silent exception and an `AttributeError` raised by running a single testcase on interactive UI with an active filter.

--- a/doc/newsfragments/2649_changed.fix_attribute_error_prune.rst
+++ b/doc/newsfragments/2649_changed.fix_attribute_error_prune.rst
@@ -1,0 +1,1 @@
+Fixed silent exception thrown by the UI when attempting a rerun of a single testcase with an active filter.

--- a/doc/newsfragments/2649_changed.fix_attribute_error_prune.rst
+++ b/doc/newsfragments/2649_changed.fix_attribute_error_prune.rst
@@ -1,1 +1,0 @@
-Fixed silent exception thrown by the UI when attempting a rerun of a single testcase with an active filter.

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -940,6 +940,22 @@ class TestCaseReport(Report):
         if new_status == RuntimeStatus.FINISHED:
             self._status = Status.PASSED  # passed if case report has no entry
 
+    # NOTE: this is only for compatibility with the API for filtering.
+    def set_runtime_status_filtered(
+        self,
+        new_status: str,
+        entries: Dict,
+    ) -> None:
+        """
+        Alternative setter for the runtime status of an entry, here it is
+            equivalent to simply setting the runtime status.
+
+        :param new_status: new runtime status to be set
+        :param entries: tree-like structure of entries names, unused, but
+            needed for current API compatibility
+        """
+        self.runtime_status = new_status
+
     def _assertions_status(self):
         for entry in self:
             if entry.get(Status.PASSED) is False:

--- a/testplan/runnable/interactive/http.py
+++ b/testplan/runnable/interactive/http.py
@@ -919,7 +919,7 @@ def _extract_entries(entry: Dict) -> Dict:
     """
     entries = {}
 
-    if entry["category"] == "testcase":
+    if entry["category"] == ReportCategories.TESTCASE:
         return entries
 
     for child in entry.get("entries", []):

--- a/testplan/runnable/interactive/http.py
+++ b/testplan/runnable/interactive/http.py
@@ -919,12 +919,11 @@ def _extract_entries(entry: Dict) -> Dict:
     """
     entries = {}
 
-    # NOTE: we ignore assertions (DEFAULT category) and testcases
+    if entry["category"] == "testcase":
+        return entries
+
     for child in entry.get("entries", []):
-        if child["category"] in ("DEFAULT"):
-            pass
-        else:
-            entries[child["name"]] = _extract_entries(child)
+        entries[child["name"]] = _extract_entries(child)
 
     return entries
 

--- a/testplan/runnable/interactive/http.py
+++ b/testplan/runnable/interactive/http.py
@@ -919,10 +919,10 @@ def _extract_entries(entry: Dict) -> Dict:
     """
     entries = {}
 
-    # NOTE: we assume "entries" is present, see application of the function
-    for child in entry["entries"]:
-        if child["category"] == ReportCategories.TESTCASE:
-            entries[child["name"]] = {}
+    # NOTE: we ignore assertions (DEFAULT category) and testcases
+    for child in entry.get("entries", []):
+        if child["category"] in ("DEFAULT"):
+            pass
         else:
             entries[child["name"]] = _extract_entries(child)
 

--- a/testplan/web_ui/testing/src/Report/InteractiveReport.js
+++ b/testplan/web_ui/testing/src/Report/InteractiveReport.js
@@ -471,8 +471,12 @@ class InteractiveReportComponent extends BaseReport {
       category: category,
     };
 
-    if (entries.length !== 0 && category !== "testcase") {
-      pruneEntry.entries = entries.map((entry) => this.pruneReportEntry(entry));
+    if (entries) {
+        if (entries.length && category !== "testcase") {
+            pruneEntry.entries = entries.map(
+                (entry) => this.pruneReportEntry(entry)
+            );
+        }
     }
 
     return pruneEntry;
@@ -480,7 +484,7 @@ class InteractiveReportComponent extends BaseReport {
 
   /**
    * Shallow copy of a report entry, by replacing the "entries" attribute
-   * with an array of entry UIDs if not filter is present.
+   * with an array of entry UIDs if no filter is present.
    * In case there is a non-empty filter text, the entries attribute is pruned.
    */
   shallowReportEntry(reportEntry) {

--- a/tests/unit/testplan/runnable/interactive/test_api.py
+++ b/tests/unit/testplan/runnable/interactive/test_api.py
@@ -546,6 +546,26 @@ class TestSingleTestcase:
     def test_put_filtered(self, api_env):
         """Test updating the SingleTestcase resource via PUT."""
         client, ihandler = api_env
+        report_entry = ihandler.report["MTest1"]["MT1Suite1"]["MT1S1TC1"]
+
+        testcase_json = report_entry.serialize()
+        testcase_json["runtime_status"] = report.RuntimeStatus.RUNNING
+        rsp = client.put(
+            "/api/v1/interactive/report/tests/MTest1/suites/MT1Suite1/"
+            "testcases/{}".format("MT1S1TC1"),
+            json=testcase_json,
+        )
+        assert rsp.status_code == 200
+        ihandler.run_test_case.assert_called_once_with(
+            "MTest1",
+            "MT1Suite1",
+            "MT1S1TC1",
+            shallow_report=testcase_json,
+            await_results=False,
+        )
+
+    def test_put_filtered_parametrized(self, api_env):
+        client, ihandler = api_env
         report_entry = ihandler.report["MTest1"]["MT1Suite1"]["MT1S1TC2"]
 
         testcase_json = report_entry.serialize()


### PR DESCRIPTION
## Bug / Requirement Description
There are two attribute errors related to the interactive UI with filter expression feature. One is a silent exception thrown on rerun of single testcases on a missing length attribute. The other is related to running a single testcase where the filtered runtime status was not implemented.

## Solution description
Added proper handling for these scenarios and an additional test for running a single testcase with an API call.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
