### PR TITLE
Enlarge abort_wait_timeout to fix leftover driver 

### DIFF
--- a/examples/Transports/FIX/over_one_session.py
+++ b/examples/Transports/FIX/over_one_session.py
@@ -162,6 +162,7 @@ def get_multitest():
                 target="ISLD",
                 msgclass=FixMessage,
                 codec=CODEC,
+                logoff_at_stop=False,
             ),
         ],
     )

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -93,7 +93,7 @@ def result_for_failed_task(original_result):
     """
     result = TestResult()
     result.report = TestGroupReport(
-        name=original_result.task.name, category=ReportCategories.ERROR
+        name=str(original_result.task), category=ReportCategories.ERROR
     )
     attrs = [attr for attr in original_result.task.serializable_attrs]
     result_lines = [
@@ -957,14 +957,16 @@ class TestRunner(Runnable):
 
         while self.active:
             if self.cfg.timeout and time.time() - _start_ts > self.cfg.timeout:
-                self.result.test_report.logger.error(
-                    "Timeout: Aborting execution after %d seconds",
-                    self.cfg.timeout,
+                msg = (
+                    f"Timeout: Aborting execution after {self.cfg.timeout} seconds",
                 )
-                # Abort dependencies, wait sometime till test reports are ready
+                self.result.test_report.logger.error(msg)
+                self.logger.error(msg)
+
+                # Abort resources e.g pools
                 for dep in self.abort_dependencies():
                     self._abort_entity(dep)
-                time.sleep(self.cfg.abort_wait_timeout)
+
                 break
 
             pending_work = False

--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -814,11 +814,11 @@ class Pool(Executor):
         self.logger.critical("Discard pending tasks of %s", self)
         while self.ongoing:
             uid = self.ongoing[0]
-            target = self._input[uid]._target
+            task = self._input[uid]
             self._results[uid] = TaskResult(
                 task=self._input[uid],
                 status=False,
-                reason=f"Task [{target}] discarding due to {self} abort",
+                reason=f"{task} discarding due to {self} abort",
             )
             self.ongoing.pop(0)
 

--- a/testplan/runners/pools/tasks/base.py
+++ b/testplan/runners/pools/tasks/base.py
@@ -7,6 +7,7 @@ import warnings
 from collections import OrderedDict
 from typing import Optional, Tuple, Union, Dict, Sequence, Callable
 
+from testplan.common.entity import Runnable
 from testplan.testing.base import Test, TestResult
 from testplan.common.serialization import SelectiveSerializable
 from testplan.common.utils import strings
@@ -85,7 +86,15 @@ class Task(SelectiveSerializable):
         self._part = part
 
     def __str__(self) -> str:
-        return "{}[{}]".format(self.__class__.__name__, self._uid)
+        if isinstance(self._target, Runnable):
+            name = (
+                getattr(self._target, "name", None)
+                or self._target.__class__.__name__
+            )
+        else:
+            name = self._target
+
+        return f"{self.__class__.__name__}[{name}(uid={self._uid})]"
 
     @property
     def weight(self) -> int:
@@ -110,18 +119,6 @@ class Task(SelectiveSerializable):
     def uid(self) -> str:
         """Task string uid."""
         return self._uid
-
-    @property
-    def name(self) -> str:
-        """Task name."""
-        if not isinstance(self._target, str):
-            try:
-                name = self._target.__class__.__name__
-            except AttributeError:
-                name = self._target
-        else:
-            name = self._target
-        return "Task[{}]".format(name)
 
     @property
     def args(self) -> Tuple:


### PR DESCRIPTION
## Bug / Requirement Description
When we abort testplan from interactive UI, timeout kicks-in before all driver are stopped.

## Solution description
1) Enlarge the abort_wait_timeout
2) Suppress the exception of abort_wait_timeout so that abort will continue
3) Remove an unnecessary wait

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
