### PR TITLE
Non-italic counter and timing

### DIFF
--- a/doc/newsfragments/2732_changed.normal_font_for_status.rst
+++ b/doc/newsfragments/2732_changed.normal_font_for_status.rst
@@ -1,0 +1,1 @@
+Passed and failed count, together with report entry time information is now consistently normal font-style.

--- a/testplan/web_ui/testing/src/Common/Styles.js
+++ b/testplan/web_ui/testing/src/Common/Styles.js
@@ -15,21 +15,27 @@ export const unselectable = {
 export const statusStyles = {
   passed: {
     color: GREEN,
+    fontStyle: "normal",
   },
   failed: {
     color: RED,
+    fontStyle: "normal",
   },
   error: {
     color: RED,
+    fontStyle: "normal",
   },
   skipped: {
     color: ORANGE,
+    fontStyle: "normal",
   },
   unstable: {
     color: ORANGE,
+    fontStyle: "normal",
   },
   unknown: {
     color: BLACK,
+    fontStyle: "normal",
   },
 };
 

--- a/testplan/web_ui/testing/src/Common/Styles.js
+++ b/testplan/web_ui/testing/src/Common/Styles.js
@@ -15,27 +15,21 @@ export const unselectable = {
 export const statusStyles = {
   passed: {
     color: GREEN,
-    fontStyle: "normal",
   },
   failed: {
     color: RED,
-    fontStyle: "normal",
   },
   error: {
     color: RED,
-    fontStyle: "normal",
   },
   skipped: {
     color: ORANGE,
-    fontStyle: "normal",
   },
   unstable: {
     color: ORANGE,
-    fontStyle: "normal",
   },
   unknown: {
     color: BLACK,
-    fontStyle: "normal",
   },
 };
 

--- a/testplan/web_ui/testing/src/Nav/InteractiveNavEntry.js
+++ b/testplan/web_ui/testing/src/Nav/InteractiveNavEntry.js
@@ -78,10 +78,10 @@ const InteractiveNavEntry = (props) => {
         {props.name}
       </div>
       <div className={css(styles.entryIcons)}>
-        <i className={css(styles.entryIcon)} title="passed/failed testcases">
+        <span className={css(styles.entryIcon)} title="passed/failed testcases">
           <span className={css(styles.passed)}>{props.caseCountPassed}</span>/
           <span className={css(styles.failed)}>{props.caseCountFailed}</span>
-        </i>
+        </span>
         {resetReportIcon}
         {envStatusIcon}
         {statusIcon}

--- a/testplan/web_ui/testing/src/Nav/NavEntry.js
+++ b/testplan/web_ui/testing/src/Nav/NavEntry.js
@@ -27,11 +27,11 @@ const NavEntry = (props) => {
   const badgeStyle = `${STATUS_CATEGORY[props.status]}Badge`;
   const executionTime =
     props.displayTime && _.isNumber(props.executionTime) ? (
-      <i className={css(styles.entryIcon)} title="Execution time">
+      <span className={css(styles.entryIcon)} title="Execution time">
         <span className={css(styles[STATUS_CATEGORY[props.status]])}>
           {formatMilliseconds(props.executionTime)}
         </span>
-      </i>
+      </span>
     ) : null;
   return (
     <div
@@ -56,10 +56,10 @@ const NavEntry = (props) => {
       </div>
       <div className={css(styles.entryIcons)}>
         {executionTime}
-        <i className={css(styles.entryIcon)} title="passed/failed testcases">
+        <span className={css(styles.entryIcon)} title="passed/failed testcases">
           <span className={css(styles.passed)}>{props.caseCountPassed}</span>/
           <span className={css(styles.failed)}>{props.caseCountFailed}</span>
-        </i>
+        </span>
       </div>
     </div>
   );

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/InteractiveNavEntry.test.js.snap
@@ -28,7 +28,7 @@ exports[`InteractiveNavEntry renders a testcase in "failed" state 1`] = `
   <div
     className="entryIcons_195essn"
   >
-    <i
+    <span
       className="entryIcon_9gb3m5"
       title="passed/failed testcases"
     >
@@ -43,7 +43,7 @@ exports[`InteractiveNavEntry renders a testcase in "failed" state 1`] = `
       >
         1
       </span>
-    </i>
+    </span>
     <FontAwesomeIcon
       beat={false}
       beatFade={false}
@@ -117,7 +117,7 @@ exports[`InteractiveNavEntry renders a testcase in "not_run" state 1`] = `
   <div
     className="entryIcons_195essn"
   >
-    <i
+    <span
       className="entryIcon_9gb3m5"
       title="passed/failed testcases"
     >
@@ -132,7 +132,7 @@ exports[`InteractiveNavEntry renders a testcase in "not_run" state 1`] = `
       >
         0
       </span>
-    </i>
+    </span>
     <FontAwesomeIcon
       beat={false}
       beatFade={false}
@@ -206,7 +206,7 @@ exports[`InteractiveNavEntry renders a testcase in "passed" state 1`] = `
   <div
     className="entryIcons_195essn"
   >
-    <i
+    <span
       className="entryIcon_9gb3m5"
       title="passed/failed testcases"
     >
@@ -221,7 +221,7 @@ exports[`InteractiveNavEntry renders a testcase in "passed" state 1`] = `
       >
         0
       </span>
-    </i>
+    </span>
     <FontAwesomeIcon
       beat={false}
       beatFade={false}
@@ -295,7 +295,7 @@ exports[`InteractiveNavEntry renders a testcase in "ready" state 1`] = `
   <div
     className="entryIcons_195essn"
   >
-    <i
+    <span
       className="entryIcon_9gb3m5"
       title="passed/failed testcases"
     >
@@ -310,7 +310,7 @@ exports[`InteractiveNavEntry renders a testcase in "ready" state 1`] = `
       >
         0
       </span>
-    </i>
+    </span>
     <FontAwesomeIcon
       beat={false}
       beatFade={false}
@@ -384,7 +384,7 @@ exports[`InteractiveNavEntry renders a testcase in "resetting" state 1`] = `
   <div
     className="entryIcons_195essn"
   >
-    <i
+    <span
       className="entryIcon_9gb3m5"
       title="passed/failed testcases"
     >
@@ -399,7 +399,7 @@ exports[`InteractiveNavEntry renders a testcase in "resetting" state 1`] = `
       >
         0
       </span>
-    </i>
+    </span>
     <FontAwesomeIcon
       beat={false}
       beatFade={false}
@@ -473,7 +473,7 @@ exports[`InteractiveNavEntry renders a testcase in "running" state 1`] = `
   <div
     className="entryIcons_195essn"
   >
-    <i
+    <span
       className="entryIcon_9gb3m5"
       title="passed/failed testcases"
     >
@@ -488,7 +488,7 @@ exports[`InteractiveNavEntry renders a testcase in "running" state 1`] = `
       >
         0
       </span>
-    </i>
+    </span>
     <FontAwesomeIcon
       beat={false}
       beatFade={false}
@@ -562,7 +562,7 @@ exports[`InteractiveNavEntry renders a testcase in "waiting" state 1`] = `
   <div
     className="entryIcons_195essn"
   >
-    <i
+    <span
       className="entryIcon_9gb3m5"
       title="passed/failed testcases"
     >
@@ -577,7 +577,7 @@ exports[`InteractiveNavEntry renders a testcase in "waiting" state 1`] = `
       >
         0
       </span>
-    </i>
+    </span>
     <FontAwesomeIcon
       beat={false}
       beatFade={false}
@@ -651,7 +651,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTED 1`
   <div
     className="entryIcons_195essn"
   >
-    <i
+    <span
       className="entryIcon_9gb3m5"
       title="passed/failed testcases"
     >
@@ -666,7 +666,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTED 1`
       >
         0
       </span>
-    </i>
+    </span>
     <FontAwesomeIcon
       beat={false}
       beatFade={false}
@@ -822,7 +822,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTING 1
   <div
     className="entryIcons_195essn"
   >
-    <i
+    <span
       className="entryIcon_9gb3m5"
       title="passed/failed testcases"
     >
@@ -837,7 +837,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STARTING 1
       >
         0
       </span>
-    </i>
+    </span>
     <FontAwesomeIcon
       beat={false}
       beatFade={false}
@@ -993,7 +993,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPED 1`
   <div
     className="entryIcons_195essn"
   >
-    <i
+    <span
       className="entryIcon_9gb3m5"
       title="passed/failed testcases"
     >
@@ -1008,7 +1008,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPED 1`
       >
         0
       </span>
-    </i>
+    </span>
     <FontAwesomeIcon
       beat={false}
       beatFade={false}
@@ -1164,7 +1164,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPING 1
   <div
     className="entryIcons_195essn"
   >
-    <i
+    <span
       className="entryIcon_9gb3m5"
       title="passed/failed testcases"
     >
@@ -1179,7 +1179,7 @@ exports[`InteractiveNavEntry renders an entry with environment status STOPPING 1
       >
         0
       </span>
-    </i>
+    </span>
     <FontAwesomeIcon
       beat={false}
       beatFade={false}

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavEntry.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavEntry.test.js.snap
@@ -20,7 +20,7 @@ exports[`NavEntry shallow renders the correct HTML structure 1`] = `
     TP
   </Badge>
   <div
-    className="entryName_1ocij4b-o_O-passed_1kh4m98"
+    className="entryName_1ocij4b-o_O-passed_ee16j1"
     title="entry description - passed"
   >
     entry name
@@ -33,13 +33,13 @@ exports[`NavEntry shallow renders the correct HTML structure 1`] = `
       title="passed/failed testcases"
     >
       <span
-        className="passed_1kh4m98"
+        className="passed_ee16j1"
       >
         0
       </span>
       /
       <span
-        className="failed_11es5k7"
+        className="failed_lmznuu"
       >
         0
       </span>
@@ -68,7 +68,7 @@ exports[`NavEntry when prop status="failed" name div and Badge have correct styl
     TP
   </Badge>
   <div
-    className="entryName_1ocij4b-o_O-failed_11es5k7"
+    className="entryName_1ocij4b-o_O-failed_lmznuu"
     title="entry description - failed"
   >
     entry name
@@ -81,13 +81,13 @@ exports[`NavEntry when prop status="failed" name div and Badge have correct styl
       title="passed/failed testcases"
     >
       <span
-        className="passed_1kh4m98"
+        className="passed_ee16j1"
       >
         0
       </span>
       /
       <span
-        className="failed_11es5k7"
+        className="failed_lmznuu"
       >
         0
       </span>
@@ -116,7 +116,7 @@ exports[`NavEntry when prop status="xfail" name div and Badge have correct style
     TP
   </Badge>
   <div
-    className="entryName_1ocij4b-o_O-unstable_17i2uy2"
+    className="entryName_1ocij4b-o_O-unstable_13lli17"
     title="entry description - xfail"
   >
     entry name
@@ -129,13 +129,13 @@ exports[`NavEntry when prop status="xfail" name div and Badge have correct style
       title="passed/failed testcases"
     >
       <span
-        className="passed_1kh4m98"
+        className="passed_ee16j1"
       >
         0
       </span>
       /
       <span
-        className="failed_11es5k7"
+        className="failed_lmznuu"
       >
         0
       </span>

--- a/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavEntry.test.js.snap
+++ b/testplan/web_ui/testing/src/Nav/__tests__/__snapshots__/NavEntry.test.js.snap
@@ -20,7 +20,7 @@ exports[`NavEntry shallow renders the correct HTML structure 1`] = `
     TP
   </Badge>
   <div
-    className="entryName_1ocij4b-o_O-passed_ee16j1"
+    className="entryName_1ocij4b-o_O-passed_1kh4m98"
     title="entry description - passed"
   >
     entry name
@@ -28,22 +28,22 @@ exports[`NavEntry shallow renders the correct HTML structure 1`] = `
   <div
     className="entryIcons_jqmit5"
   >
-    <i
+    <span
       className="entryIcon_9gb3m5"
       title="passed/failed testcases"
     >
       <span
-        className="passed_ee16j1"
+        className="passed_1kh4m98"
       >
         0
       </span>
       /
       <span
-        className="failed_lmznuu"
+        className="failed_11es5k7"
       >
         0
       </span>
-    </i>
+    </span>
   </div>
 </div>
 `;
@@ -68,7 +68,7 @@ exports[`NavEntry when prop status="failed" name div and Badge have correct styl
     TP
   </Badge>
   <div
-    className="entryName_1ocij4b-o_O-failed_lmznuu"
+    className="entryName_1ocij4b-o_O-failed_11es5k7"
     title="entry description - failed"
   >
     entry name
@@ -76,22 +76,22 @@ exports[`NavEntry when prop status="failed" name div and Badge have correct styl
   <div
     className="entryIcons_jqmit5"
   >
-    <i
+    <span
       className="entryIcon_9gb3m5"
       title="passed/failed testcases"
     >
       <span
-        className="passed_ee16j1"
+        className="passed_1kh4m98"
       >
         0
       </span>
       /
       <span
-        className="failed_lmznuu"
+        className="failed_11es5k7"
       >
         0
       </span>
-    </i>
+    </span>
   </div>
 </div>
 `;
@@ -116,7 +116,7 @@ exports[`NavEntry when prop status="xfail" name div and Badge have correct style
     TP
   </Badge>
   <div
-    className="entryName_1ocij4b-o_O-unstable_13lli17"
+    className="entryName_1ocij4b-o_O-unstable_17i2uy2"
     title="entry description - xfail"
   >
     entry name
@@ -124,22 +124,22 @@ exports[`NavEntry when prop status="xfail" name div and Badge have correct style
   <div
     className="entryIcons_jqmit5"
   >
-    <i
+    <span
       className="entryIcon_9gb3m5"
       title="passed/failed testcases"
     >
       <span
-        className="passed_ee16j1"
+        className="passed_1kh4m98"
       >
         0
       </span>
       /
       <span
-        className="failed_lmznuu"
+        className="failed_11es5k7"
       >
         0
       </span>
-    </i>
+    </span>
   </div>
 </div>
 `;


### PR DESCRIPTION
## Bug / Requirement Description
Report entry counters and the timing information shown next to them are italic which is inconsistent.

## Solution description
Made status styles use normal font style.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
