### PR TITLE
Fix PDFExporter cannot render result.matplot with RemotePool

### DIFF
--- a/doc/newsfragments/2719_changed.fix_pdf.rst
+++ b/doc/newsfragments/2719_changed.fix_pdf.rst
@@ -1,0 +1,1 @@
+Fix PDFExporter cannot render result.matplot with RemotePool.

--- a/testplan/runners/pools/remote.py
+++ b/testplan/runners/pools/remote.py
@@ -173,6 +173,18 @@ class RemoteWorker(ProcessWorker, RemoteResource):
             self.logger.error(msg)
             raise RuntimeError(msg)
 
+    def _rebase_assertion(self, result) -> None:
+        if isinstance(result, dict) and "source_path" in result:
+            result["source_path"] = rebase_path(
+                result["source_path"],
+                self._remote_plan_runpath,
+                self._get_plan().runpath,
+            )
+        else:
+            entries = getattr(result, "entries", [])
+            for entry in entries:
+                self._rebase_assertion(entry)
+
     def rebase_attachment(self, result) -> None:
         """Rebase the path of attachment from remote to local"""
 
@@ -183,6 +195,7 @@ class RemoteWorker(ProcessWorker, RemoteResource):
                     self._remote_plan_runpath,
                     self._get_plan().runpath,
                 )
+            self._rebase_assertion(result.report)
 
     def rebase_task_path(self, task) -> None:
         """Rebase the path of task from local to remote"""


### PR DESCRIPTION
## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
