### PR TITLE
Add --xfail-tests support for GTest

### DIFF
--- a/doc/newsfragments/2278_change.interactive_abort_timeout.rst
+++ b/doc/newsfragments/2278_change.interactive_abort_timeout.rst
@@ -1,0 +1,1 @@
+Enlarge interactive mode abort timeout for avoid left-over drivers.

--- a/doc/newsfragments/2604_changed.xfail_tests_for_gtest.rst
+++ b/doc/newsfragments/2604_changed.xfail_tests_for_gtest.rst
@@ -1,0 +1,1 @@
+``--xfail-tests`` now supports wildcard pattern for MultiTest and GTest.

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -157,10 +157,33 @@ class TestplanParser:
             "--xfail-tests",
             metavar="PATH",
             type=_read_json_file,
-            help="Read a list of known to fail testcases from a JSON file "
-            "with each entry looks like: "
-            '{"<Multitest>:<TestSuite>:<testcase>": '
-            '{"reason": <value>, "strict": <value>} }',
+            help="""
+Read a list of testcase name patterns from a JSON files, and mark matching testcases as xfail.
+This feature works for MultiTest, GTest and CPPUnit.
+A typical input JSON looks like below:
+{
+    "Fatal GTest:*:*": {
+        "reason": "test known to crash",
+        "strict": true
+    },
+    "Flaky GTest:SuiteName:CaseName": {
+        "reason": "test not stable",
+        "strict": false
+    },
+    "Fatal MultiTest:*:*": {
+        "reason": "env does not start",
+        "strict": true
+    },
+    "Flaky MultiTest:Suite Name:*": {
+        "reason": "everything under that suite flaky",
+        "strict": true
+    }
+}
+
+"with each entry looks like: "
+'{"<Multitest>:<TestSuite>:<testcase>": '
+'{"reason": <value>, "strict": <value>} }',
+""",
         )
 
         general_group.add_argument(

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -844,15 +844,16 @@ class ProcessRunnerTest(Test):
         )
 
     def apply_xfail_tests(self):
-        # import pdb
-        # pdb.set_trace()
-        test_report = self.result.report
+        """
+        Apply xfail tests specified via --xfail-tests or @test_plan(xfail_tests=...).
+        """
 
         def _xfail(pattern, report):
             found = self.cfg.xfail_tests.get(pattern)
             if found:
-                report.xfail(strict=found['strict'])
+                report.xfail(strict=found["strict"])
 
+        test_report = self.result.report
         pattern = f"{test_report.name}:*:*"
         _xfail(pattern, test_report)
 
@@ -863,8 +864,6 @@ class ProcessRunnerTest(Test):
             for case_report in suite_report.entries:
                 pattern = f"{test_report.name}:{suite_report.name}:{case_report.name}"
                 _xfail(pattern, case_report)
-
-
 
     def pre_resource_steps(self):
         """Runnable steps to be executed before environment starts."""

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -843,6 +843,29 @@ class ProcessRunnerTest(Test):
             )
         )
 
+    def apply_xfail_tests(self):
+        # import pdb
+        # pdb.set_trace()
+        test_report = self.result.report
+
+        def _xfail(pattern, report):
+            found = self.cfg.xfail_tests.get(pattern)
+            if found:
+                report.xfail(strict=found['strict'])
+
+        pattern = f"{test_report.name}:*:*"
+        _xfail(pattern, test_report)
+
+        for suite_report in test_report.entries:
+            pattern = f"{test_report.name}:{suite_report.name}:*"
+            _xfail(pattern, suite_report)
+
+            for case_report in suite_report.entries:
+                pattern = f"{test_report.name}:{suite_report.name}:{case_report.name}"
+                _xfail(pattern, case_report)
+
+
+
     def pre_resource_steps(self):
         """Runnable steps to be executed before environment starts."""
         super(ProcessRunnerTest, self).pre_resource_steps()
@@ -860,6 +883,7 @@ class ProcessRunnerTest(Test):
         """Runnable steps to be executed while environment is running."""
         self._add_step(self.run_tests)
         self._add_step(self.update_test_report)
+        self._add_step(self.apply_xfail_tests)
         self._add_step(self.propagate_tag_indices)
         self._add_step(self.log_test_results, top_down=False)
 

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -849,9 +849,10 @@ class ProcessRunnerTest(Test):
         """
 
         def _xfail(pattern, report):
-            found = self.cfg.xfail_tests.get(pattern)
-            if found:
-                report.xfail(strict=found["strict"])
+            if getattr(self.cfg, "xfail_tests", None):
+                found = self.cfg.xfail_tests.get(pattern)
+                if found:
+                    report.xfail(strict=found["strict"])
 
         test_report = self.result.report
         pattern = f"{test_report.name}:*:*"

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -735,12 +735,11 @@ class MultiTest(testing_base.Test):
         Testcase level xfail already applied during test execution.
         """
 
-        # import pdb
-        # pdb.set_trace()
         def _xfail(pattern, report):
-            found = self.cfg.xfail_tests.get(pattern)
-            if found:
-                report.xfail(strict=found["strict"])
+            if getattr(self.cfg, "xfail_tests", None):
+                found = self.cfg.xfail_tests.get(pattern)
+                if found:
+                    report.xfail(strict=found["strict"])
 
         test_report = self.result.report
         pattern = f"{test_report.name}:*:*"

--- a/tests/functional/testplan/testing/cpp/test_gtest.py
+++ b/tests/functional/testplan/testing/cpp/test_gtest.py
@@ -78,6 +78,10 @@ def test_gtest_xfail():
     plan = TestplanMock(
         name="GTest Xfail",
         xfail_tests={
+            "Error GTest:*:*": {
+                "reason": "GTest crash",
+                "strict": True,
+            },
             "Failing GTest:SquareRootTest:PositiveNos": {
                 "reason": "known flaky",
                 "strict": False,
@@ -86,25 +90,25 @@ def test_gtest_xfail():
                 "reason": "known flaky",
                 "strict": False,
             },
-            "Error GTest:*:*": {
-                "reason": "GTest crash",
-                "strict": True,
-            },
         },
     )
 
-    failing_binary = os.path.join(fixture_root, "failing", "runTests")
     error_binary = os.path.join(fixture_root, "error", "runTests.sh")
-
-    plan.add(GTest(name="Failing GTest", binary=failing_binary))
     plan.add(GTest(name="Error GTest", binary=error_binary))
+
+    failing_binary = os.path.join(fixture_root, "failing", "runTests")
+    if os.path.exists(failing_binary):
+        plan.add(GTest(name="Failing GTest", binary=failing_binary))
 
     assert plan.run().run is True
 
-    assert plan.report.entries[0].entries[0].entries[0].status == Status.XFAIL
-    assert plan.report.entries[0].entries[1].status == Status.XFAIL
-    assert plan.report.entries[1].status == Status.XFAIL
-    assert plan.report.status == Status.FAILED
+    assert plan.report.entries[0].status == Status.XFAIL
+
+    if os.path.exists(failing_binary):
+        assert (
+            plan.report.entries[1].entries[0].entries[0].status == Status.XFAIL
+        )
+        assert plan.report.entries[1].entries[1].status == Status.XFAIL
 
 
 def test_gtest_custom_args():

--- a/tests/functional/testplan/testing/fixtures/cpp/cppunit/error/runTests.sh
+++ b/tests/functional/testplan/testing/fixtures/cpp/cppunit/error/runTests.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/sh
+#!/bin/sh
 
 echo "No output file generated"
+exit(1)
 

--- a/tests/functional/testplan/testing/fixtures/cpp/cppunit/error/runTests.sh
+++ b/tests/functional/testplan/testing/fixtures/cpp/cppunit/error/runTests.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 echo "No output file generated"
-exit(1)
+exit 1
 

--- a/tests/functional/testplan/testing/fixtures/cpp/gtest/error/runTests.sh
+++ b/tests/functional/testplan/testing/fixtures/cpp/gtest/error/runTests.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 echo "No output file generated"
-exit(1)
+exit 1

--- a/tests/functional/testplan/testing/fixtures/cpp/gtest/error/runTests.sh
+++ b/tests/functional/testplan/testing/fixtures/cpp/gtest/error/runTests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 
 echo "No output file generated"
-
+exit(1)


### PR DESCRIPTION
## Bug / Requirement Description
This is to expand the effect of --xfail-tests to cover GTest as well.

## Solution description
A bit of special treatment is when GTest crashes and generates no report. xfail with "GTestName:*:*" pattern in json.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [x] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
