### PR TITLE
remove warning from signalhandler install falure

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -10,6 +10,7 @@ import threading
 import time
 import traceback
 from collections import OrderedDict, deque
+from contextlib import suppress
 from typing import (
     Callable,
     Deque,
@@ -1677,14 +1678,10 @@ class RunnableManager(Entity):
         :rtype: :py:class:
             `RunnableResult <testplan.common.entity.base.RunnableResult>`
         """
-        try:
+        with suppress(ValueError):
+            # best effort signal handling
             for sig in self._cfg.abort_signals:
                 signal.signal(sig, self._handle_abort)
-        except ValueError:
-            self.logger.warning(
-                "Not able to install signal handler -"
-                " signal only works in main thread"
-            )
 
         execute_as_thread(
             self._runnable.run,


### PR DESCRIPTION
## Bug / Requirement Description
The log does not have an added value, as signal handling is best effort anyway. 
But may litter the std out for no good reason, especially in tests.


## Solution description
suppress the exception silently

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
