### PR TITLE
Feature/interactive fast stop

### DIFF
--- a/doc/newsfragments/2278_new.fast_kill.rst
+++ b/doc/newsfragments/2278_new.fast_kill.rst
@@ -1,0 +1,4 @@
+In interactive mode when testplan is stopped with ctr-c, instead of properly shutting down the tests, which can take
+even minutes for a complex environment, now a fast kill approach is killing all started test processes forcefully.
+The same happens when a testplan script is interrupted by ctr-c, or with the SIGINT signal. SIGTERM will shutdown the
+test gracefully.


### PR DESCRIPTION
## Bug / Requirement Description
Proper startup can take minutes for a complex environment. During development when using the interactive mode devs would like to be fast on stop and restart. 

## Solution description
Now if ctrl-c is used in interactive mode the testplan and all of its child process is forecfully killed

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
