### PR TITLE
Suppressed flask/flask_restx warnings

### DIFF
--- a/doc/newsfragments/2735_changed.suppress_flaks_restx_warning.rst
+++ b/doc/newsfragments/2735_changed.suppress_flaks_restx_warning.rst
@@ -1,0 +1,1 @@
+Verbose logging of `flask` related warning upon interactive UI startup are now suppressed on the console.

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -4,6 +4,7 @@ Interactive handler for TestRunner runnable class.
 import numbers
 import re
 import threading
+import warnings
 from concurrent import futures
 from typing import Union, Awaitable, Dict, Optional
 
@@ -839,7 +840,11 @@ class TestRunnerIHandler(entity.Entity):
             ihandler=self, port=self.cfg.http_port
         )
         http_handler.cfg.parent = self.cfg
-        http_handler.setup()
+
+        # Mute flask_restx warning.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            http_handler.setup()
 
         return http_handler
 


### PR DESCRIPTION
## Bug / Requirement Description
A couple of verbose logs of UserWarnings are emitted during the HTTP handler setup step. We would like to suppress those.

## Solution description
Locally filtering the warnings.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [x] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
