### PR TITLE
Failed setup runtime status fix

### DIFF
--- a/doc/newsfragments/2643_changed.fix_runtime_status_upon_setup_exception.rst
+++ b/doc/newsfragments/2643_changed.fix_runtime_status_upon_setup_exception.rst
@@ -1,0 +1,1 @@
+Fixed a defect whereas a failing setup would cause the interactive GUI to hang on testcase runtime status.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@
         "flask_restx",
         "cheroot",
         "boltons",
-        "validators",
+        "validators<=0.20.0",
         "Pillow",
         "plotly",
         "rpyc",

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -18,7 +18,7 @@ werkzeug>2.0.0
 flask_restx
 cheroot
 boltons
-validators
+validators<=0.20.0
 Pillow
 plotly
 rpyc

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -1297,7 +1297,9 @@ class MultiTest(testing_base.Test):
 
             if setup_report.failed:
                 # NOTE: we are going to skip the cases and update the status
-                for status, parent_uids in self._skip_testcases(testsuite, testcases):
+                for status, parent_uids in self._skip_testcases(
+                    testsuite, testcases
+                ):
                     yield status, parent_uids
                 teardown_report = self._teardown_testsuite(testsuite)
                 if teardown_report is not None:
@@ -1322,9 +1324,7 @@ class MultiTest(testing_base.Test):
         :return: list of parent UIDs
         """
 
-        param_template = getattr(
-            testcase, "_parametrization_template", None
-        )
+        param_template = getattr(testcase, "_parametrization_template", None)
         if param_template:
             parent_uids = [
                 self.uid(),

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -1296,6 +1296,9 @@ class MultiTest(testing_base.Test):
             yield setup_report, [self.uid(), testsuite.uid()]
 
             if setup_report.failed:
+                # NOTE: we are going to skip the cases and update the status
+                for status, parent_uids in self._skip_testcases(testsuite, testcases):
+                    yield status, parent_uids
                 teardown_report = self._teardown_testsuite(testsuite)
                 if teardown_report is not None:
                     yield teardown_report, [self.uid(), testsuite.uid()]
@@ -1309,6 +1312,47 @@ class MultiTest(testing_base.Test):
         teardown_report = self._teardown_testsuite(testsuite)
         if teardown_report is not None:
             yield teardown_report, [self.uid(), testsuite.uid()]
+
+    def _get_parent_uids(self, testsuite, testcase):
+        """
+        Utility method to get parent UIDs of a particular testcase.
+
+        :param testsuite: suite to which the case belongs
+        :param testcase: the testcase for which the UIDs are derived
+        :return: list of parent UIDs
+        """
+
+        param_template = getattr(
+            testcase, "_parametrization_template", None
+        )
+        if param_template:
+            parent_uids = [
+                self.uid(),
+                testsuite.uid(),
+                testcase._parametrization_template,
+            ]
+        else:
+            parent_uids = [self.uid(), testsuite.uid()]
+        return parent_uids
+
+    def _skip_testcases(self, testsuite, testcases):
+        """
+        Utility to forcefully skip testcases and modify their runtime status to not
+        run. Used during the failed setup scenario to update the runtime status.
+
+        :param testsuite: testsuite to which the testcases belong
+        :param testcases: testcases to skip
+        :return: generator yielding the not run status for each parent UIDs list
+        """
+        for testcase in testcases:
+            if not self.active:
+                break
+
+            parent_uids = self._get_parent_uids(testsuite, testcase)
+
+            yield {"runtime_status": RuntimeStatus.NOT_RUN}, parent_uids + [
+                testcase.__name__
+            ]
 
     def _run_testcases_iter(self, testsuite, testcases):
         """
@@ -1324,17 +1368,7 @@ class MultiTest(testing_base.Test):
             if not self.active:
                 break
 
-            param_template = getattr(
-                testcase, "_parametrization_template", None
-            )
-            if param_template:
-                parent_uids = [
-                    self.uid(),
-                    testsuite.uid(),
-                    testcase._parametrization_template,
-                ]
-            else:
-                parent_uids = [self.uid(), testsuite.uid()]
+            parent_uids = self._get_parent_uids(testsuite, testcase)
 
             # set the runtime status of testcase report to RUNNING so that
             # client UI can get the change and show testcase is running

--- a/tests/unit/testplan/runnable/interactive/test_irunner.py
+++ b/tests/unit/testplan/runnable/interactive/test_irunner.py
@@ -196,7 +196,7 @@ def test_run_suite_with_failed_setup():
     target.resources.add(local_runner)
 
     with mock.patch("cheroot.wsgi.Server"), mock.patch(
-            "testplan.runnable.interactive.reloader.ModuleReloader"
+        "testplan.runnable.interactive.reloader.ModuleReloader"
     ) as MockReloader:
         MockReloader.return_value = None
 


### PR DESCRIPTION
Fixed a defect whereas failure in setup would cause the runtime status to not move from WAITING. Added a unit test to cover the scenario and a newsfragment.

## Bug / Requirement Description
A failed setup results only in the teardown report yielded in the iterative testcase runner and does not set the runtime status back to "ready" or "not run" for any of the cases, leaving the UI hanging on those cases forever.

## Solution description
Added a method to forcefully skip cases and update their status to "not run".

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
