### PR TITLE
result.fix.match() assertion will use the tags present in the expected message when include_only_expected parameter set to True

### DIFF
--- a/doc/newsfragments/2691_changed.fix_match_assertion.rst
+++ b/doc/newsfragments/2691_changed.fix_match_assertion.rst
@@ -1,1 +1,1 @@
-py:meth:`result.fix.match() <testplan.testing.multitest.result.FixNamespace.match>` assertion now supports repeating groups when a FIX message is specified in the ``include_tags`` or ``exclude_tags`` parameters.
+py:meth:`result.fix.match() <testplan.testing.multitest.result.FixNamespace.match>` assertion now only compares the tags present in the expected message when ``include_tags`` parameter set to `True`.

--- a/doc/newsfragments/2691_changed.fix_match_assertion.rst
+++ b/doc/newsfragments/2691_changed.fix_match_assertion.rst
@@ -1,0 +1,1 @@
+py:meth:`result.fix.match() <testplan.testing.multitest.result.FixNamespace.match>` assertion now supports repeating groups when a FixMessage object specified in the ``include_tags`` or ``exclude_tags`` parameters.

--- a/doc/newsfragments/2691_changed.fix_match_assertion.rst
+++ b/doc/newsfragments/2691_changed.fix_match_assertion.rst
@@ -1,1 +1,1 @@
-Introduced a new parameter ``include_only_tags_of_expected`` for py:meth:`result.fix.match() <testplan.testing.multitest.result.FixNamespace.match>` assertion, It will only compares the tags present in the expected message when the parameter is set to `True`.
+Introduced a new parameter ``include_only_expected`` for py:meth:`result.fix.match() <testplan.testing.multitest.result.FixNamespace.match>` assertion, It will only compares the tags present in the expected message when the parameter is set to `True`.

--- a/doc/newsfragments/2691_changed.fix_match_assertion.rst
+++ b/doc/newsfragments/2691_changed.fix_match_assertion.rst
@@ -1,1 +1,1 @@
-py:meth:`result.fix.match() <testplan.testing.multitest.result.FixNamespace.match>` assertion now only compares the tags present in the expected message when ``include_tags`` parameter set to `True`.
+Introduced a new parameter ``include_only_tags_of_expected`` for py:meth:`result.fix.match() <testplan.testing.multitest.result.FixNamespace.match>` assertion, It will only compares the tags present in the expected message when the parameter is set to `True`.

--- a/doc/newsfragments/2691_changed.fix_match_assertion.rst
+++ b/doc/newsfragments/2691_changed.fix_match_assertion.rst
@@ -1,1 +1,1 @@
-py:meth:`result.fix.match() <testplan.testing.multitest.result.FixNamespace.match>` assertion now supports repeating groups when a FixMessage object specified in the ``include_tags`` or ``exclude_tags`` parameters.
+py:meth:`result.fix.match() <testplan.testing.multitest.result.FixNamespace.match>` assertion now supports repeating groups when a FIX message is specified in the ``include_tags`` or ``exclude_tags`` parameters.

--- a/doc/newsfragments/2691_changed.fix_match_assertion.rst
+++ b/doc/newsfragments/2691_changed.fix_match_assertion.rst
@@ -1,1 +1,1 @@
-Introduced a new parameter ``include_only_expected`` for py:meth:`result.fix.match() <testplan.testing.multitest.result.FixNamespace.match>` assertion, It will only compares the tags present in the expected message when the parameter is set to `True`.
+Introduced a new parameter ``include_only_expected`` for py:meth:`result.fix.match() <testplan.testing.multitest.result.FixNamespace.match>` assertion. It will only compare the tags present in the expected message when the parameter is set to `True`.

--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -535,7 +535,8 @@ def _cmp_dicts(
                 lhs=lhs_val,
                 rhs=rhs_val,
                 ignore=ignore,
-                only=only[iter_key] if isinstance(only, dict) and iter_key in only
+                only=only[iter_key]
+                if isinstance(only, dict) and iter_key in only
                 else only,
                 key=iter_key,
                 report_mode=report_mode,
@@ -678,7 +679,8 @@ def _rec_compare(
                 lhs=lhs_item,
                 rhs=rhs_item,
                 ignore=ignore,
-                only=only[i] if isinstance(only, list) and i < len(only)
+                only=only[i]
+                if isinstance(only, list) and i < len(only)
                 else only,
                 key=None,
                 report_mode=report_mode,

--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -246,8 +246,8 @@ class Not(Callable):
 
     def __eq__(self, other):
         return (
-                self.__class__ == other.__class__
-                and self.callable_obj == other.callable_obj
+            self.__class__ == other.__class__
+            and self.callable_obj == other.callable_obj
         )
 
 
@@ -476,13 +476,13 @@ def _partition(results):
 
 
 def _cmp_dicts(
-        lhs: Dict,
-        rhs: Dict,
-        ignore: Container,
-        include: Container,
-        report_mode: int,
-        value_cmp_func: Union[Callable, None],
-        include_only_keys_of_rhs: bool = False,
+    lhs: Dict,
+    rhs: Dict,
+    ignore: Container,
+    include: Container,
+    report_mode: int,
+    value_cmp_func: Union[Callable, None],
+    include_only_keys_of_rhs: bool = False,
 ) -> Tuple[str, List]:
     """
     Compares two dictionaries with optional restriction to keys,
@@ -559,15 +559,15 @@ def _cmp_dicts(
 
 
 def _rec_compare(
-        lhs,
-        rhs,
-        ignore,
-        include,
-        key,
-        report_mode,
-        value_cmp_func,
-        _regex_adapter=RegexAdapter,
-        include_only_keys_of_rhs=False,
+    lhs,
+    rhs,
+    ignore,
+    include,
+    key,
+    report_mode,
+    value_cmp_func,
+    _regex_adapter=RegexAdapter,
+    include_only_keys_of_rhs=False,
 ):
     """
     Recursive deep comparison implementation
@@ -581,9 +581,9 @@ def _rec_compare(
 
     ## NO VALS
     if (
-            ((lhs_cat == Category.ABSENT) or (rhs_cat == Category.ABSENT))
-            and (lhs_cat != Category.CALLABLE)
-            and (rhs_cat != Category.CALLABLE)
+        ((lhs_cat == Category.ABSENT) or (rhs_cat == Category.ABSENT))
+        and (lhs_cat != Category.CALLABLE)
+        and (rhs_cat != Category.CALLABLE)
     ):
         return _build_res(
             key=key,
@@ -732,8 +732,8 @@ def untyped_fixtag(x, y):
 
     if not ret:
         if any(
-                isinstance(val, float) or isinstance(val, decimal.Decimal)
-                for val in (x, y)
+            isinstance(val, float) or isinstance(val, decimal.Decimal)
+            for val in (x, y)
         ):
             x_, y_ = (
                 val.rstrip("0").rstrip(".") if "." in val else val
@@ -781,15 +781,15 @@ class ReportOptions(enum.Enum):
 
 
 def compare(
-        lhs: Dict,
-        rhs: Dict,
-        ignore: List[Hashable] = None,
-        include: List[Hashable] = None,
-        report_mode=ReportOptions.ALL,
-        value_cmp_func: typing_Callable[[Any, Any], bool] = COMPARE_FUNCTIONS[
-            "native_equality"
-        ],
-        include_only_keys_of_rhs: bool = False,
+    lhs: Dict,
+    rhs: Dict,
+    ignore: List[Hashable] = None,
+    include: List[Hashable] = None,
+    report_mode=ReportOptions.ALL,
+    value_cmp_func: typing_Callable[[Any, Any], bool] = COMPARE_FUNCTIONS[
+        "native_equality"
+    ],
+    include_only_keys_of_rhs: bool = False,
 ) -> Tuple[bool, List[Tuple]]:
     """
     Compare two iterable key, value objects (e.g. dict or dict-like mapping)
@@ -951,21 +951,21 @@ def _to_error(cmpr_tuple, weights):
         """
         absent_side = (0, None, Absent.descr)
         return (
-                sum(
-                    [
-                        (0 if entry[2] == absent_side else 1)
-                        for entry in comparisons
-                    ]
-                )
-                == 0
+            sum(
+                [
+                    (0 if entry[2] == absent_side else 1)
+                    for entry in comparisons
+                ]
+            )
+            == 0
         ) or (
-                sum(
-                    [
-                        (0 if entry[3] == absent_side else 1)
-                        for entry in comparisons
-                    ]
-                )
-                == 0
+            sum(
+                [
+                    (0 if entry[3] == absent_side else 1)
+                    for entry in comparisons
+                ]
+            )
+            == 0
         )
 
     pass_flag, comparisons = cmpr_tuple
@@ -982,7 +982,7 @@ def _to_error(cmpr_tuple, weights):
         comparison_match = comparison[1]
         # tag exists and matches, or ignored
         if (comparison_match == Match.PASS) or (
-                comparison_match == Match.IGNORED
+            comparison_match == Match.IGNORED
         ):
             match_err = 0
         else:  # tag exists, but wrong data or tag is missing
@@ -1017,12 +1017,12 @@ class Expected:
 
 
 def unordered_compare(
-        match_name,
-        values,
-        comparisons,
-        description=None,
-        tag_weightings=None,
-        value_cmp_func=COMPARE_FUNCTIONS["native_equality"],
+    match_name,
+    values,
+    comparisons,
+    description=None,
+    tag_weightings=None,
+    value_cmp_func=COMPARE_FUNCTIONS["native_equality"],
 ):
     """
     Matches a list of expected values against a list of expected comparisons.
@@ -1350,12 +1350,12 @@ class DictmatchAllResult:
 
 
 def dictmatch_all_compat(
-        match_name,
-        comparisons,
-        values,
-        description,
-        key_weightings,
-        value_cmp_func=COMPARE_FUNCTIONS["native_equality"],
+    match_name,
+    comparisons,
+    values,
+    description,
+    key_weightings,
+    value_cmp_func=COMPARE_FUNCTIONS["native_equality"],
 ):
     """This is being used for internal compatibility."""
     matches = unordered_compare(

--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -507,7 +507,10 @@ def _cmp_dicts(
         if key in ignore:
             should_ignore = True
         elif only is not None:
-            should_ignore = key not in only
+            if isinstance(only, Iterable):
+                should_ignore = key not in only
+            else:
+                should_ignore = not key == only
         else:
             should_ignore = False
         return should_ignore
@@ -521,12 +524,14 @@ def _cmp_dicts(
                 #            enforce ignorance of match
                 results.append(
                     _rec_compare(
-                        lhs_val,
-                        rhs_val,
-                        ignore,
-                        only,
-                        iter_key,
-                        report_mode,
+                        lhs=lhs_val,
+                        rhs=rhs_val,
+                        ignore=ignore,
+                        only=only[iter_key]
+                        if isinstance(only, dict) and iter_key in only
+                        else only,
+                        key=iter_key,
+                        report_mode=report_mode,
                         value_cmp_func=None,
                     )
                 )
@@ -680,7 +685,9 @@ def _rec_compare(
                 rhs=rhs_item,
                 ignore=ignore,
                 only=only[i]
-                if isinstance(only, list) and i < len(only)
+                if isinstance(only, Iterable)
+                and i < len(only)
+                and isinstance(only[i], dict)
                 else only,
                 key=None,
                 report_mode=report_mode,

--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -506,11 +506,10 @@ def _cmp_dicts(
         """
         if key in ignore:
             should_ignore = True
+        elif only is True:
+            should_ignore = key not in rhs.keys()
         elif only is not None:
-            if isinstance(only, Iterable):
-                should_ignore = key not in only
-            else:
-                should_ignore = not key == only
+            should_ignore = key not in only
         else:
             should_ignore = False
         return should_ignore
@@ -527,9 +526,7 @@ def _cmp_dicts(
                         lhs=lhs_val,
                         rhs=rhs_val,
                         ignore=ignore,
-                        only=only[iter_key]
-                        if isinstance(only, dict) and iter_key in only
-                        else only,
+                        only=only,
                         key=iter_key,
                         report_mode=report_mode,
                         value_cmp_func=None,
@@ -540,9 +537,7 @@ def _cmp_dicts(
                 lhs=lhs_val,
                 rhs=rhs_val,
                 ignore=ignore,
-                only=only[iter_key]
-                if isinstance(only, dict) and iter_key in only
-                else only,
+                only=only,
                 key=iter_key,
                 report_mode=report_mode,
                 value_cmp_func=value_cmp_func,
@@ -678,17 +673,13 @@ def _rec_compare(
     if lhs_cat == rhs_cat == Category.ITERABLE:
         results = []
         match = Match.IGNORED
-        for i, (lhs_item, rhs_item) in enumerate(zip_longest(lhs, rhs)):
+        for lhs_item, rhs_item in zip_longest(lhs, rhs):
             # iterate all elems in both iterable non-mapping objects
             result = _rec_compare(
                 lhs=lhs_item,
                 rhs=rhs_item,
                 ignore=ignore,
-                only=only[i]
-                if isinstance(only, Iterable)
-                and i < len(only)
-                and isinstance(only[i], dict)
-                else only,
+                only=only,
                 key=None,
                 report_mode=report_mode,
                 value_cmp_func=value_cmp_func,

--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -532,13 +532,14 @@ def _cmp_dicts(
                 )
         else:
             result = _rec_compare(
-                lhs_val,
-                rhs_val,
-                ignore,
-                only,
-                iter_key,
-                report_mode,
-                value_cmp_func,
+                lhs=lhs_val,
+                rhs=rhs_val,
+                ignore=ignore,
+                only=only[iter_key] if isinstance(only, dict) and iter_key in only
+                else only,
+                key=iter_key,
+                report_mode=report_mode,
+                value_cmp_func=value_cmp_func,
             )
             # Decide whether to keep or discard the result, depending on the
             # reporting mode.
@@ -671,13 +672,14 @@ def _rec_compare(
     if lhs_cat == rhs_cat == Category.ITERABLE:
         results = []
         match = Match.IGNORED
-        for lhs_item, rhs_item in zip_longest(lhs, rhs):
+        for i, (lhs_item, rhs_item) in enumerate(zip_longest(lhs, rhs)):
             # iterate all elems in both iterable non-mapping objects
             result = _rec_compare(
-                lhs_item,
-                rhs_item,
-                ignore,
-                only,
+                lhs=lhs_item,
+                rhs=rhs_item,
+                ignore=ignore,
+                only=only[i] if isinstance(only, list) and i < len(only)
+                else only,
                 key=None,
                 report_mode=report_mode,
                 value_cmp_func=value_cmp_func,

--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -482,7 +482,7 @@ def _cmp_dicts(
     include: Container,
     report_mode: int,
     value_cmp_func: Union[Callable, None],
-    include_only_keys_of_rhs: bool = False,
+    include_only_rhs: bool = False,
 ) -> Tuple[str, List]:
     """
     Compares two dictionaries with optional restriction to keys,
@@ -505,7 +505,7 @@ def _cmp_dicts(
         """
         if key in ignore:
             should_ignore = True
-        elif include_only_keys_of_rhs is True:
+        elif include_only_rhs is True:
             should_ignore = key not in rhs.keys()
         elif include is not None:
             should_ignore = key not in include
@@ -529,7 +529,7 @@ def _cmp_dicts(
                         key=iter_key,
                         report_mode=report_mode,
                         value_cmp_func=None,
-                        include_only_keys_of_rhs=include_only_keys_of_rhs,
+                        include_only_rhs=include_only_rhs,
                     )
                 )
         else:
@@ -541,7 +541,7 @@ def _cmp_dicts(
                 key=iter_key,
                 report_mode=report_mode,
                 value_cmp_func=value_cmp_func,
-                include_only_keys_of_rhs=include_only_keys_of_rhs,
+                include_only_rhs=include_only_rhs,
             )
             # Decide whether to keep or discard the result, depending on the
             # reporting mode.
@@ -567,7 +567,7 @@ def _rec_compare(
     report_mode,
     value_cmp_func,
     _regex_adapter=RegexAdapter,
-    include_only_keys_of_rhs=False,
+    include_only_rhs=False,
 ):
     """
     Recursive deep comparison implementation
@@ -685,7 +685,7 @@ def _rec_compare(
                 key=None,
                 report_mode=report_mode,
                 value_cmp_func=value_cmp_func,
-                include_only_keys_of_rhs=include_only_keys_of_rhs,
+                include_only_rhs=include_only_rhs,
             )
 
             match = Match.combine(match, result[1])
@@ -707,7 +707,7 @@ def _rec_compare(
             include=include,
             report_mode=report_mode,
             value_cmp_func=value_cmp_func,
-            include_only_keys_of_rhs=include_only_keys_of_rhs,
+            include_only_rhs=include_only_rhs,
         )
         lhs_vals, rhs_vals = _partition(results)
         return _build_res(
@@ -789,7 +789,7 @@ def compare(
     value_cmp_func: typing_Callable[[Any, Any], bool] = COMPARE_FUNCTIONS[
         "native_equality"
     ],
-    include_only_keys_of_rhs: bool = False,
+    include_only_rhs: bool = False,
 ) -> Tuple[bool, List[Tuple]]:
     """
     Compare two iterable key, value objects (e.g. dict or dict-like mapping)
@@ -807,7 +807,7 @@ def compare(
                         for more detail.
     :param value_cmp_func: function to compare values in a dict. Defaults
         to COMPARE_FUNCTIONS['native_equality'].
-    :param include_only_keys_of_rhs: use the keys present in rhs.
+    :param include_only_rhs: use the keys present in rhs.
 
     :return: Tuple of comparison bool ``(passed: True, failed: False)`` and
              a description object for the testdb report
@@ -847,7 +847,7 @@ def compare(
         include=include,
         report_mode=report_mode,
         value_cmp_func=value_cmp_func,
-        include_only_keys_of_rhs=include_only_keys_of_rhs,
+        include_only_rhs=include_only_rhs,
     )
 
     # For the keys in include not matching anything,

--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -493,6 +493,7 @@ def _cmp_dicts(
     :param include: collection of keys to restrict comparison to
     :param report_mode: report option code
     :param value_cmp_func: value comparison function
+    :param include_only_rhs: use the keys present in rhs.
     :return: pair of match result and comparison result
     """
 

--- a/testplan/testing/multitest/entries/assertions.py
+++ b/testplan/testing/multitest/entries/assertions.py
@@ -1308,7 +1308,7 @@ class DictMatch(Assertion):
         self,
         value: Dict,
         expected: Dict,
-        include_only_keys_of_expected: bool = False,
+        include_only_expected: bool = False,
         include_keys: List[Hashable] = None,
         exclude_keys: List[Hashable] = None,
         report_mode=comparison.ReportOptions.ALL,
@@ -1320,7 +1320,7 @@ class DictMatch(Assertion):
     ):
         self.value = value
         self.expected = expected
-        self.include_only_keys_of_expected = include_only_keys_of_expected
+        self.include_only_expected = include_only_expected
         self.include_keys = include_keys
         self.exclude_keys = exclude_keys
         self.actual_description = actual_description
@@ -1342,7 +1342,7 @@ class DictMatch(Assertion):
             include=self.include_keys,
             report_mode=self._report_mode,
             value_cmp_func=self._value_cmp_func,
-            include_only_keys_of_rhs=self.include_only_keys_of_expected,
+            include_only_rhs=self.include_only_expected,
         )
         self.comparison = flatten_dict_comparison(cmp_result)
         return passed
@@ -1358,7 +1358,7 @@ class FixMatch(DictMatch):
         self,
         value: Dict,
         expected: Dict,
-        include_only_tags_of_expected: bool = False,
+        include_only_expected: bool = False,
         include_tags: List[Hashable] = None,
         exclude_tags: List[Hashable] = None,
         report_mode=comparison.ReportOptions.ALL,
@@ -1383,7 +1383,7 @@ class FixMatch(DictMatch):
         super(FixMatch, self).__init__(
             value=value,
             expected=expected,
-            include_only_keys_of_expected=include_only_tags_of_expected,
+            include_only_expected=include_only_expected,
             include_keys=include_tags,
             exclude_keys=exclude_tags,
             report_mode=report_mode,

--- a/testplan/testing/multitest/entries/assertions.py
+++ b/testplan/testing/multitest/entries/assertions.py
@@ -19,8 +19,6 @@ import sys
 import tempfile
 import lxml
 
-from ms.fix import FixMessage
-
 from testplan.common.utils.convert import make_tuple, flatten_dict_comparison
 from testplan.common.utils import comparison, difflib
 from testplan.common.utils.process import subprocess_popen
@@ -1370,7 +1368,13 @@ class FixMatch(DictMatch):
         strings.
         """
 
-        def get_taglist_from_msg(msg: FixMessage):
+        def get_taglist_from_msg(msg: dict) -> list:
+            """
+            Extracts tags from a FIX message-like object.
+
+            :param msg: FIX message-like object
+            :return: list of tags
+            """
             taglist = []
             for tag in list(msg):
                 taglist.append(tag)
@@ -1400,10 +1404,10 @@ class FixMatch(DictMatch):
             value=value,
             expected=expected,
             include_keys=get_taglist_from_msg(include_tags)
-            if isinstance(include_tags, FixMessage)
+            if isinstance(include_tags, dict)
             else include_tags,
             exclude_keys=get_taglist_from_msg(exclude_tags)
-            if isinstance(exclude_tags, FixMessage)
+            if isinstance(exclude_tags, dict)
             else exclude_tags,
             report_mode=report_mode,
             description=description,

--- a/testplan/testing/multitest/entries/assertions.py
+++ b/testplan/testing/multitest/entries/assertions.py
@@ -9,6 +9,7 @@ use the result of that call to set its ``passed`` attribute.
 import cmath
 import collections
 import decimal
+import lxml
 import numbers
 import operator
 import os
@@ -17,8 +18,7 @@ import re
 import subprocess
 import sys
 import tempfile
-
-import lxml
+from typing import Dict, Hashable, List
 
 from testplan.common.utils.convert import make_tuple, flatten_dict_comparison
 from testplan.common.utils import comparison, difflib
@@ -1306,21 +1306,21 @@ class DictMatch(Assertion):
 
     def __init__(
         self,
-        value,
-        expected,
-        use_keys_of_expected=False,
-        include_keys=None,
-        exclude_keys=None,
+        value: Dict,
+        expected: Dict,
+        include_only_keys_of_expected: bool = False,
+        include_keys: List[Hashable] = None,
+        exclude_keys: List[Hashable] = None,
         report_mode=comparison.ReportOptions.ALL,
-        description=None,
-        category=None,
-        actual_description=None,
-        expected_description=None,
+        description: str = None,
+        category: str = None,
+        actual_description: str = None,
+        expected_description: str = None,
         value_cmp_func=comparison.COMPARE_FUNCTIONS["native_equality"],
     ):
         self.value = value
         self.expected = expected
-        self.use_keys_of_expected = use_keys_of_expected
+        self.include_only_keys_of_expected = include_only_keys_of_expected
         self.include_keys = include_keys
         self.exclude_keys = exclude_keys
         self.actual_description = actual_description
@@ -1339,9 +1339,10 @@ class DictMatch(Assertion):
             lhs=self.value,
             rhs=self.expected,
             ignore=self.exclude_keys,
-            only=True if self.use_keys_of_expected else self.include_keys,
+            include=self.include_keys,
             report_mode=self._report_mode,
             value_cmp_func=self._value_cmp_func,
+            include_only_keys_of_rhs=self.include_only_keys_of_expected,
         )
         self.comparison = flatten_dict_comparison(cmp_result)
         return passed
@@ -1355,16 +1356,16 @@ class FixMatch(DictMatch):
 
     def __init__(
         self,
-        value,
-        expected,
-        use_tags_of_expected=False,
-        include_tags=None,
-        exclude_tags=None,
+        value: Dict,
+        expected: Dict,
+        include_only_tags_of_expected: bool = False,
+        include_tags: List[Hashable] = None,
+        exclude_tags: List[Hashable] = None,
         report_mode=comparison.ReportOptions.ALL,
-        description=None,
-        category=None,
-        actual_description=None,
-        expected_description=None,
+        description: str = None,
+        category: str = None,
+        actual_description: str = None,
+        expected_description: str = None,
     ):
         """
         If both FIX messages are typed, we enable strict type checking.
@@ -1382,7 +1383,7 @@ class FixMatch(DictMatch):
         super(FixMatch, self).__init__(
             value=value,
             expected=expected,
-            use_keys_of_expected=use_tags_of_expected,
+            include_only_keys_of_expected=include_only_tags_of_expected,
             include_keys=include_tags,
             exclude_keys=exclude_tags,
             report_mode=report_mode,

--- a/testplan/testing/multitest/entries/assertions.py
+++ b/testplan/testing/multitest/entries/assertions.py
@@ -1403,12 +1403,8 @@ class FixMatch(DictMatch):
         super(FixMatch, self).__init__(
             value=value,
             expected=expected,
-            include_keys=get_taglist_from_msg(include_tags)
-            if isinstance(include_tags, dict)
-            else include_tags,
-            exclude_keys=get_taglist_from_msg(exclude_tags)
-            if isinstance(exclude_tags, dict)
-            else exclude_tags,
+            include_keys=include_tags,
+            exclude_keys=exclude_tags,
             report_mode=report_mode,
             description=description,
             category=category,

--- a/testplan/testing/multitest/entries/assertions.py
+++ b/testplan/testing/multitest/entries/assertions.py
@@ -17,6 +17,7 @@ import re
 import subprocess
 import sys
 import tempfile
+
 import lxml
 
 from testplan.common.utils.convert import make_tuple, flatten_dict_comparison
@@ -1367,31 +1368,6 @@ class FixMatch(DictMatch):
         Otherwise, if either side is untyped we will compare the values as
         strings.
         """
-
-        def get_taglist_from_msg(msg: dict) -> list:
-            """
-            Extracts tags from a FIX message-like object.
-
-            :param msg: FIX message-like object
-            :return: list of tags
-            """
-            taglist = []
-            for tag in list(msg):
-                taglist.append(tag)
-                if isinstance(msg[tag], list):
-                    # we hit a repeating group
-                    for fixfragment in msg[tag]:
-                        taglist.extend(
-                            [
-                                fragment_tag
-                                for fragment_tag in get_taglist_from_msg(
-                                    fixfragment
-                                )
-                                if fragment_tag not in taglist
-                            ]
-                        )
-            return taglist
-
         typed_value = getattr(value, "typed_values", False)
         typed_expected = getattr(expected, "typed_values", False)
 

--- a/testplan/testing/multitest/entries/assertions.py
+++ b/testplan/testing/multitest/entries/assertions.py
@@ -1308,6 +1308,7 @@ class DictMatch(Assertion):
         self,
         value,
         expected,
+        use_keys_of_expected=False,
         include_keys=None,
         exclude_keys=None,
         report_mode=comparison.ReportOptions.ALL,
@@ -1319,6 +1320,7 @@ class DictMatch(Assertion):
     ):
         self.value = value
         self.expected = expected
+        self.use_keys_of_expected = use_keys_of_expected
         self.include_keys = include_keys
         self.exclude_keys = exclude_keys
         self.actual_description = actual_description
@@ -1337,7 +1339,7 @@ class DictMatch(Assertion):
             lhs=self.value,
             rhs=self.expected,
             ignore=self.exclude_keys,
-            only=self.include_keys,
+            only=True if self.use_keys_of_expected else self.include_keys,
             report_mode=self._report_mode,
             value_cmp_func=self._value_cmp_func,
         )
@@ -1355,6 +1357,7 @@ class FixMatch(DictMatch):
         self,
         value,
         expected,
+        use_tags_of_expected=False,
         include_tags=None,
         exclude_tags=None,
         report_mode=comparison.ReportOptions.ALL,
@@ -1379,6 +1382,7 @@ class FixMatch(DictMatch):
         super(FixMatch, self).__init__(
             value=value,
             expected=expected,
+            use_keys_of_expected=use_tags_of_expected,
             include_keys=include_tags,
             exclude_keys=exclude_tags,
             report_mode=report_mode,

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -1244,7 +1244,8 @@ class FixNamespace(AssertionNamespace):
             expected=expected,
             description=description,
             category=category,
-            include_tags=include_tags,
+            include_tags=expected if include_tags is True
+            else include_tags,
             exclude_tags=exclude_tags,
             report_mode=report_mode,
             expected_description=expected_description,

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -12,7 +12,7 @@ import platform
 import re
 import threading
 from functools import wraps
-from typing import Callable, Optional
+from typing import Callable, Optional, Dict, Hashable, List, Any
 import functools
 
 from testplan import defaults
@@ -938,17 +938,20 @@ class DictNamespace(AssertionNamespace):
     @assertion
     def match(
         self,
-        actual,
-        expected,
-        description=None,
-        category=None,
-        include_keys=None,
-        exclude_keys=None,
+        actual: Dict,
+        expected: Dict,
+        use_keys_of_expected: bool = False,
+        description: str = None,
+        category: str = None,
+        include_keys: List[Hashable] = None,
+        exclude_keys: List[Hashable] = None,
         report_mode=comparison.ReportOptions.ALL,
-        actual_description=None,
-        expected_description=None,
-        value_cmp_func=comparison.COMPARE_FUNCTIONS["native_equality"],
-    ):
+        actual_description: str = None,
+        expected_description: str = None,
+        value_cmp_func: Callable[
+            [Any, Any], bool
+        ] = comparison.COMPARE_FUNCTIONS["native_equality"],
+    ) -> bool:
         r"""
         Matches two dictionaries, supports nested data. Custom
         comparators can be used as values on the ``expected`` dict.
@@ -985,40 +988,31 @@ class DictNamespace(AssertionNamespace):
             )
 
         :param actual: Original dictionary.
-        :type actual: ``dict``.
         :param expected: Comparison dictionary, can contain custom comparators
                          (e.g. regex, lambda functions)
-        :type expected: ``dict``
+        :param use_keys_of_expected: Use the keys present in the expected message.
         :param include_keys: Keys to exclusively consider in the comparison.
-        :type include_keys: ``list`` of ``object`` (items must be hashable)
         :param exclude_keys: Keys to ignore in the comparison.
-        :type exclude_keys: ``list`` of ``object`` (items must be hashable)
         :param report_mode: Specify which comparisons should be kept and
                             reported. Default option is to report all
                             comparisons but this can be restricted if desired.
                             See ReportOptions enum for more detail.
-        :type report_mode: ``testplan.common.utils.comparison.ReportOptions``
         :param actual_description: Column header description for original dict.
-        :type actual_description: ``str``
         :param expected_description: Column header
                                     description for expected dict.
-        :type expected_description: ``str``
         :param description: Text description for the assertion.
-        :type description: ``str``
         :param category: Custom category that will be used for summarization.
-        :type category: ``str``
         :param value_cmp_func: Function to use to compare values in expected
                                and actual dicts. Defaults to using
                                `operator.eq()`.
-        :type value_cmp_func: ``Callable[[Any, Any], bool]``
 
         :return: Assertion pass status
-        :rtype: ``bool``
         """
         entry = assertions.DictMatch(
             value=actual,
             expected=expected,
             description=description,
+            use_keys_of_expected=use_keys_of_expected,
             include_keys=include_keys,
             exclude_keys=exclude_keys,
             report_mode=report_mode,
@@ -1178,16 +1172,17 @@ class FixNamespace(AssertionNamespace):
     @assertion
     def match(
         self,
-        actual,
-        expected,
-        description=None,
-        category=None,
-        include_tags=None,
-        exclude_tags=None,
+        actual: Dict,
+        expected: Dict,
+        use_tags_of_expected: bool = False,
+        description: str = None,
+        category: str = None,
+        include_tags: List[Hashable] = None,
+        exclude_tags: List[Hashable] = None,
         report_mode=comparison.ReportOptions.ALL,
-        actual_description=None,
-        expected_description=None,
-    ):
+        actual_description: str = None,
+        expected_description: str = None,
+    ) -> bool:
         """
         Matches two FIX messages, supports repeating groups (nested data).
         Custom comparators can be used as values on the ``expected`` msg.
@@ -1212,40 +1207,31 @@ class FixNamespace(AssertionNamespace):
             )
 
         :param actual: Original FIX message.
-        :type actual: ``dict``
         :param expected: Expected FIX message, can include compiled
                          regex patterns or callables for
                          advanced comparison.
-        :type expected: ``dict``
+        :param use_tags_of_expected: Use the tags present in the expected message.
         :param include_tags: Tags to exclusively consider in the comparison.
-                             It will automatically use the tags from the expected message when set to True.
-        :type include_tags: ``list`` of ``object`` (items must be hashable) or ``bool``
         :param exclude_tags: Keys to ignore in the comparison.
-        :type exclude_tags: ``list`` of ``object`` (items must be hashable)
         :param report_mode: Specify which comparisons should be kept and
                             reported. Default option is to report all
                             comparisons but this can be restricted if desired.
                             See ReportOptions enum for more detail.
-        :type report_mode: ``testplan.common.utils.comparison.ReportOptions``
         :param actual_description: Column header description for original msg.
-        :type actual_description: ``str``
         :param expected_description: Column header
                                      description for expected msg.
-        :type expected_description: ``str``
         :param description: Text description for the assertion.
-        :type description: ``str``
         :param category: Custom category that will be used for summarization.
-        :type category: ``str``
 
         :return: Assertion pass status
-        :rtype: ``bool``
         """
         entry = assertions.FixMatch(
             value=actual,
             expected=expected,
             description=description,
             category=category,
-            include_tags=expected if include_tags is True else include_tags,
+            use_tags_of_expected=use_tags_of_expected,
+            include_tags=include_tags,
             exclude_tags=exclude_tags,
             report_mode=report_mode,
             expected_description=expected_description,

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -940,7 +940,7 @@ class DictNamespace(AssertionNamespace):
         self,
         actual: Dict,
         expected: Dict,
-        use_keys_of_expected: bool = False,
+        include_only_keys_of_expected: bool = False,
         description: str = None,
         category: str = None,
         include_keys: List[Hashable] = None,
@@ -951,7 +951,7 @@ class DictNamespace(AssertionNamespace):
         value_cmp_func: Callable[
             [Any, Any], bool
         ] = comparison.COMPARE_FUNCTIONS["native_equality"],
-    ) -> bool:
+    ) -> assertions.DictMatch:
         r"""
         Matches two dictionaries, supports nested data. Custom
         comparators can be used as values on the ``expected`` dict.
@@ -990,7 +990,7 @@ class DictNamespace(AssertionNamespace):
         :param actual: Original dictionary.
         :param expected: Comparison dictionary, can contain custom comparators
                          (e.g. regex, lambda functions)
-        :param use_keys_of_expected: Use the keys present in the expected message.
+        :param include_only_keys_of_expected: Use the keys present in the expected message.
         :param include_keys: Keys to exclusively consider in the comparison.
         :param exclude_keys: Keys to ignore in the comparison.
         :param report_mode: Specify which comparisons should be kept and
@@ -1012,7 +1012,7 @@ class DictNamespace(AssertionNamespace):
             value=actual,
             expected=expected,
             description=description,
-            use_keys_of_expected=use_keys_of_expected,
+            include_only_keys_of_expected=include_only_keys_of_expected,
             include_keys=include_keys,
             exclude_keys=exclude_keys,
             report_mode=report_mode,
@@ -1174,7 +1174,7 @@ class FixNamespace(AssertionNamespace):
         self,
         actual: Dict,
         expected: Dict,
-        use_tags_of_expected: bool = False,
+        include_only_tags_of_expected: bool = False,
         description: str = None,
         category: str = None,
         include_tags: List[Hashable] = None,
@@ -1182,7 +1182,7 @@ class FixNamespace(AssertionNamespace):
         report_mode=comparison.ReportOptions.ALL,
         actual_description: str = None,
         expected_description: str = None,
-    ) -> bool:
+    ) -> assertions.FixMatch:
         """
         Matches two FIX messages, supports repeating groups (nested data).
         Custom comparators can be used as values on the ``expected`` msg.
@@ -1210,7 +1210,7 @@ class FixNamespace(AssertionNamespace):
         :param expected: Expected FIX message, can include compiled
                          regex patterns or callables for
                          advanced comparison.
-        :param use_tags_of_expected: Use the tags present in the expected message.
+        :param include_only_tags_of_expected: Use the tags present in the expected message.
         :param include_tags: Tags to exclusively consider in the comparison.
         :param exclude_tags: Keys to ignore in the comparison.
         :param report_mode: Specify which comparisons should be kept and
@@ -1230,7 +1230,7 @@ class FixNamespace(AssertionNamespace):
             expected=expected,
             description=description,
             category=category,
-            use_tags_of_expected=use_tags_of_expected,
+            include_only_tags_of_expected=include_only_tags_of_expected,
             include_tags=include_tags,
             exclude_tags=exclude_tags,
             report_mode=report_mode,

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -990,7 +990,7 @@ class DictNamespace(AssertionNamespace):
         :param actual: Original dictionary.
         :param expected: Comparison dictionary, can contain custom comparators
                          (e.g. regex, lambda functions)
-        :param include_only_expected: Use the keys present in the expected message.
+        :param include_only_expected: Use the keys present in the expected dictionary.
         :param include_keys: Keys to exclusively consider in the comparison.
         :param exclude_keys: Keys to ignore in the comparison.
         :param report_mode: Specify which comparisons should be kept and

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -1217,9 +1217,10 @@ class FixNamespace(AssertionNamespace):
                          regex patterns or callables for
                          advanced comparison.
         :type expected: ``dict``
-        :param include_tags: Tags to exclusively consider in the comparison. (Accepts FixMessage object)
-        :type include_tags: ``list`` of ``object`` (items must be hashable)
-        :param exclude_tags: Keys to ignore in the comparison. (Accepts FixMessage object)
+        :param include_tags: Tags to exclusively consider in the comparison.
+                             It will automatically use the tags from the expected message when set to True.
+        :type include_tags: ``list`` of ``object`` (items must be hashable) or ``bool``
+        :param exclude_tags: Keys to ignore in the comparison.
         :type exclude_tags: ``list`` of ``object`` (items must be hashable)
         :param report_mode: Specify which comparisons should be kept and
                             reported. Default option is to report all
@@ -1244,8 +1245,7 @@ class FixNamespace(AssertionNamespace):
             expected=expected,
             description=description,
             category=category,
-            include_tags=expected if include_tags is True
-            else include_tags,
+            include_tags=expected if include_tags is True else include_tags,
             exclude_tags=exclude_tags,
             report_mode=report_mode,
             expected_description=expected_description,

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -1217,9 +1217,9 @@ class FixNamespace(AssertionNamespace):
                          regex patterns or callables for
                          advanced comparison.
         :type expected: ``dict``
-        :param include_tags: Tags to exclusively consider in the comparison.
+        :param include_tags: Tags to exclusively consider in the comparison. (Accepts FixMessage object)
         :type include_tags: ``list`` of ``object`` (items must be hashable)
-        :param exclude_tags: Keys to ignore in the comparison.
+        :param exclude_tags: Keys to ignore in the comparison. (Accepts FixMessage object)
         :type exclude_tags: ``list`` of ``object`` (items must be hashable)
         :param report_mode: Specify which comparisons should be kept and
                             reported. Default option is to report all

--- a/testplan/testing/multitest/result.py
+++ b/testplan/testing/multitest/result.py
@@ -940,7 +940,7 @@ class DictNamespace(AssertionNamespace):
         self,
         actual: Dict,
         expected: Dict,
-        include_only_keys_of_expected: bool = False,
+        include_only_expected: bool = False,
         description: str = None,
         category: str = None,
         include_keys: List[Hashable] = None,
@@ -990,7 +990,7 @@ class DictNamespace(AssertionNamespace):
         :param actual: Original dictionary.
         :param expected: Comparison dictionary, can contain custom comparators
                          (e.g. regex, lambda functions)
-        :param include_only_keys_of_expected: Use the keys present in the expected message.
+        :param include_only_expected: Use the keys present in the expected message.
         :param include_keys: Keys to exclusively consider in the comparison.
         :param exclude_keys: Keys to ignore in the comparison.
         :param report_mode: Specify which comparisons should be kept and
@@ -1012,7 +1012,7 @@ class DictNamespace(AssertionNamespace):
             value=actual,
             expected=expected,
             description=description,
-            include_only_keys_of_expected=include_only_keys_of_expected,
+            include_only_expected=include_only_expected,
             include_keys=include_keys,
             exclude_keys=exclude_keys,
             report_mode=report_mode,
@@ -1174,7 +1174,7 @@ class FixNamespace(AssertionNamespace):
         self,
         actual: Dict,
         expected: Dict,
-        include_only_tags_of_expected: bool = False,
+        include_only_expected: bool = False,
         description: str = None,
         category: str = None,
         include_tags: List[Hashable] = None,
@@ -1210,7 +1210,7 @@ class FixNamespace(AssertionNamespace):
         :param expected: Expected FIX message, can include compiled
                          regex patterns or callables for
                          advanced comparison.
-        :param include_only_tags_of_expected: Use the tags present in the expected message.
+        :param include_only_expected: Use the tags present in the expected message.
         :param include_tags: Tags to exclusively consider in the comparison.
         :param exclude_tags: Keys to ignore in the comparison.
         :param report_mode: Specify which comparisons should be kept and
@@ -1230,7 +1230,7 @@ class FixNamespace(AssertionNamespace):
             expected=expected,
             description=description,
             category=category,
-            include_only_tags_of_expected=include_only_tags_of_expected,
+            include_only_expected=include_only_expected,
             include_tags=include_tags,
             exclude_tags=exclude_tags,
             report_mode=report_mode,

--- a/tests/unit/testplan/testing/multitest/test_result.py
+++ b/tests/unit/testplan/testing/multitest/test_result.py
@@ -787,7 +787,7 @@ class TestFIXNamespace:
             actual=actual,
             expected=expected,
             description="complex fix message comparison",
-            include_only_tags_of_expected=True,
+            include_only_expected=True,
         )
         assert len(fix_ns.result.entries) == 1
 

--- a/tests/unit/testplan/testing/multitest/test_result.py
+++ b/tests/unit/testplan/testing/multitest/test_result.py
@@ -787,7 +787,7 @@ class TestFIXNamespace:
             actual=actual,
             expected=expected,
             description="complex fix message comparison",
-            use_tags_of_expected=True,
+            include_only_tags_of_expected=True,
         )
         assert len(fix_ns.result.entries) == 1
 

--- a/tests/unit/testplan/testing/multitest/test_result.py
+++ b/tests/unit/testplan/testing/multitest/test_result.py
@@ -730,6 +730,130 @@ class TestFIXNamespace:
             and _700[4] == (None, "ABSENT")  # key not found in expected data
         )
 
+    def test_subset_of_tags_with_only_true(self, fix_ns):
+        """Test the comparison result in flattened entries."""
+
+        expected = {
+            35: "D",
+            55: 2,
+            555: [
+                {
+                    601: "A",
+                    683: [
+                        {689: "a"},
+                        {689: "b"},
+                    ],
+                },
+                {
+                    601: "B",
+                    683: [
+                        {688: "c", 689: "c"},
+                        {688: "d"},
+                    ],
+                },
+            ],
+        }
+
+        actual = {
+            35: "D",
+            22: 5,
+            55: 2,
+            38: 5,
+            555: [
+                {
+                    600: "A",
+                    601: "A",
+                    683: [
+                        {688: "a", 689: "a"},
+                        {688: "b", 689: "b"},
+                    ],
+                },
+                {
+                    600: "B",
+                    601: "B",
+                    55: 4,
+                    683: [
+                        {688: "c", 689: "c"},
+                        {688: "d", 689: "d"},
+                    ],
+                },
+            ],
+        }
+
+        assert fix_ns.match(
+            actual=actual,
+            expected=expected,
+            description="complex fix message comparison",
+            include_tags=True,
+        )
+        assert len(fix_ns.result.entries) == 1
+
+        # Comparison result is a list of list items in below format:
+        # [indent, key, result, (act_type, act_value), (exp_type, exp_value)]
+
+        comp_result = fix_ns.result.entries[0].comparison
+
+        _35 = [item for item in comp_result if item[1] == 35][0]
+        assert _35[0] == 0 and _35[2][0].lower() == comparison.Match.PASS
+        _22 = [item for item in comp_result if item[1] == 22][0]
+        assert (
+            _22[0] == 0
+            and _22[2][0].lower() == comparison.Match.IGNORED
+            and _22[3][1] == "5"
+            and _22[4][1] == "ABSENT"
+        )
+        _55 = [item for item in comp_result if item[1] == 55][0]
+        assert _55[0] == 0 and _55[2][0].lower() == comparison.Match.PASS
+        _38 = [item for item in comp_result if item[1] == 38][0]
+        assert (
+            _38[0] == 0
+            and _38[2][0].lower() == comparison.Match.IGNORED
+            and _38[3][1] == "5"
+            and _38[4][1] == "ABSENT"
+        )
+        _555 = [item for item in comp_result if item[1] == 555][0]
+        assert _555[0] == 0 and _555[2][0].lower() == comparison.Match.PASS
+        _600 = [item for item in comp_result if item[1] == 600][0]
+        assert (
+            _600[0] == 1
+            and _600[2][0].lower() == comparison.Match.IGNORED
+            and _600[3][1] == "A"
+            and _600[4][1] == "ABSENT"
+        )
+        _601 = [item for item in comp_result if item[1] == 601][0]
+        assert _601[0] == 1 and _601[2][0].lower() == comparison.Match.PASS
+        _683 = [item for item in comp_result if item[1] == 683][0]
+        assert _683[0] == 1 and _683[2][0].lower() == comparison.Match.PASS
+        _688_1, _688_2, _688_3, _688_4 = [
+            item for item in comp_result if item[1] == 688
+        ]
+        assert (
+            _688_1[0] == 2
+            and _688_1[2][0].lower() == comparison.Match.IGNORED
+            and _688_1[3][1] == "a"
+            and _688_1[4][1] == "ABSENT"
+        )
+        assert (
+            _688_2[0] == 2
+            and _688_2[2][0].lower() == comparison.Match.IGNORED
+            and _688_2[3][1] == "b"
+            and _688_2[4][1] == "ABSENT"
+        )
+        assert _688_3[0] == 2 and _688_3[2][0].lower() == comparison.Match.PASS
+        assert _688_4[0] == 2 and _688_4[2][0].lower() == comparison.Match.PASS
+        _689_1, _689_2, _689_3, _689_4 = [
+            item for item in comp_result if item[1] == 689
+        ]
+        assert _689_1[0] == 2 and _689_1[2][0].lower() == comparison.Match.PASS
+        assert _689_2[0] == 2 and _689_2[2][0].lower() == comparison.Match.PASS
+        assert _689_3[0] == 2 and _689_3[2][0].lower() == comparison.Match.PASS
+        assert (
+            _689_4[0] == 2
+            and _689_4[2][0].lower() == comparison.Match.IGNORED
+            and _689_4[3][1] == "d"
+            and _689_4[4][1] == "ABSENT"
+        )
+
 
 class TestResultBaseNamespace:
     """Test assertions and other methods in the base result.* namespace."""

--- a/tests/unit/testplan/testing/multitest/test_result.py
+++ b/tests/unit/testplan/testing/multitest/test_result.py
@@ -787,7 +787,7 @@ class TestFIXNamespace:
             actual=actual,
             expected=expected,
             description="complex fix message comparison",
-            include_tags=True,
+            use_tags_of_expected=True,
         )
         assert len(fix_ns.result.entries) == 1
 

--- a/tests/unit/testplan/testing/multitest/test_result.py
+++ b/tests/unit/testplan/testing/multitest/test_result.py
@@ -802,8 +802,14 @@ class TestFIXNamespace:
             and _22[3][1] == "5"
             and _22[4][1] == "ABSENT"
         )
-        _55 = [item for item in comp_result if item[1] == 55][0]
-        assert _55[0] == 0 and _55[2][0].lower() == comparison.Match.PASS
+        _55_1, _55_2 = [item for item in comp_result if item[1] == 55]
+        assert _55_1[0] == 0 and _55_1[2][0].lower() == comparison.Match.PASS
+        assert (
+            _55_2[0] == 1
+            and _55_2[2][0].lower() == comparison.Match.IGNORED
+            and _55_2[3][1] == "4"
+            and _55_2[4][1] == "ABSENT"
+        )
         _38 = [item for item in comp_result if item[1] == 38][0]
         assert (
             _38[0] == 0

--- a/tests/unit/testplan/testing/multitest/test_result.py
+++ b/tests/unit/testplan/testing/multitest/test_result.py
@@ -730,8 +730,11 @@ class TestFIXNamespace:
             and _700[4] == (None, "ABSENT")  # key not found in expected data
         )
 
-    def test_subset_of_tags_with_only_true(self, fix_ns):
-        """Test the comparison result in flattened entries."""
+    def test_subset_of_tags_with_include_tags_true(self, fix_ns):
+        """
+        Test the comparison result when the expected FIX message with repeating groups is the subset of the actual
+        while include_tags set to True.
+        """
 
         expected = {
             35: "D",


### PR DESCRIPTION
## Solution description
result.fix.match() assertion will use the tags present in the expected message when include_only_expected parameter set to True

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
