### PR TITLE
Feature/interactive display hostname

### DIFF
--- a/doc/newsfragments/2697_changed.interactive_display_hostname.rst
+++ b/doc/newsfragments/2697_changed.interactive_display_hostname.rst
@@ -1,0 +1,1 @@
+Interactive run now logs the exact hostname rather than localhost or IP address.

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -855,7 +855,8 @@ class TestRunnerIHandler(entity.Entity):
 
         self.logger.user_info(
             "\nInteractive Testplan web UI is running. Access it at:\n%s:%s/interactive",
-            platform.node(), str(port)
+            platform.node(),
+            str(port),
         )
 
     def _initial_report(self):

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -2,8 +2,8 @@
 Interactive handler for TestRunner runnable class.
 """
 import numbers
-import platform
 import re
+import socket
 import threading
 import warnings
 from concurrent import futures
@@ -860,7 +860,7 @@ class TestRunnerIHandler(entity.Entity):
 
         self.logger.user_info(
             "\nInteractive Testplan web UI is running. Access it at: %s:%s/interactive",
-            platform.node(),
+            socket.getfqdn(),
             str(port),
         )
 

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -854,7 +854,7 @@ class TestRunnerIHandler(entity.Entity):
             )
 
         self.logger.user_info(
-            "\nInteractive Testplan web UI is running. Access it at:\n%s:%s/interactive",
+            "\nInteractive Testplan web UI is running. Access it at: %s:%s/interactive",
             platform.node(),
             str(port),
         )

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -2,6 +2,7 @@
 Interactive handler for TestRunner runnable class.
 """
 import numbers
+import platform
 import re
 import threading
 from concurrent import futures
@@ -9,10 +10,7 @@ from typing import Union, Awaitable, Dict, Optional
 
 from testplan.common import config, entity
 from testplan.common.report import Report
-from testplan.common.utils import networking
-
 from testplan.runnable.interactive import http, reloader, resource_loader
-
 from testplan.report import (
     TestReport,
     TestGroupReport,
@@ -856,8 +854,8 @@ class TestRunnerIHandler(entity.Entity):
             )
 
         self.logger.user_info(
-            "\nInteractive Testplan web UI is running. Access it at:\n%s",
-            networking.format_access_urls(host, port, "/interactive/"),
+            "\nInteractive Testplan web UI is running. Access it at:\n%s:%s/interactive",
+            platform.node(), str(port)
         )
 
     def _initial_report(self):


### PR DESCRIPTION
## Bug / Requirement Description
There is a requirement that instead of localhost or IP address we log the exact hostname on the console during interactive UI startup.

## Solution description
Simply use platform module and its node method.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
