### PR TITLE
fix flaky interactive tests

### DIFF
--- a/tests/functional/testplan/runnable/interactive/__init__.py
+++ b/tests/functional/testplan/runnable/interactive/__init__.py
@@ -1,0 +1,13 @@
+from testplan.common.utils.timing import wait
+
+
+def interactive_started(plan):
+    return plan.interactive.http_handler_info[0] is not None
+
+
+def wait_for_interactive_start(plan):
+    wait(
+        lambda: interactive_started(plan),
+        5,
+        raise_on_timeout=True,
+    )

--- a/tests/functional/testplan/runnable/interactive/interactive_executable.py
+++ b/tests/functional/testplan/runnable/interactive/interactive_executable.py
@@ -328,7 +328,7 @@ def _get_actual_reports(plan):
     # Generate a list test reports from Testplan for comparing
     return [
         [
-            plan.i.test_case_report(
+            plan.interactive.test_case_report(
                 test_uid="BasicTest",
                 suite_uid="Suite",
                 case_uid="case",
@@ -336,7 +336,7 @@ def _get_actual_reports(plan):
             )["entries"][0]["entries"][0]["entries"][0],
         ],
         [
-            plan.i.test_case_report(
+            plan.interactive.test_case_report(
                 test_uid="InnerTest",
                 suite_uid="Suite",
                 case_uid="case",
@@ -344,13 +344,13 @@ def _get_actual_reports(plan):
             )["entries"][0]["entries"][0]["entries"][0],
         ],
         [
-            plan.i.test_case_report(
+            plan.interactive.test_case_report(
                 test_uid="ExtraTest",
                 suite_uid="Suite1",
                 case_uid="case",
                 serialized=True,
             )["entries"][0]["entries"][0]["entries"][0],
-            plan.i.test_case_report(
+            plan.interactive.test_case_report(
                 test_uid="ExtraTest",
                 suite_uid="Suite2",
                 case_uid="case",
@@ -358,7 +358,7 @@ def _get_actual_reports(plan):
             )["entries"][0]["entries"][0]["entries"][0],
         ],
         [
-            plan.i.test_case_report(
+            plan.interactive.test_case_report(
                 test_uid="CallableTarget",
                 suite_uid="AnotherSuite",
                 case_uid="case",
@@ -366,7 +366,7 @@ def _get_actual_reports(plan):
             )["entries"][0]["entries"][0]["entries"][0],
         ],
         [
-            plan.i.test_case_report(
+            plan.interactive.test_case_report(
                 test_uid="ScheduledTest1",
                 suite_uid="Suite",
                 case_uid="case",
@@ -374,7 +374,7 @@ def _get_actual_reports(plan):
             )["entries"][0]["entries"][0]["entries"][0],
         ],
         [
-            plan.i.test_case_report(
+            plan.interactive.test_case_report(
                 test_uid="ScheduledTest2",
                 suite_uid="Suite",
                 case_uid="case",
@@ -437,7 +437,7 @@ def main():
     plan.run()
 
     # Run tests
-    plan.i.run_all_tests()
+    plan.interactive.run_all_tests()
 
     # Check reports
     _compare_reports(
@@ -447,7 +447,7 @@ def main():
         actual_reports=_get_actual_reports(plan),
         ignore=["file_path", "line_no", "machine_time", "utc_time"],
     )
-    assert plan.i.report.passed is False
+    assert plan.interactive.report.passed is False
 
     # Apply code changes, two testcase changed and one newly added
     for module_info in TEST_SUITE_MODULES:
@@ -458,16 +458,16 @@ def main():
                 fp_w.write(fp_r.read().format(**module_info.updated_value))
 
     # Reload code from changed files and update report
-    plan.i.reload(rebuild_dependencies=True)
-    plan.i.reload_report()
+    plan.interactive.reload(rebuild_dependencies=True)
+    plan.interactive.reload_report()
 
     # Run tests again
-    plan.i.run_all_tests()
+    plan.interactive.run_all_tests()
 
     # 2 suites has new testcase added respectively
     actual_reports = _get_actual_reports(plan)
     actual_reports[1].append(
-        plan.i.test_case_report(
+        plan.interactive.test_case_report(
             test_uid="InnerTest",
             suite_uid="Suite",
             case_uid="another_case",
@@ -475,7 +475,7 @@ def main():
         )["entries"][0]["entries"][0]["entries"][0]
     )
     actual_reports[5].append(
-        plan.i.test_case_report(
+        plan.interactive.test_case_report(
             test_uid="ScheduledTest2",
             suite_uid="Suite",
             case_uid="another_case",
@@ -492,7 +492,7 @@ def main():
         ignore=["file_path", "line_no", "machine_time", "utc_time"],
     )
 
-    assert plan.i.report.passed is True
+    assert plan.interactive.report.passed is True
 
 
 if __name__ == "__main__":

--- a/tests/functional/testplan/runnable/interactive/test_api.py
+++ b/tests/functional/testplan/runnable/interactive/test_api.py
@@ -1,5 +1,4 @@
 """Functional tests for interactive HTTP API."""
-import time
 import functools
 from unittest import mock
 
@@ -7,13 +6,15 @@ import pytest
 import requests
 
 import testplan
-from testplan.testing import multitest
-from testplan.testing.multitest import driver
-from testplan.report import Status, RuntimeStatus
 from testplan.common import entity
 from testplan.common.utils import timing
 from testplan.exporters.testing import XMLExporter
-
+from testplan.report import Status, RuntimeStatus
+from testplan.testing import multitest
+from testplan.testing.multitest import driver
+from tests.functional.testplan.runnable.interactive import (
+    wait_for_interactive_start,
+)
 from tests.unit.testplan.runnable.interactive import test_api
 
 
@@ -81,11 +82,7 @@ def plan(tmpdir):
             )
         )
         plan.run()
-        timing.wait(
-            lambda: plan.interactive.http_handler_info[0] is not None,
-            300,
-            raise_on_timeout=True,
-        )
+        wait_for_interactive_start(plan)
         yield plan
         plan.abort()
 
@@ -131,11 +128,7 @@ def plan2(tmpdir):
             )
         )
         plan.run()
-        timing.wait(
-            lambda: plan.interactive.http_handler_info[0] is not None,
-            300,
-            raise_on_timeout=True,
-        )
+        wait_for_interactive_start(plan)
         yield plan
         plan.abort()
 
@@ -207,11 +200,7 @@ def plan3(tmpdir):
             )
         )
         plan.run()
-        timing.wait(
-            lambda: plan.interactive.http_handler_info[0] is not None,
-            300,
-            raise_on_timeout=True,
-        )
+        wait_for_interactive_start(plan)
         yield plan
         plan.abort()
 

--- a/tests/functional/testplan/runnable/interactive/test_interactive.py
+++ b/tests/functional/testplan/runnable/interactive/test_interactive.py
@@ -1,8 +1,6 @@
 """Interactive mode tests."""
 
 import os
-import sys
-import threading
 
 import requests
 from pytest_test_filters import skip_on_windows
@@ -15,8 +13,10 @@ from testplan.common.utils.logger import USER_INFO
 from testplan.common.utils.timing import wait
 from testplan.environment import LocalEnvironment
 from testplan.testing.multitest import MultiTest, testsuite, testcase
-from testplan.testing.multitest.driver.app import App
 from testplan.testing.multitest.driver.tcp import TCPServer, TCPClient
+from tests.functional.testplan.runnable.interactive import (
+    wait_for_interactive_start,
+)
 
 THIS_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
@@ -108,48 +108,50 @@ def test_top_level_tests():
         plan.add(make_multitest("1"))
         plan.add(make_multitest("2"))
         plan.run()
-        wait(lambda: bool(plan.i.http_handler_info), 5, raise_on_timeout=True)
-        assert isinstance(plan.i.test("Test1"), MultiTest)
-        assert isinstance(plan.i.test("Test2"), MultiTest)
+        wait_for_interactive_start(plan)
+        assert isinstance(plan.interactive.test("Test1"), MultiTest)
+        assert isinstance(plan.interactive.test("Test2"), MultiTest)
 
-        # print_report(plan.i.report(serialized=True))
+        # print_report(plan.interactive.report(serialized=True))
 
         # TESTS AND ASSIGNED RUNNERS
-        assert list(plan.i.all_tests()) == ["Test1", "Test2"]
+        assert list(plan.interactive.all_tests()) == ["Test1", "Test2"]
 
         # OPERATE TEST DRIVERS (start/stop)
-        resources = [res.uid() for res in plan.i.test("Test2").resources]
+        resources = [
+            res.uid() for res in plan.interactive.test("Test2").resources
+        ]
         assert resources == ["server", "client"]
-        for resource in plan.i.test("Test2").resources:
+        for resource in plan.interactive.test("Test2").resources:
             assert resource.status == resource.STATUS.NONE
-        plan.i.start_test_resources("Test2")  # START
-        for resource in plan.i.test("Test2").resources:
+        plan.interactive.start_test_resources("Test2")  # START
+        for resource in plan.interactive.test("Test2").resources:
             assert resource.status == resource.STATUS.STARTED
-        plan.i.stop_test_resources("Test2")  # STOP
-        for resource in plan.i.test("Test2").resources:
+        plan.interactive.stop_test_resources("Test2")  # STOP
+        for resource in plan.interactive.test("Test2").resources:
             assert resource.status == resource.STATUS.STOPPED
 
         # RESET REPORTS
-        plan.i.reset_all_tests()
+        plan.interactive.reset_all_tests()
         from .reports.basic_top_level_reset import REPORT as BTLReset
 
         assert (
             compare(
                 BTLReset,
-                plan.i.report.serialize(),
+                plan.interactive.report.serialize(),
                 ignore=["hash", "information", "line_no"],
             )[0]
             is True
         )
 
         # RUN ALL TESTS
-        plan.i.run_all_tests()
+        plan.interactive.run_all_tests()
         from .reports.basic_top_level import REPORT as BTLevel
 
         assert (
             compare(
                 BTLevel,
-                plan.i.report.serialize(),
+                plan.interactive.report.serialize(),
                 ignore=[
                     "hash",
                     "information",
@@ -164,39 +166,39 @@ def test_top_level_tests():
         )
 
         # RESET REPORTS
-        plan.i.reset_all_tests()
+        plan.interactive.reset_all_tests()
         from .reports.basic_top_level_reset import REPORT as BTLReset
 
         assert (
             compare(
                 BTLReset,
-                plan.i.report.serialize(),
+                plan.interactive.report.serialize(),
                 ignore=["hash", "information"],
             )[0]
             is True
         )
 
         # RUN SINGLE TESTSUITE (CUSTOM NAME)
-        plan.i.run_test_suite("Test2", "TCPSuite - Custom_1")
+        plan.interactive.run_test_suite("Test2", "TCPSuite - Custom_1")
         from .reports.basic_run_suite_test2 import REPORT as BRSTest2
 
         assert (
             compare(
                 BRSTest2,
-                plan.i.test_report("Test2"),
+                plan.interactive.test_report("Test2"),
                 ignore=["hash"],
             )[0]
             is True
         )
 
         # RUN SINGLE TESTCASE
-        plan.i.run_test_case("Test1", "*", "basic_case__arg_1")
+        plan.interactive.run_test_case("Test1", "*", "basic_case__arg_1")
         from .reports.basic_run_case_test1 import REPORT as BRCTest1
 
         assert (
             compare(
                 BRCTest1,
-                plan.i.test_report("Test1"),
+                plan.interactive.test_report("Test1"),
                 ignore=[
                     "hash",
                     "information",
@@ -233,15 +235,17 @@ def test_top_level_environment():
             )
         )
         plan.run()
-        wait(lambda: bool(plan.i.http_handler_info), 5, raise_on_timeout=True)
+        wait_for_interactive_start(plan)
 
         assert len(plan.resources.environments.envs) == 1
 
         # Create an environment using serializable arguments.
         # That is mandatory for HTTP usage.
-        plan.i.create_new_environment("env2")
-        plan.i.add_environment_resource("env2", "TCPServer", name="server")
-        plan.i.add_environment_resource(
+        plan.interactive.create_new_environment("env2")
+        plan.interactive.add_environment_resource(
+            "env2", "TCPServer", name="server"
+        )
+        plan.interactive.add_environment_resource(
             "env2",
             "TCPClient",
             name="client",
@@ -250,23 +254,23 @@ def test_top_level_environment():
             _ctx_port_ctx_driver="server",
             _ctx_port_ctx_value="{{port}}",
         )
-        plan.i.add_created_environment("env2")
+        plan.interactive.add_created_environment("env2")
 
         assert len(plan.resources.environments.envs) == 2
 
         for env_uid in ("env1", "env2"):
-            env = plan.i.get_environment(env_uid)
+            env = plan.interactive.get_environment(env_uid)
             assert isinstance(env, entity.Environment)
             resources = [res.uid() for res in env]
             assert resources == ["server", "client"]
             for resource in env:
                 assert resource.status == resource.STATUS.NONE
-            plan.i.start_environment(env_uid)  # START
+            plan.interactive.start_environment(env_uid)  # START
 
             # INSPECT THE CONTEXT WHEN STARTED
-            env_context = plan.i.get_environment_context(env_uid)
+            env_context = plan.interactive.get_environment_context(env_uid)
             for resource in [res.uid() for res in env]:
-                res_context = plan.i.environment_resource_context(
+                res_context = plan.interactive.environment_resource_context(
                     env_uid, resource_uid=resource
                 )
                 assert env_context[resource] == res_context
@@ -275,27 +279,27 @@ def test_top_level_environment():
                 assert res_context["port"] > 0
 
             # CUSTOM RESOURCE OPERATIONS
-            plan.i.environment_resource_operation(
+            plan.interactive.environment_resource_operation(
                 env_uid, "server", "accept_connection"
             )
-            plan.i.environment_resource_operation(
+            plan.interactive.environment_resource_operation(
                 env_uid, "client", "send_text", msg="hello"
             )
-            received = plan.i.environment_resource_operation(
+            received = plan.interactive.environment_resource_operation(
                 env_uid, "server", "receive_text"
             )
             assert received == "hello"
-            plan.i.environment_resource_operation(
+            plan.interactive.environment_resource_operation(
                 env_uid, "server", "send_text", msg="worlds"
             )
-            received = plan.i.environment_resource_operation(
+            received = plan.interactive.environment_resource_operation(
                 env_uid, "client", "receive_text"
             )
             assert received == "worlds"
 
             for resource in env:
                 assert resource.status == resource.STATUS.STARTED
-            plan.i.stop_environment(env_uid)  # STOP
+            plan.interactive.stop_environment(env_uid)  # STOP
             for resource in env:
                 assert resource.status == resource.STATUS.STOPPED
 
@@ -319,12 +323,8 @@ def test_env_operate():
         plan.add(make_multitest("2"))
 
         plan.run()
-        wait(
-            lambda: plan.i.http_handler_info[0] is not None,
-            5,
-            raise_on_timeout=True,
-        )
-        addr = "http://{}:{}".format(*plan.i.http_handler_info)
+        wait_for_interactive_start(plan)
+        addr = "http://{}:{}".format(*plan.interactive.http_handler_info)
 
         response = requests.get(f"{addr}/api/v1/interactive/report/tests")
         assert response.ok
@@ -332,7 +332,7 @@ def test_env_operate():
         current_report = response.json()
         assert len(current_report) == 2
 
-        for resource in plan.i.test("Test2").resources:
+        for resource in plan.interactive.test("Test2").resources:
             assert resource.status == resource.STATUS.NONE
 
         test2_report = current_report[1].copy()
@@ -346,14 +346,14 @@ def test_env_operate():
         )
         assert response.ok
 
-        current_test2_report = plan.i.report["Test2"]
+        current_test2_report = plan.interactive.report["Test2"]
         assert current_test2_report.env_status in (
             entity.ResourceStatus.STARTING,
             entity.ResourceStatus.STARTED,
         )
 
         wait(
-            lambda: plan.i.report["Test2"].env_status
+            lambda: plan.interactive.report["Test2"].env_status
             == entity.ResourceStatus.STARTED,
             5,
             raise_on_timeout=True,
@@ -374,13 +374,13 @@ def test_env_operate():
         )
         assert response.ok
 
-        current_test2_report = plan.i.report["Test2"]
+        current_test2_report = plan.interactive.report["Test2"]
         assert current_test2_report.env_status in (
             entity.ResourceStatus.STOPPING,
             entity.ResourceStatus.STOPPED,
         )
         wait(
-            lambda: plan.i.report["Test2"].env_status
+            lambda: plan.interactive.report["Test2"].env_status
             == entity.ResourceStatus.STOPPED,
             5,
             raise_on_timeout=True,
@@ -406,9 +406,9 @@ def test_abort_handler():
         plan.add(multitest)
         plan.run()
         # NOTE: wait until the HTTP handler is available
-        wait(lambda: bool(plan.i.http_handler_info), 5, raise_on_timeout=True)
+        wait_for_interactive_start(plan)
 
-        plan.i.start_test_resources("Test1")
+        plan.interactive.start_test_resources("Test1")
         for resource in multitest.resources:
             wait(
                 lambda: resource.status == resource.STATUS.STARTED,
@@ -416,7 +416,7 @@ def test_abort_handler():
                 raise_on_timeout=True,
             )
         # NOTE: triggering abortion for the interactive handler mocking API
-        plan.i.abort()
+        plan.interactive.abort()
         for resource in multitest.resources:
             wait(
                 lambda: resource.status == resource.STATUS.STOPPED,


### PR DESCRIPTION

## Bug / Requirement Description
Interactive tests are flaky as some times the interactive handler did not start when the test start run. This is because of a wait with an always true predicate

## Solution description
- the wait for interactive is now uniformized
- instead of a bool(tuple) which is always true check the first item of tupple for Noneness
- plan.i => plan.interactive to make some sense


## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
