### PR TITLE
Test Environment delayed evaluation

### DIFF
--- a/doc/en/download/Driver.rst
+++ b/doc/en/download/Driver.rst
@@ -17,3 +17,26 @@ test_plan.py
 suites.py
 +++++++++
 .. literalinclude:: ../../../examples/Driver/Dependency/suites.py
+
+.. _example_env_buider:
+
+Environment Builder
+===================
+
+Required files:
+  - :download:`test_plan.py <../../../examples/Driver/EnvBuilder/test_plan.py>`
+  - :download:`suites.py <../../../examples/Driver/EnvBuilder/suites.py>`
+  - :download:`env_builder.py <../../../examples/Driver/EnvBuilder/env_builder.py>`
+
+test_plan.py
+++++++++++++
+.. literalinclude:: ../../../examples/Driver/EnvBuilder/test_plan.py
+
+suites.py
++++++++++
+.. literalinclude:: ../../../examples/Driver/EnvBuilder/suites.py
+
+env_builder.py
+++++++++++++++
+.. literalinclude:: ../../../examples/Driver/EnvBuilder/env_builder.py
+

--- a/doc/newsfragments/2805_new.env_builder.rst
+++ b/doc/newsfragments/2805_new.env_builder.rst
@@ -1,0 +1,2 @@
+``environment`` ``dependencies`` and ``initial_context`` parameters of :py:class:`~testplan.testing.base.Test` (thus its
+inheritances) now supports callable arguments. Please refer to :ref:`example <example_env_buider>` for usage.

--- a/examples/Driver/Dependency/test_plan.py
+++ b/examples/Driver/Dependency/test_plan.py
@@ -51,9 +51,9 @@ def main(plan):
         port=context("server_2", "{{port}}"),
     )
 
-    # If driver A depends on driver B to start, we will put driver A in the key
+    # If driver A is a dependency for driver B to start, we put driver A in the key
     # of dependencies dictionary and driver B as its corresponding value, so
-    # driver A is before driver B visually.
+    # visually driver A appears before driver B.
 
     # Here server_1 and server_2 will be started simutaneously to reduce the
     # overall test running time while not violating the dependencies.

--- a/examples/Driver/EnvBuilder/env_builder.py
+++ b/examples/Driver/EnvBuilder/env_builder.py
@@ -1,0 +1,64 @@
+"""
+This demonstrates one possible way of implementing of EnvBuilder class.
+"""
+import functools
+
+from testplan.common.utils.context import context
+from testplan.testing.multitest.driver.tcp import TCPClient, TCPServer
+
+
+class EnvBuilder:
+    def __init__(self, env_name: str, drivers: list):
+        """
+        :param env_name: name of this env builder
+        :param drivers: list of drivers to be created
+        """
+        self.env_name = env_name
+        self.drivers = drivers
+        self.client_auto_connect = False if len(self.drivers) == 3 else True
+        self._client1 = None
+        self._client2 = None
+        self._server1 = None
+
+    def build_env(self):
+        return [getattr(self, driver_name) for driver_name in self.drivers]
+
+    def init_ctx(self):
+        return {"env_name": self.env_name}
+
+    def build_deps(self):
+        if len(self.drivers) == 2:
+            return {self.server1: self.client1}
+        elif len(self.drivers) == 3:
+            return {self.server1: (self.client1, self.client2)}
+
+    @property
+    # @functools.cached_property
+    def client1(self):
+        if not self._client1:
+            self._client1 = TCPClient(
+                name="client1",
+                host=context("server1", "{{host}}"),
+                port=context("server1", "{{port}}"),
+                connect_at_start=self.client_auto_connect,
+            )
+        return self._client1
+
+    @property
+    # @functools.cached_property
+    def client2(self):
+        if not self._client2:
+            self._client2 = TCPClient(
+                name="client2",
+                host=context("server1", "{{host}}"),
+                port=context("server1", "{{port}}"),
+                connect_at_start=self.client_auto_connect,
+            )
+        return self._client2
+
+    @property
+    # @functools.cached_property
+    def server1(self):
+        if not self._server1:
+            self._server1 = TCPServer(name="server1")
+        return self._server1

--- a/examples/Driver/EnvBuilder/env_builder.py
+++ b/examples/Driver/EnvBuilder/env_builder.py
@@ -1,7 +1,6 @@
 """
 This demonstrates one possible way of implementing of EnvBuilder class.
 """
-import functools
 
 from testplan.common.utils.context import context
 from testplan.testing.multitest.driver.tcp import TCPClient, TCPServer
@@ -33,7 +32,6 @@ class EnvBuilder:
             return {self.server1: (self.client1, self.client2)}
 
     @property
-    # @functools.cached_property
     def client1(self):
         if not self._client1:
             self._client1 = TCPClient(
@@ -45,7 +43,6 @@ class EnvBuilder:
         return self._client1
 
     @property
-    # @functools.cached_property
     def client2(self):
         if not self._client2:
             self._client2 = TCPClient(
@@ -57,7 +54,6 @@ class EnvBuilder:
         return self._client2
 
     @property
-    # @functools.cached_property
     def server1(self):
         if not self._server1:
             self._server1 = TCPServer(name="server1")

--- a/examples/Driver/EnvBuilder/suites.py
+++ b/examples/Driver/EnvBuilder/suites.py
@@ -1,0 +1,48 @@
+from testplan.testing.multitest import testsuite, testcase
+
+
+@testsuite
+class TestOneClient:
+    def setup(self, env, result):
+        result.log(f"Testing with [{env.env_name}] env")
+        env.server1.accept_connection()
+
+    @testcase
+    def test_send_and_receive_msg(self, env, result):
+        env.client1.send_text("hi server")
+        result.equal("hi server", env.server1.receive_text())
+
+        env.server1.send_text("hi client")
+        result.equal("hi client", env.client1.receive_text())
+
+
+@testsuite
+class TestTwoClients:
+    def setup(self, env, result):
+        result.log(f"Testing with [{env.env_name}] env")
+
+        env.client1.connect()
+        self.conn1 = env.server1.accept_connection()
+
+        env.client2.connect()
+        self.conn2 = env.server1.accept_connection()
+
+    @testcase
+    def test_send_and_receive_msg(self, env, result):
+        env.client1.send_text("hi server from client1")
+        env.client2.send_text("hi server from client2")
+
+        result.equal(
+            "hi server from client1",
+            env.server1.receive_text(conn_idx=self.conn1),
+        )
+        result.equal(
+            "hi server from client2",
+            env.server1.receive_text(conn_idx=self.conn2),
+        )
+
+        env.server1.send_text("hi client1", conn_idx=self.conn1)
+        env.server1.send_text("hi client2", conn_idx=self.conn2)
+
+        result.equal("hi client1", env.client1.receive_text())
+        result.equal("hi client2", env.client2.receive_text())

--- a/examples/Driver/EnvBuilder/test_plan.py
+++ b/examples/Driver/EnvBuilder/test_plan.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""
+This example demonstrates usage of callable object to construct environment,
+intial_context and dependencies for a multitest at runtime.
+"""
+
+import sys
+
+from testplan import test_plan
+from testplan.testing.multitest import MultiTest
+from env_builder import EnvBuilder
+from suites import TestOneClient, TestTwoClients
+
+
+@test_plan(name="EnvBuilderExample")
+def main(plan):
+
+    env_builder1 = EnvBuilder("One Client", ["client1", "server1"])
+    env_builder2 = EnvBuilder("Two Clients", ["client1", "client2", "server1"])
+    plan.add(
+        MultiTest(
+            name="TestOneClient",
+            suites=[TestOneClient()],
+            environment=env_builder1.build_env,
+            dependencies=env_builder1.build_deps,
+            initial_context=env_builder1.init_ctx,
+        )
+    )
+
+    plan.add(
+        MultiTest(
+            name="TestTwoClients",
+            suites=[TestTwoClients()],
+            environment=env_builder2.build_env,
+            dependencies=env_builder2.build_deps,
+            initial_context=env_builder2.init_ctx,
+        )
+    )
+
+
+if __name__ == "__main__":
+    res = main()
+    print("Exiting code: {}".format(res.exit_code))
+    sys.exit(res.exit_code)

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -473,7 +473,6 @@ class EntityConfig(Config):
         """
         return {
             ConfigOption("runpath"): Or(None, str, callable),
-            ConfigOption("initial_context", default={}): dict,
             ConfigOption("path_cleanup", default=False): bool,
             ConfigOption("status_wait_timeout", default=600): int,
             ConfigOption("abort_wait_timeout", default=300): int,
@@ -490,8 +489,6 @@ class Entity(logger.Loggable):
 
     :param runpath: Path to be used for temp/output files by entity.
     :type runpath: ``str`` or ``NoneType`` callable that returns ``str``
-    :param initial_context: Initial key: value pair context information.
-    :type initial_context: ``dict``
     :param path_cleanup: Remove previous runpath created dirs/files.
     :type path_cleanup: ``bool``
     :param status_wait_timeout: Timeout for wait status events.
@@ -964,15 +961,14 @@ class Runnable(Entity):
         start_threads, start_procs = self._get_start_info()
 
         self._add_step(self.setup)
-        self.pre_resource_steps()
-        self._add_step(self.resources.start)
+        self.add_pre_resource_steps()
+        self.add_start_resource_steps()
 
-        self.pre_main_steps()
-        self.main_batch_steps()
-        self.post_main_steps()
-
-        self._add_step(self.resources.stop, is_reversed=True)
-        self.post_resource_steps()
+        self.add_pre_main_steps()
+        self.add_main_batch_steps()
+        self.add_post_main_steps()
+        self.add_stop_resource_steps()
+        self.add_post_resource_steps()
         self._add_step(self.teardown)
 
         self._run()
@@ -1055,31 +1051,43 @@ class Runnable(Entity):
             self.result.step_results[step.__name__] = res
             self.status.update_metadata(**{str(step): res})
 
-    def pre_resource_steps(self):
+    def add_pre_resource_steps(self):
         """
         Runnable steps to run before environment started.
         """
         pass
 
-    def pre_main_steps(self):
+    def add_start_resource_steps(self):
+        """
+        Runnable steps to start environment
+        """
+        self._add_step(self.resources.start)
+
+    def add_pre_main_steps(self):
         """
         Runnable steps to run after environment started.
         """
         pass
 
-    def main_batch_steps(self):
+    def add_main_batch_steps(self):
         """
         Runnable steps to be executed while environment is running.
         """
         pass
 
-    def post_main_steps(self):
+    def add_post_main_steps(self):
         """
         Runnable steps to run before environment stopped.
         """
         pass
 
-    def post_resource_steps(self):
+    def add_stop_resource_steps(self):
+        """
+        Runnable steps to stop environment
+        """
+        self._add_step(self.resources.stop, is_reversed=True)
+
+    def add_post_resource_steps(self):
         """
         Runnable steps to run after environment stopped.
         """

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -963,9 +963,10 @@ class Runnable(Entity):
         self._add_step(self.setup)
         self.add_pre_resource_steps()
         self.add_start_resource_steps()
-
         self.add_pre_main_steps()
+
         self.add_main_batch_steps()
+
         self.add_post_main_steps()
         self.add_stop_resource_steps()
         self.add_post_resource_steps()

--- a/testplan/common/report/base.py
+++ b/testplan/common/report/base.py
@@ -345,6 +345,12 @@ class ReportGroup(Report):
         """
         return self.entries[self._index[uid]]
 
+    def has_uid(self, uid):
+        """
+        Has a child report of `uid`
+        """
+        return uid in self._index
+
     def __getitem__(self, uid):
         """Shortcut to `get_by_uid()` method via [] operator."""
         return self.get_by_uid(uid)

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -998,19 +998,19 @@ class TestRunner(Runnable):
         ) as fp:
             pass
 
-    def pre_resource_steps(self):
+    def add_pre_resource_steps(self):
         """Runnable steps to be executed before resources started."""
-        super(TestRunner, self).pre_resource_steps()
+        super(TestRunner, self).add_pre_resource_steps()
         self._add_step(self._record_start)
         self._add_step(self.make_runpath_dirs)
         self._add_step(self._configure_file_logger)
         self._add_step(self.calculate_pool_size)
 
-    def main_batch_steps(self):
+    def add_main_batch_steps(self):
         """Runnable steps to be executed while resources are running."""
         self._add_step(self._wait_ongoing)
 
-    def post_resource_steps(self):
+    def add_post_resource_steps(self):
         """Runnable steps to be executed after resources stopped."""
         self._add_step(self._stop_remote_services)
         self._add_step(self._create_result)
@@ -1020,7 +1020,7 @@ class TestRunner(Runnable):
         self._add_step(self._invoke_exporters)
         self._add_step(self._post_exporters)
         self._add_step(self._close_file_logger)
-        super(TestRunner, self).post_resource_steps()
+        super(TestRunner, self).add_post_resource_steps()
 
     def _wait_ongoing(self):
         # TODO: if a pool fails to initialize we could reschedule the tasks.

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -489,7 +489,6 @@ class TestRunnerIHandler(entity.Entity):
 
         exceptions = self.test(test_uid).resources.start_exceptions
         if exceptions:
-            self._log_env_errors(test_uid, exceptions.values())
             self._set_env_status(test_uid, entity.ResourceStatus.STOPPED)
             raise RuntimeError(
                 "Exception raised during starting drivers: {}".format(
@@ -520,7 +519,6 @@ class TestRunnerIHandler(entity.Entity):
 
         exceptions = self.test(test_uid).resources.stop_exceptions
         if exceptions:
-            self._log_env_errors(test_uid, exceptions.values())
             self._set_env_status(test_uid, entity.ResourceStatus.STOPPED)
             raise RuntimeError(
                 "Exception raised during stopping drivers: {}".format(

--- a/testplan/runners/pools/child.py
+++ b/testplan/runners/pools/child.py
@@ -345,7 +345,6 @@ def child_logic(args):
 
         # To eliminate a not needed runpath layer.
         def make_runpath_dirs(self):
-            print(11111111, self._runpath)
             self._runpath = self.cfg.runpath
 
     class NoRunpathThreadPool(Pool):

--- a/testplan/runners/pools/child.py
+++ b/testplan/runners/pools/child.py
@@ -345,6 +345,7 @@ def child_logic(args):
 
         # To eliminate a not needed runpath layer.
         def make_runpath_dirs(self):
+            print(11111111, self._runpath)
             self._runpath = self.cfg.runpath
 
     class NoRunpathThreadPool(Pool):

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -3,8 +3,7 @@ import os
 import subprocess
 import sys
 import warnings
-from typing import Dict, Generator, List, Optional
-
+from typing import Dict, Generator, List, Optional, Union, Callable, Iterable
 from schema import And, Or, Use
 
 from testplan import defaults
@@ -17,7 +16,8 @@ from testplan.common.entity import (
     RunnableResult,
 )
 from testplan.common.remote.remote_driver import RemoteDriver
-from testplan.common.utils import strings
+from testplan.common.utils import strings, interface
+from testplan.common.utils.composer import compose_contexts
 from testplan.common.utils.context import render
 from testplan.common.utils.process import (
     enforce_timeout,
@@ -70,11 +70,14 @@ class TestConfig(RunnableConfig):
                 test_name_sanity_check,
             ),
             ConfigOption("description", default=None): Or(str, None),
-            ConfigOption("environment", default=[]): [
-                Or(Resource, RemoteDriver)
-            ],
+            ConfigOption("environment", default=[]): Or(
+                [Or(Resource, RemoteDriver)], validate_func()
+            ),
             ConfigOption("dependencies", default=None): Or(
-                None, Use(parse_dependency)
+                Use(parse_dependency), validate_func()
+            ),
+            ConfigOption("initial_context", default={}): Or(
+                dict, validate_func()
             ),
             ConfigOption("before_start", default=None): start_stop_signature,
             ConfigOption("after_start", default=None): start_stop_signature,
@@ -115,8 +118,17 @@ class Test(Runnable):
     :type description: ``str``
     :param environment: List of
         :py:class:`drivers <testplan.tesitng.multitest.driver.base.Driver>` to
-        be started and made available on tests execution.
-    :type environment: ``list``
+        be started and made available on tests execution. Can also take a
+        callable that returns the list of drivers.
+    :type environment: ``list`` or ``callable``
+    :param dependencies: driver start-up dependencies as a directed graph,
+        e.g {server1: (client1, client2)} indicates server1 shall start before
+        client1 and client2. Can also take a callable that returns a dict.
+    :type dependencies: ``dict`` or ``callable``
+    :param initial_context: key: value pairs that will be made available as
+        context for drivers in environment. Can also take a callbale that
+        returns a dict.
+    :type initial_context: ``dict`` or ``callable``
     :param test_filter: Class with test filtering logic.
     :type test_filter: :py:class:`~testplan.testing.filtering.BaseFilter`
     :param test_sorter: Class with tests sorting logic.
@@ -146,7 +158,24 @@ class Test(Runnable):
     # Base test class only allows Test (top level) filtering
     filter_levels = [filtering.FilterLevel.TEST]
 
-    def __init__(self, **options):
+    def __init__(
+        self,
+        name: str,
+        description: str = None,
+        environment: Union[list, Callable] = None,
+        dependencies: Union[dict, Callable] = None,
+        initial_context: Union[dict, Callable] = None,
+        before_start: callable = None,
+        after_start: callable = None,
+        before_stop: callable = None,
+        after_stop: callable = None,
+        test_filter: filtering.BaseFilter = None,
+        test_sorter: ordering.BaseSorter = None,
+        stdout_style: test_styles.Style = None,
+        tags: Union[str, Iterable[str]] = None,
+        **options,
+    ):
+        options.update(self.filter_locals(locals()))
         super(Test, self).__init__(**options)
 
         if ":" in self.cfg.name:
@@ -156,18 +185,12 @@ class Test(Runnable):
                 )
             )
 
-        self.resources._initial_context = self.cfg.initial_context
-        for driver in self.cfg.environment:
-            driver.parent = self
-            driver.cfg.parent = self.cfg
-            self.resources.add(driver)
-
-        if self.cfg.dependencies is not None:
-            self.resources.set_dependency(self.cfg.dependencies)
-
         self._test_context = None
-        self._init_test_report()
         self._discover_path = None
+
+        self._init_test_report()
+        self._env_built = False
+        self._build_environment(delay=True)
 
     def __str__(self):
         return "{}[{}]".format(self.__class__.__name__, self.name)
@@ -366,19 +389,95 @@ class Test(Runnable):
     def _record_teardown_end(self):
         self.report.timer.end("teardown")
 
-    def pre_resource_steps(self):
+    def _init_context(self):
+        if callable(self.cfg.initial_context):
+            self.resources._initial_context = self.cfg.initial_context()
+        else:
+            self.resources._initial_context = self.cfg.initial_context
+
+    def _build_environment(self, delay: bool):
+        """
+        This method will execute at most twice, once with delay=True during __init__,
+        and then with delay=False during _run. It will be no-op if called more
+        than once in interactive mode.
+        :param delay: delay eval if self.cfg.environment is a callable
+        """
+
+        if self._env_built:
+            return
+
+        if delay:
+            if callable(self.cfg.environment):
+                return
+            else:
+                drivers = self.cfg.environment
+        else:
+            if callable(self.cfg.environment):
+                drivers = self.cfg.environment()
+            else:
+                return
+
+        for driver in drivers:
+            driver.parent = self
+            driver.cfg.parent = self.cfg
+            self.resources.add(driver)
+        self._env_built = True
+
+    def _set_dependencies(self):
+        if callable(self.cfg.dependencies):
+            deps = parse_dependency(self.cfg.dependencies())
+        else:
+            deps = self.cfg.dependencies
+        if deps:
+            self.resources.set_dependency(deps)
+
+    def add_pre_resource_steps(self):
         """Runnable steps to be executed before environment starts."""
         self._add_step(self._record_setup_start)
 
-    def pre_main_steps(self):
+        self._add_step(self._init_context)
+        self._add_step(self._build_environment, delay=False)
+        self._add_step(self._set_dependencies)
+
+    def add_start_resource_steps(self):
+        self._add_step(
+            self._run_resource_hook,
+            hook=self.cfg.before_start,
+            label="Before Start",
+        )
+
+        self._add_step(self.resources.start)
+
+        self._add_step(
+            self._run_resource_hook,
+            hook=self.cfg.after_start,
+            label="After Start",
+        )
+
+    def add_stop_resource_steps(self):
+        self._add_step(
+            self._run_resource_hook,
+            hook=self.cfg.before_stop,
+            label="Before Stop",
+        )
+
+        self._add_step(self.resources.stop, is_reversed=True)
+
+        self._add_step(
+            self._run_resource_hook,
+            hook=self.cfg.after_stop,
+            label="After Stop",
+        )
+
+    def add_pre_main_steps(self):
         """Runnable steps to run after environment started."""
         self._add_step(self._record_setup_end)
 
-    def post_main_steps(self):
+    def add_post_main_steps(self):
         """Runnable steps to run before environment stopped."""
         self._add_step(self._record_teardown_start)
 
-    def post_resource_steps(self):
+    def add_post_resource_steps(self):
         """Runnable steps to run after environment stopped."""
         self._add_step(self._record_teardown_end)
 
@@ -412,8 +511,15 @@ class Test(Runnable):
         The base implementation is very simple but may be overridden in sub-
         classes to run additional setup pre- and post-environment start.
         """
-        self.make_runpath_dirs()
-        self.resources.start()
+        # in case this is called more than once from interactive
+        self.report.timer.clear()
+
+        self._add_step(self.setup)
+        self.add_pre_resource_steps()
+        self.add_start_resource_steps()
+        self.add_pre_main_steps()
+
+        self._run()
 
     def stop_test_resources(self):
         """
@@ -421,15 +527,99 @@ class Test(Runnable):
         interactive mode and is very simple in this base Test class, but may
         be overridden by sub-classes.
         """
-        self.resources.stop()
 
-    def dry_run(self):
+        self.add_post_main_steps()
+        self.add_stop_resource_steps()
+        self.add_post_resource_steps()
+        self._add_step(self.teardown)
+
+        self._run()
+
+    def _run_resource_hook(self, hook, label):
         """
-        Return an empty report skeleton for this test including all
-        testsuites, testcases etc. hierarchy. Does not run any tests.
+        This method runs post/pre_start/stop hooks. User can optionally make
+        use of assertions if the function accepts both ``env`` and ``result``
+        arguments.
+
+        These functions are also run within report error logging context,
+        meaning that if something goes wrong we will have the stack trace
+        in the final report.
         """
+
+        if not hook:
+            return
+
+        suite_report = TestGroupReport(
+            name=label,
+            category=ReportCategories.TESTSUITE,
+            suite_related=True,
+            # TODO: use synthesized instead of suite_related
+            # category=ReportCategories.SYNTHESIZED,
+        )
+        if self.result.report.has_uid(label):
+            self.result.report[label] = suite_report
+        else:
+            self.result.report.append(suite_report)
+
+        case_report = TestCaseReport(
+            name=hook.__name__,
+            description=strings.get_docstring(hook),
+            suite_related=True,
+            # TODO: use synthesized instead of suite_related
+            # category=ReportCategories.SYNTHESIZED,
+        )
+        suite_report.append(case_report)
+        case_result = self.cfg.result(
+            stdout_style=self.stdout_style, _scratch=self.scratch
+        )
+        # TODO: we are not using runtime_environment here as it is multitest-only
+        try:
+            interface.check_signature(hook, ["env", "result"])
+            hook_args = (self.resources, case_result)
+        except interface.MethodSignatureMismatch:
+            interface.check_signature(hook, ["env"])
+            hook_args = (self.resources,)
+
+        with compose_contexts(
+            case_report.timer.record("run"),
+            case_report.logged_exceptions(),
+            self.watcher.save_covered_lines_to(self.report),
+        ):
+            hook(*hook_args)
+
+        case_report.extend(case_result.serialized_entries)
+        case_report.attachments.extend(case_result.attachments)
+
+        if self.get_stdout_style(case_report.passed).display_testcase:
+            self.log_testcase_status(case_report)
+
+        case_report.pass_if_empty()
+        case_report.runtime_status = RuntimeStatus.FINISHED
+        suite_report.runtime_status = RuntimeStatus.FINISHED
+
+    def _dry_run_resource_hook(self, hook, label):
+
+        if not hook:
+            return
+
+        suite_report = TestGroupReport(
+            name=label,
+            category=ReportCategories.TESTSUITE,
+            suite_related=True,
+            # TODO: use synthesized instead of suite_related
+            # category=ReportCategories.SYNTHESIZED,
+        )
+        case_report = TestCaseReport(
+            name=hook.__name__,
+            suite_related=True,
+            # TODO: use synthesized instead of suite_related
+            # category=ReportCategories.SYNTHESIZED,
+        )
+        suite_report.append(case_report)
+        self.result.report.append(suite_report)
+
+    def _dry_run_testsuites(self):
         suites_to_run = self.test_context
-        self.result.report = self._new_test_report()
 
         for testsuite, testcases in suites_to_run:
             testsuite_report = TestGroupReport(
@@ -442,6 +632,28 @@ class Test(Runnable):
                 testsuite_report.append(testcase_report)
 
             self.result.report.append(testsuite_report)
+
+    def dry_run(self):
+        """
+        Return an empty report skeleton for this test including all
+        testsuites, testcases etc. hierarchy. Does not run any tests.
+        """
+
+        self.result.report = self._new_test_report()
+
+        for hook, label in (
+            (self.cfg.before_start, "Before Start"),
+            (self.cfg.after_start, "After Start"),
+        ):
+            self._dry_run_resource_hook(hook, label)
+
+        self._dry_run_testsuites()
+
+        for hook, label in (
+            (self.cfg.before_stop, "Before Stop"),
+            (self.cfg.after_stop, "After Stop"),
+        ):
+            self._dry_run_resource_hook(hook, label)
 
         return self.result
 
@@ -914,20 +1126,20 @@ class ProcessRunnerTest(Test):
                 pattern = f"{test_report.name}:{suite_report.name}:{case_report.name}"
                 _xfail(pattern, case_report)
 
-    def pre_resource_steps(self):
+    def add_pre_resource_steps(self):
         """Runnable steps to be executed before environment starts."""
-        super(ProcessRunnerTest, self).pre_resource_steps()
+        super(ProcessRunnerTest, self).add_pre_resource_steps()
         self._add_step(self.make_runpath_dirs)
         if self.cfg.before_start:
             self._add_step(self.cfg.before_start)
 
-    def pre_main_steps(self):
+    def add_pre_main_steps(self):
         """Runnable steps to be executed after environment starts."""
         if self.cfg.after_start:
             self._add_step(self.cfg.after_start)
-        super(ProcessRunnerTest, self).pre_main_steps()
+        super(ProcessRunnerTest, self).add_pre_main_steps()
 
-    def main_batch_steps(self):
+    def add_main_batch_steps(self):
         """Runnable steps to be executed while environment is running."""
         self._add_step(self.run_tests)
         self._add_step(self.update_test_report)
@@ -935,30 +1147,14 @@ class ProcessRunnerTest(Test):
         self._add_step(self.propagate_tag_indices)
         self._add_step(self.log_test_results, top_down=False)
 
-    def post_main_steps(self):
-        """Runnable steps to run before environment stopped."""
-        super(ProcessRunnerTest, self).post_main_steps()
-        if self.cfg.before_stop:
-            self._add_step(self.cfg.before_stop)
-
-    def post_resource_steps(self):
-        """Runnable steps to be executed after environment stops."""
-        if self.cfg.after_stop:
-            self._add_step(self.cfg.after_stop)
-        super(ProcessRunnerTest, self).post_resource_steps()
-
     def aborting(self):
         if self._test_process is not None:
             kill_process(self._test_process)
             self._test_process_killed = True
 
-    def dry_run(self):
-        """
-        Return an empty report skeleton for this test including all
-        testsuites, testcases etc. hierarchy. Does not run any tests.
-        """
-        result = super(ProcessRunnerTest, self).dry_run()
-        report = result.report
+    def _dry_run_testsuites(self):
+
+        super(ProcessRunnerTest, self)._dry_run_testsuites()
 
         testcase_report = TestCaseReport(
             name=self._VERIFICATION_TESTCASE_NAME,
@@ -969,9 +1165,7 @@ class ProcessRunnerTest(Test):
             category=ReportCategories.TESTSUITE,
             entries=[testcase_report],
         )
-        report.append(testsuite_report)
-
-        return result
+        self.result.report.append(testsuite_report)
 
     def run_testcases_iter(
         self,

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -190,7 +190,6 @@ class Test(Runnable):
 
         self._init_test_report()
         self._env_built = False
-        self._build_environment(delay=True)
 
     def __str__(self):
         return "{}[{}]".format(self.__class__.__name__, self.name)
@@ -395,7 +394,7 @@ class Test(Runnable):
         else:
             self.resources._initial_context = self.cfg.initial_context
 
-    def _build_environment(self, delay: bool):
+    def _build_environment(self):
         """
         This method will execute at most twice, once with delay=True during __init__,
         and then with delay=False during _run. It will be no-op if called more
@@ -406,16 +405,10 @@ class Test(Runnable):
         if self._env_built:
             return
 
-        if delay:
-            if callable(self.cfg.environment):
-                return
-            else:
-                drivers = self.cfg.environment
+        if callable(self.cfg.environment):
+            drivers = self.cfg.environment()
         else:
-            if callable(self.cfg.environment):
-                drivers = self.cfg.environment()
-            else:
-                return
+            drivers = self.cfg.environment
 
         for driver in drivers:
             driver.parent = self
@@ -436,7 +429,7 @@ class Test(Runnable):
         self._add_step(self._record_setup_start)
 
         self._add_step(self._init_context)
-        self._add_step(self._build_environment, delay=False)
+        self._add_step(self._build_environment)
         self._add_step(self._set_dependencies)
 
     def add_start_resource_steps(self):

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -395,13 +395,7 @@ class Test(Runnable):
             self.resources._initial_context = self.cfg.initial_context
 
     def _build_environment(self):
-        """
-        This method will execute at most twice, once with delay=True during __init__,
-        and then with delay=False during _run. It will be no-op if called more
-        than once in interactive mode.
-        :param delay: delay eval if self.cfg.environment is a callable
-        """
-
+        # build environment only once in interactive mode
         if self._env_built:
             return
 
@@ -1123,14 +1117,6 @@ class ProcessRunnerTest(Test):
         """Runnable steps to be executed before environment starts."""
         super(ProcessRunnerTest, self).add_pre_resource_steps()
         self._add_step(self.make_runpath_dirs)
-        if self.cfg.before_start:
-            self._add_step(self.cfg.before_start)
-
-    def add_pre_main_steps(self):
-        """Runnable steps to be executed after environment starts."""
-        if self.cfg.after_start:
-            self._add_step(self.cfg.after_start)
-        super(ProcessRunnerTest, self).add_pre_main_steps()
 
     def add_main_batch_steps(self):
         """Runnable steps to be executed while environment is running."""

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -1100,33 +1100,39 @@ class MultiTest(testing_base.Test):
                 self.log_testcase_status(testcase_report)
             return testcase_report
 
-        with compose_contexts(
-            testcase_report.timer.record("run"),
-            testcase_report.logged_exceptions(),
-            self.watcher.save_covered_lines_to(testcase_report),
-        ):
-            if pre_testcase and callable(pre_testcase):
-                self._run_case_related(
-                    pre_testcase, testcase, resources, case_result
-                )
+        with testcase_report.timer.record("run"):
 
-            time_restriction = getattr(testcase, "timeout", None)
-            if time_restriction:
-                # pylint: disable=unbalanced-tuple-unpacking
-                executed, execution_result = timing.timeout(
-                    time_restriction,
-                    f"`{testcase.name}` timeout after {{}} second(s)",
-                )(testcase)(resources, case_result)
-                if not executed:
-                    testcase_report.logger.error(execution_result)
-                    testcase_report.status_override = Status.ERROR
-            else:
-                testcase(resources, case_result)
+            with compose_contexts(
+                testcase_report.logged_exceptions(),
+                self.watcher.save_covered_lines_to(testcase_report),
+            ):
+                if pre_testcase and callable(pre_testcase):
+                    self._run_case_related(
+                        pre_testcase, testcase, resources, case_result
+                    )
 
-            if post_testcase and callable(post_testcase):
-                self._run_case_related(
-                    post_testcase, testcase, resources, case_result
-                )
+                time_restriction = getattr(testcase, "timeout", None)
+                if time_restriction:
+                    # pylint: disable=unbalanced-tuple-unpacking
+                    executed, execution_result = timing.timeout(
+                        time_restriction,
+                        f"`{testcase.name}` timeout after {{}} second(s)",
+                    )(testcase)(resources, case_result)
+                    if not executed:
+                        testcase_report.logger.error(execution_result)
+                        testcase_report.status_override = Status.ERROR
+                else:
+                    testcase(resources, case_result)
+
+            # always run post_testcase
+            with compose_contexts(
+                testcase_report.logged_exceptions(),
+                self.watcher.save_covered_lines_to(testcase_report),
+            ):
+                if post_testcase and callable(post_testcase):
+                    self._run_case_related(
+                        post_testcase, testcase, resources, case_result
+                    )
 
         # Apply testcase level summarization
         if getattr(testcase, "summarize", False):

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -10,7 +10,6 @@ from typing import Callable, Dict, Generator, List, Optional, Tuple
 from schema import And, Or, Use
 
 from testplan.common import config, entity
-from testplan.common.utils import callable as callable_utils
 from testplan.common.utils import (
     interface,
     strings,
@@ -19,7 +18,6 @@ from testplan.common.utils import (
     watcher,
 )
 from testplan.common.utils.composer import compose_contexts
-from testplan.common.utils.path import change_directory
 from testplan.report import (
     ReportCategories,
     RuntimeStatus,
@@ -177,6 +175,9 @@ class RuntimeEnvironment:
     def __iter__(self):
         return iter(self._environment)
 
+    def __len__(self):
+        return len(self._environment)
+
 
 class MultiTestConfig(testing_base.TestConfig):
     """
@@ -305,8 +306,6 @@ class MultiTest(testing_base.Test):
             for suite in self.suites:
                 mtest_suite.propagate_tag_indices(suite, self.cfg.tags)
 
-        self._pre_post_step_report = None
-
         # MultiTest may start a thread pool for running testcases concurrently,
         # if they are marked with an execution group.
         self._thread_pool = None
@@ -322,16 +321,6 @@ class MultiTest(testing_base.Test):
         )
 
         self.watcher = watcher.Watcher()
-
-    @property
-    def pre_post_step_report(self):
-        if self._pre_post_step_report is None:
-            self._pre_post_step_report = TestGroupReport(
-                name="Before/After Step Checks",
-                category=ReportCategories.TESTSUITE,
-            )
-            self._pre_post_step_report.status = Status.PASSED
-        return self._pre_post_step_report
 
     @property
     def suites(self):
@@ -444,36 +433,23 @@ class MultiTest(testing_base.Test):
 
         return ctx
 
-    def dry_run(self, status=None):
-        """
-        A testing process that creates a full structured report without
-        any assertion entry. Initial status of each entry can be set.
-        """
-        self._pre_post_step_report = (
-            None  # TODO: this needs to be more generic
-        )
+    def _dry_run_testsuites(self):
         suites_to_run = self.test_context
-        self.result.report = self._new_test_report()
 
         for testsuite, testcases in suites_to_run:
             testsuite_report = self._new_testsuite_report(testsuite)
-            self.result.report.append(testsuite_report)
 
             if getattr(testsuite, "setup", None):
-                testsuite_report.append(
-                    self._suite_related_report("setup", status)
-                )
+                testsuite_report.append(self._suite_related_report("setup"))
 
             testsuite_report.extend(
-                self._testcase_reports(testsuite, testcases, status)
+                self._testcase_reports(testsuite, testcases)
             )
 
             if getattr(testsuite, "teardown", None):
-                testsuite_report.append(
-                    self._suite_related_report("teardown", status)
-                )
+                testsuite_report.append(self._suite_related_report("teardown"))
 
-        return self.result
+            self.result.report.append(testsuite_report)
 
     def run_tests(self):
         """Run all tests as a batch and return the results."""
@@ -559,20 +535,6 @@ class MultiTest(testing_base.Test):
             if testcases:
                 yield from self._run_testsuite_iter(testsuite, testcases)
 
-    def append_pre_post_step_report(self) -> None:
-        """
-        Pre-resource step to append pre/post step report if any is configured.
-        """
-        if any(
-            [
-                self.cfg.before_start,
-                self.cfg.after_start,
-                self.cfg.before_stop,
-                self.cfg.after_stop,
-            ],
-        ):
-            self.report.append(self.pre_post_step_report)
-
     def get_tags_index(self):
         """
         Tags index for a multitest is its native tags merged with tag indices
@@ -619,53 +581,17 @@ class MultiTest(testing_base.Test):
                     if error_log:
                         self.result.report.logger.error(error_log)
 
-    def pre_resource_steps(self):
+    def add_pre_resource_steps(self):
         """Runnable steps to be executed before environment starts."""
-        super(MultiTest, self).pre_resource_steps()
+
+        super(MultiTest, self).add_pre_resource_steps()
         self._add_step(self.make_runpath_dirs)
-        if self.cfg.before_start:
-            self._add_step(
-                self._wrap_run_step(
-                    label="before_start", func=self.cfg.before_start
-                )
-            )
-        self._add_step(self.append_pre_post_step_report)
 
-    def pre_main_steps(self):
-        """Runnable steps to be executed after environment starts."""
-        if self.cfg.after_start:
-            self._add_step(
-                self._wrap_run_step(
-                    label="after_start", func=self.cfg.after_start
-                )
-            )
-        super(MultiTest, self).pre_main_steps()
-
-    def main_batch_steps(self):
+    def add_main_batch_steps(self):
         """Runnable steps to be executed while environment is running."""
         self._add_step(self.run_tests)
         self._add_step(self.apply_xfail_tests)
         self._add_step(self.propagate_tag_indices)
-
-    def post_main_steps(self):
-        """Runnable steps to run before environment stopped."""
-        super(MultiTest, self).post_main_steps()
-        if self.cfg.before_stop:
-            self._add_step(
-                self._wrap_run_step(
-                    label="before_stop", func=self.cfg.before_stop
-                )
-            )
-
-    def post_resource_steps(self):
-        """Runnable steps to be executed after environment stops."""
-        if self.cfg.after_stop:
-            self._add_step(
-                self._wrap_run_step(
-                    label="after_stop", func=self.cfg.after_stop
-                )
-            )
-        super(MultiTest, self).post_resource_steps()
 
     def should_run(self):
         """
@@ -675,49 +601,6 @@ class MultiTest(testing_base.Test):
 
     def aborting(self):
         """Suppressing not implemented debug log from parent class."""
-
-    def start_test_resources(self):
-        """
-        Start all test resources but do not run any tests. Used in the
-        interactive mode when environments may be started/stopped on demand -
-        this method handles running the before/after_start callables if
-        required.
-        """
-        # Need to clean up pre/post steps report in the following scenario:
-        #   - resources are started
-        #   - stopped
-        #   - started again
-        # Reason is that dry_run only applies for state reset while appending of
-        #   the report group happens only in static run we cannot capture
-        self._pre_post_step_report = None
-        self.make_runpath_dirs()
-        if self.cfg.before_start:
-            self._wrap_run_step(
-                label="before_start", func=self.cfg.before_start
-            )()
-        with change_directory(self._discover_path):
-            self.resources.start()
-
-        if self.cfg.after_start:
-            self._wrap_run_step(
-                label="after_start", func=self.cfg.after_start
-            )()
-
-    def stop_test_resources(self):
-        """
-        Stop all test resources. As above, this method is used for the
-        interactive mode where a test environment may be stopped on-demand.
-        Handles running before/after_stop callables if required.
-        """
-        if self.cfg.before_stop:
-            self._wrap_run_step(
-                label="before_stop", func=self.cfg.before_stop
-            )()
-
-        self.resources.stop()
-
-        if self.cfg.after_stop:
-            self._wrap_run_step(label="after_stop", func=self.cfg.after_stop)()
 
     def get_metadata(self) -> TestMetadata:
         return TestMetadata(
@@ -762,7 +645,7 @@ class MultiTest(testing_base.Test):
                 self.DEFAULT_THREAD_POOL_SIZE,
             )
 
-    def _suite_related_report(self, name, status):
+    def _suite_related_report(self, name, status=None):
         """
         Return a report for a testsuite-related action, such as setup or
         teardown.
@@ -775,7 +658,7 @@ class MultiTest(testing_base.Test):
 
         return testcase_report
 
-    def _testcase_reports(self, testsuite, testcases, status):
+    def _testcase_reports(self, testsuite, testcases, status=None):
         """
         Generate a list of reports for testcases, including parametrization
         groups.
@@ -1267,56 +1150,6 @@ class MultiTest(testing_base.Test):
             self.log_testcase_status(testcase_report)
 
         return testcase_report
-
-    def _wrap_run_step(self, func, label):
-        """
-        Utility wrapper for special step related functions
-        (`before_start`, `after_stop` etc.).
-
-        This method wraps post/pre start/stop related functions so that the
-        user can optionally make use of assertions if the function accepts
-        both ``env`` and ``result`` arguments.
-
-        These functions are also run within report error logging context,
-        meaning that if something goes wrong we will have the stack trace
-        in the final report.
-        """
-
-        @functools.wraps(func)
-        def _wrapper():
-            case_result = self.cfg.result(
-                stdout_style=self.stdout_style, _scratch=self.scratch
-            )
-
-            testcase_report = TestCaseReport(
-                name="{} - {}".format(label, func.__name__),
-                description=strings.get_docstring(func),
-            )
-
-            num_args = len(callable_utils.getargspec(func).args)
-            resources = self._get_runtime_environment(
-                testcase_name=func.__name__, testcase_report=testcase_report
-            )
-
-            args = (resources,) if num_args == 1 else (resources, case_result)
-
-            with compose_contexts(
-                testcase_report.timer.record("run"),
-                testcase_report.logged_exceptions(),
-                self.watcher.save_covered_lines_to(self.report),
-            ):
-                func(*args)
-
-            testcase_report.extend(case_result.serialized_entries)
-            testcase_report.attachments.extend(case_result.attachments)
-
-            if self.get_stdout_style(testcase_report.passed).display_testcase:
-                self.log_testcase_status(testcase_report)
-
-            testcase_report.pass_if_empty()
-            self.pre_post_step_report.append(testcase_report)
-
-        return _wrapper
 
     def _log_status(self, report, indent):
         """Log the test status for a report at the given indent level."""

--- a/testplan/testing/py_test.py
+++ b/testplan/testing/py_test.py
@@ -103,7 +103,7 @@ class PyTest(testing.Test):
         # tests are collected via dry_run().
         self._nodeids = None
 
-    def main_batch_steps(self):
+    def add_main_batch_steps(self):
         """Specify the test steps: run the tests, then log the results."""
         self._add_step(self.run_tests)
         self._add_step(self.log_test_results, top_down=False)
@@ -173,12 +173,8 @@ class PyTest(testing.Test):
             (suite, list(testcases)) for suite, testcases in suites.items()
         ]
 
-    def dry_run(self):
-        """
-        Collect tests and build a report tree skeleton, but do not run any
-        tests.
-        """
-        self.result.report = self._new_test_report()
+    def _dry_run_testsuites(self):
+
         self._nodeids = {
             "testsuites": {},
             "testcases": collections.defaultdict(dict),
@@ -186,8 +182,6 @@ class PyTest(testing.Test):
 
         for item in self._collect_tests():
             _add_empty_testcase_report(item, self.result.report, self._nodeids)
-
-        return self.result
 
     def run_testcases_iter(
         self,

--- a/testplan/testing/pyunit.py
+++ b/testplan/testing/pyunit.py
@@ -51,7 +51,7 @@ class PyUnit(testing.Test):
             testcase.__name__: testcase for testcase in self.cfg.testcases
         }
 
-    def main_batch_steps(self):
+    def add_main_batch_steps(self):
         """Specify the test steps: run the tests, then log the results."""
         self._add_step(self.run_tests)
         self._add_step(self.log_test_results)
@@ -71,9 +71,7 @@ class PyUnit(testing.Test):
             for testcase in self._pyunit_testcases.keys()
         ]
 
-    def dry_run(self):
-        """Return an empty report tree."""
-        self.result.report = self._new_test_report()
+    def _dry_run_testsuites(self):
 
         for pyunit_testcase in self.cfg.testcases:
             testsuite_report = TestGroupReport(
@@ -87,8 +85,6 @@ class PyUnit(testing.Test):
                 ],
             )
             self.result.report.append(testsuite_report)
-
-        return self.result
 
     def run_testcases_iter(
         self,

--- a/tests/functional/testplan/runnable/interactive/reports/basic_run_case_test1.data
+++ b/tests/functional/testplan/runnable/interactive/reports/basic_run_case_test1.data
@@ -1,340 +1,417 @@
 {
-    "category": "multitest",
+    "host": null,
+    "logs": [],
     "counter": {
+        "passed": 2,
         "failed": 0,
-        "passed": 1,
-        "total": 5,
+        "total": 6,
         "unknown": 4
     },
+    "strict_order": false,
+    "events": {},
+    "category": "multitest",
+    "hash": 0,
+    "definition_name": "Test1",
+    "env_status": "STARTED",
+    "parent_uids": [
+        "InteractivePlan"
+    ],
+    "part": null,
     "description": null,
     "entries": [
         {
-            "category": "testsuite",
+            "host": null,
+            "logs": [],
             "counter": {
-                "failed": 0,
                 "passed": 1,
-                "total": 3,
-                "unknown": 2
+                "failed": 0,
+                "total": 1
             },
+            "strict_order": false,
+            "events": {},
+            "category": "testsuite",
+            "hash": 0,
+            "definition_name": "After Start",
+            "env_status": null,
+            "parent_uids": [
+                "InteractivePlan",
+                "Test1"
+            ],
+            "part": null,
             "description": null,
             "entries": [
                 {
-                    "category": "parametrization",
+                    "status_override": null,
+                    "parent_uids": [
+                        "InteractivePlan",
+                        "Test1",
+                        "After Start"
+                    ],
+                    "description": null,
+                    "entries": [],
+                    "suite_related": true,
+                    "uid": "accept_connection",
+                    "runtime_status": "finished",
                     "counter": {
-                        "failed": 0,
                         "passed": 1,
+                        "failed": 0,
+                        "total": 1
+                    },
+                    "status_reason": null,
+                    "timer": {
+                        "run": {
+                            "end": "2023-11-28T02:04:57.778247+00:00",
+                            "start": "2023-11-28T02:04:57.778179+00:00"
+                        }
+                    },
+                    "status": "passed",
+                    "category": "testcase",
+                    "hash": 0,
+                    "tags": {},
+                    "name": "accept_connection",
+                    "logs": [],
+                    "definition_name": "accept_connection",
+                    "type": "TestCaseReport"
+                }
+            ],
+            "fix_spec_path": null,
+            "status_reason": null,
+            "status": "passed",
+            "tags": {},
+            "name": "After Start",
+            "type": "TestGroupReport",
+            "suite_related": true,
+            "status_override": null,
+            "timer": {},
+            "uid": "After Start",
+            "runtime_status": "finished"
+        },
+        {
+            "host": null,
+            "logs": [],
+            "counter": {
+                "passed": 1,
+                "failed": 0,
+                "total": 3,
+                "unknown": 2
+            },
+            "strict_order": false,
+            "events": {},
+            "category": "testsuite",
+            "hash": 0,
+            "definition_name": "BasicSuite",
+            "env_status": null,
+            "parent_uids": [
+                "InteractivePlan",
+                "Test1"
+            ],
+            "part": null,
+            "description": null,
+            "entries": [
+                {
+                    "host": null,
+                    "logs": [],
+                    "counter": {
+                        "passed": 1,
+                        "failed": 0,
                         "total": 3,
                         "unknown": 2
                     },
-                    "description": null,
-                    "entries": [
-                        {
-                            "category": "testcase",
-                            "counter": {
-                                "failed": 0,
-                                "passed": 0,
-                                "total": 1,
-                                "unknown": 1
-                            },
-                            "description": null,
-                            "entries": [],
-                            "hash": 0,
-                            "definition_name": "basic_case <arg=0>",
-                            "logs": [],
-                            "name": "basic_case <arg=0>",
-                            "parent_uids": [
-                                "InteractivePlan",
-                                "Test1",
-                                "BasicSuite",
-                                "basic_case"
-                            ],
-                            "runtime_status": "ready",
-                            "status": "unknown",
-                            "status_override": null,
-                            "status_reason": null,
-                            "suite_related": false,
-                            "tags": {},
-                            "timer": {},
-                            "type": "TestCaseReport",
-                            "uid": "basic_case__arg_0"
-                        },
-                        {
-                            "category": "testcase",
-                            "counter": {
-                                "failed": 0,
-                                "passed": 1,
-                                "total": 1
-                            },
-                            "description": null,
-                            "entries": [
-                                {
-                                    "category": "DEFAULT",
-                                    "description": "Passing assertion",
-                                    "file_path": "",
-                                    "first": 1,
-                                    "flag": "DEFAULT",
-                                    "label": "==",
-                                    "line_no": 0,
-                                    "machine_time": "",
-                                    "meta_type": "assertion",
-                                    "passed": true,
-                                    "second": 1,
-                                    "type": "Equal",
-                                    "type_actual": "int",
-                                    "type_expected": "int",
-                                    "utc_time": ""
-                                }
-                            ],
-                            "hash": 0,
-                            "definition_name": "basic_case <arg=1>",
-                            "logs": [],
-                            "name": "basic_case <arg=1>",
-                            "parent_uids": [
-                                "InteractivePlan",
-                                "Test1",
-                                "BasicSuite",
-                                "basic_case"
-                            ],
-                            "runtime_status": "finished",
-                            "status": "passed",
-                            "status_override": null,
-                            "status_reason": null,
-                            "suite_related": false,
-                            "tags": {},
-                            "timer": {
-                                "run": {
-                                    "end": "",
-                                    "start": ""
-                                }
-                            },
-                            "type": "TestCaseReport",
-                            "uid": "basic_case__arg_1"
-                        },
-                        {
-                            "category": "testcase",
-                            "counter": {
-                                "failed": 0,
-                                "passed": 0,
-                                "total": 1,
-                                "unknown": 1
-                            },
-                            "description": null,
-                            "entries": [],
-                            "hash": 0,
-                            "definition_name": "basic_case <arg=2>",
-                            "logs": [],
-                            "name": "basic_case <arg=2>",
-                            "parent_uids": [
-                                "InteractivePlan",
-                                "Test1",
-                                "BasicSuite",
-                                "basic_case"
-                            ],
-                            "runtime_status": "ready",
-                            "status": "unknown",
-                            "status_override": null,
-                            "status_reason": null,
-                            "suite_related": false,
-                            "tags": {},
-                            "timer": {},
-                            "type": "TestCaseReport",
-                            "uid": "basic_case__arg_2"
-                        }
-                    ],
-                    "env_status": null,
+                    "strict_order": false,
                     "events": {},
-                    "fix_spec_path": null,
+                    "category": "parametrization",
                     "hash": 0,
-                    "host": null,
                     "definition_name": "basic_case",
-                    "logs": [],
-                    "name": "basic_case",
+                    "env_status": null,
                     "parent_uids": [
                         "InteractivePlan",
                         "Test1",
                         "BasicSuite"
                     ],
                     "part": null,
-                    "runtime_status": "ready",
-                    "status": "unknown",
-                    "status_override": null,
+                    "description": null,
+                    "entries": [
+                        {
+                            "status_override": null,
+                            "parent_uids": [
+                                "InteractivePlan",
+                                "Test1",
+                                "BasicSuite",
+                                "basic_case"
+                            ],
+                            "description": null,
+                            "entries": [],
+                            "suite_related": false,
+                            "uid": "basic_case__arg_0",
+                            "runtime_status": "ready",
+                            "counter": {
+                                "passed": 0,
+                                "failed": 0,
+                                "total": 1,
+                                "unknown": 1
+                            },
+                            "status_reason": null,
+                            "timer": {},
+                            "status": "unknown",
+                            "category": "testcase",
+                            "hash": 0,
+                            "tags": {},
+                            "name": "basic_case <arg=0>",
+                            "logs": [],
+                            "definition_name": "basic_case <arg=0>",
+                            "type": "TestCaseReport"
+                        },
+                        {
+                            "status_override": null,
+                            "parent_uids": [
+                                "InteractivePlan",
+                                "Test1",
+                                "BasicSuite",
+                                "basic_case"
+                            ],
+                            "description": null,
+                            "entries": [
+                                {
+                                    "file_path": "",
+                                    "machine_time": "2023-11-28T10:04:57.795366+08:00",
+                                    "utc_time": "2023-11-28T02:04:57.795358+00:00",
+                                    "label": "==",
+                                    "description": "Passing assertion",
+                                    "passed": true,
+                                    "first": 1,
+                                    "meta_type": "assertion",
+                                    "type_expected": "int",
+                                    "category": "DEFAULT",
+                                    "line_no": 47,
+                                    "second": 1,
+                                    "flag": "DEFAULT",
+                                    "type_actual": "int",
+                                    "type": "Equal"
+                                }
+                            ],
+                            "suite_related": false,
+                            "uid": "basic_case__arg_1",
+                            "runtime_status": "finished",
+                            "counter": {
+                                "passed": 1,
+                                "failed": 0,
+                                "total": 1
+                            },
+                            "status_reason": null,
+                            "timer": {
+                                "run": {
+                                    "end": "2023-11-28T02:04:57.802172+00:00",
+                                    "start": "2023-11-28T02:04:57.795258+00:00"
+                                }
+                            },
+                            "status": "passed",
+                            "category": "testcase",
+                            "hash": 0,
+                            "tags": {},
+                            "name": "basic_case <arg=1>",
+                            "logs": [],
+                            "definition_name": "basic_case <arg=1>",
+                            "type": "TestCaseReport"
+                        },
+                        {
+                            "status_override": null,
+                            "parent_uids": [
+                                "InteractivePlan",
+                                "Test1",
+                                "BasicSuite",
+                                "basic_case"
+                            ],
+                            "description": null,
+                            "entries": [],
+                            "suite_related": false,
+                            "uid": "basic_case__arg_2",
+                            "runtime_status": "ready",
+                            "counter": {
+                                "passed": 0,
+                                "failed": 0,
+                                "total": 1,
+                                "unknown": 1
+                            },
+                            "status_reason": null,
+                            "timer": {},
+                            "status": "unknown",
+                            "category": "testcase",
+                            "hash": 0,
+                            "tags": {},
+                            "name": "basic_case <arg=2>",
+                            "logs": [],
+                            "definition_name": "basic_case <arg=2>",
+                            "type": "TestCaseReport"
+                        }
+                    ],
+                    "fix_spec_path": null,
                     "status_reason": null,
-                    "strict_order": false,
+                    "status": "unknown",
                     "tags": {},
-                    "timer": {},
+                    "name": "basic_case",
                     "type": "TestGroupReport",
-                    "uid": "basic_case"
+                    "suite_related": false,
+                    "status_override": null,
+                    "timer": {},
+                    "uid": "basic_case",
+                    "runtime_status": "ready"
                 }
             ],
-            "env_status": null,
-            "events": {},
             "fix_spec_path": null,
-            "hash": 0,
-            "host": null,
-            "definition_name": "BasicSuite",
-            "logs": [],
+            "status_reason": null,
+            "status": "unknown",
+            "tags": {},
             "name": "BasicSuite",
+            "type": "TestGroupReport",
+            "suite_related": false,
+            "status_override": null,
+            "timer": {},
+            "uid": "BasicSuite",
+            "runtime_status": "ready"
+        },
+        {
+            "host": null,
+            "logs": [],
+            "counter": {
+                "passed": 0,
+                "failed": 0,
+                "total": 1,
+                "unknown": 1
+            },
+            "strict_order": false,
+            "events": {},
+            "category": "testsuite",
+            "hash": 0,
+            "definition_name": "Custom_0",
+            "env_status": null,
             "parent_uids": [
                 "InteractivePlan",
                 "Test1"
             ],
             "part": null,
-            "runtime_status": "ready",
-            "status": "unknown",
-            "status_override": null,
-            "status_reason": null,
-            "strict_order": false,
-            "tags": {},
-            "timer": {},
-            "type": "TestGroupReport",
-            "uid": "BasicSuite"
-        },
-        {
-            "category": "testsuite",
-            "counter": {
-                "failed": 0,
-                "passed": 0,
-                "total": 1,
-                "unknown": 1
-            },
             "description": null,
             "entries": [
                 {
-                    "category": "testcase",
-                    "counter": {
-                        "failed": 0,
-                        "passed": 0,
-                        "total": 1,
-                        "unknown": 1
-                    },
-                    "description": "Client sends a message, server received and responds back.",
-                    "entries": [],
-                    "hash": 0,
-                    "definition_name": "send_and_receive_msg",
-                    "logs": [],
-                    "name": "send_and_receive_msg",
+                    "status_override": null,
                     "parent_uids": [
                         "InteractivePlan",
                         "Test1",
                         "Custom_0"
                     ],
-                    "runtime_status": "ready",
-                    "status": "unknown",
-                    "status_override": null,
-                    "status_reason": null,
+                    "description": "Client sends a message, server received and responds back.",
+                    "entries": [],
                     "suite_related": false,
-                    "tags": {},
+                    "uid": "send_and_receive_msg",
+                    "runtime_status": "ready",
+                    "counter": {
+                        "passed": 0,
+                        "failed": 0,
+                        "total": 1,
+                        "unknown": 1
+                    },
+                    "status_reason": null,
                     "timer": {},
-                    "type": "TestCaseReport",
-                    "uid": "send_and_receive_msg"
+                    "status": "unknown",
+                    "category": "testcase",
+                    "hash": 0,
+                    "tags": {},
+                    "name": "send_and_receive_msg",
+                    "logs": [],
+                    "definition_name": "send_and_receive_msg",
+                    "type": "TestCaseReport"
                 }
             ],
-            "env_status": null,
-            "events": {},
             "fix_spec_path": null,
-            "hash": 0,
-            "host": null,
-            "definition_name": "Custom_0",
-            "logs": [],
+            "status_reason": null,
+            "status": "unknown",
+            "tags": {},
             "name": "Custom_0",
+            "type": "TestGroupReport",
+            "suite_related": false,
+            "status_override": null,
+            "timer": {},
+            "uid": "Custom_0",
+            "runtime_status": "ready"
+        },
+        {
+            "host": null,
+            "logs": [],
+            "counter": {
+                "passed": 0,
+                "failed": 0,
+                "total": 1,
+                "unknown": 1
+            },
+            "strict_order": false,
+            "events": {},
+            "category": "testsuite",
+            "hash": 0,
+            "definition_name": "Custom_1",
+            "env_status": null,
             "parent_uids": [
                 "InteractivePlan",
                 "Test1"
             ],
             "part": null,
-            "runtime_status": "ready",
-            "status": "unknown",
-            "status_override": null,
-            "status_reason": null,
-            "strict_order": false,
-            "tags": {},
-            "timer": {},
-            "type": "TestGroupReport",
-            "uid": "Custom_0"
-        },
-        {
-            "category": "testsuite",
-            "counter": {
-                "failed": 0,
-                "passed": 0,
-                "total": 1,
-                "unknown": 1
-            },
             "description": null,
             "entries": [
                 {
-                    "category": "testcase",
-                    "counter": {
-                        "failed": 0,
-                        "passed": 0,
-                        "total": 1,
-                        "unknown": 1
-                    },
-                    "description": "Client sends a message, server received and responds back.",
-                    "entries": [],
-                    "hash": 0,
-                    "definition_name": "send_and_receive_msg",
-                    "logs": [],
-                    "name": "send_and_receive_msg",
+                    "status_override": null,
                     "parent_uids": [
                         "InteractivePlan",
                         "Test1",
                         "Custom_1"
                     ],
-                    "runtime_status": "ready",
-                    "status": "unknown",
-                    "status_override": null,
-                    "status_reason": null,
+                    "description": "Client sends a message, server received and responds back.",
+                    "entries": [],
                     "suite_related": false,
-                    "tags": {},
+                    "uid": "send_and_receive_msg",
+                    "runtime_status": "ready",
+                    "counter": {
+                        "passed": 0,
+                        "failed": 0,
+                        "total": 1,
+                        "unknown": 1
+                    },
+                    "status_reason": null,
                     "timer": {},
-                    "type": "TestCaseReport",
-                    "uid": "send_and_receive_msg"
+                    "status": "unknown",
+                    "category": "testcase",
+                    "hash": 0,
+                    "tags": {},
+                    "name": "send_and_receive_msg",
+                    "logs": [],
+                    "definition_name": "send_and_receive_msg",
+                    "type": "TestCaseReport"
                 }
             ],
-            "env_status": null,
-            "events": {},
             "fix_spec_path": null,
-            "hash": 0,
-            "host": null,
-            "definition_name": "Custom_1",
-            "logs": [],
-            "name": "Custom_1",
-            "parent_uids": [
-                "InteractivePlan",
-                "Test1"
-            ],
-            "part": null,
-            "runtime_status": "ready",
-            "status": "unknown",
-            "status_override": null,
             "status_reason": null,
-            "strict_order": false,
+            "status": "unknown",
             "tags": {},
-            "timer": {},
+            "name": "Custom_1",
             "type": "TestGroupReport",
-            "uid": "Custom_1"
+            "suite_related": false,
+            "status_override": null,
+            "timer": {},
+            "uid": "Custom_1",
+            "runtime_status": "ready"
         }
     ],
-    "env_status": "STARTED",
-    "events": {},
     "fix_spec_path": null,
-    "hash": 0,
-    "host": null,
-    "definition_name": "Test1",
-    "logs": [],
-    "name": "Test1",
-    "parent_uids": [
-        "InteractivePlan"
-    ],
-    "part": null,
-    "runtime_status": "ready",
-    "status": "unknown",
-    "status_override": null,
     "status_reason": null,
-    "strict_order": false,
+    "status": "unknown",
     "tags": {},
-    "timer": {},
+    "name": "Test1",
     "type": "TestGroupReport",
-    "uid": "Test1"
+    "suite_related": false,
+    "status_override": null,
+    "timer": {
+        "setup": {
+            "end": "2023-11-28T02:04:57.784193+00:00",
+            "start": "2023-11-28T02:04:57.685995+00:00"
+        }
+    },
+    "uid": "Test1",
+    "runtime_status": "ready"
 }

--- a/tests/functional/testplan/runnable/interactive/reports/basic_run_suite_test2.data
+++ b/tests/functional/testplan/runnable/interactive/reports/basic_run_suite_test2.data
@@ -1,318 +1,395 @@
 {
-    "category": "multitest",
-    "counter": {
-        "failed": 0,
-        "passed": 0,
-        "total": 5,
-        "unknown": 5
-    },
-    "description": null,
     "entries": [
         {
-            "category": "testsuite",
-            "counter": {
-                "failed": 0,
-                "passed": 0,
-                "total": 3,
-                "unknown": 3
-            },
-            "description": null,
             "entries": [
                 {
-                    "category": "parametrization",
+                    "definition_name": "accept_connection",
+                    "status_reason": null,
+                    "entries": [],
                     "counter": {
+                        "passed": 1,
                         "failed": 0,
-                        "passed": 0,
-                        "total": 3,
-                        "unknown": 3
+                        "total": 1
                     },
+                    "logs": [],
+                    "name": "accept_connection",
+                    "status_override": null,
                     "description": null,
+                    "uid": "accept_connection",
+                    "hash": 0,
+                    "parent_uids": [
+                        "InteractivePlan",
+                        "Test2",
+                        "After Start"
+                    ],
+                    "suite_related": true,
+                    "timer": {
+                        "run": {
+                            "start": "2023-11-28T01:56:24.998666+00:00",
+                            "end": "2023-11-28T01:56:24.998713+00:00"
+                        }
+                    },
+                    "status": "passed",
+                    "category": "testcase",
+                    "tags": {},
+                    "type": "TestCaseReport",
+                    "runtime_status": "finished"
+                }
+            ],
+            "logs": [],
+            "strict_order": false,
+            "events": {},
+            "fix_spec_path": null,
+            "timer": {},
+            "parent_uids": [
+                "InteractivePlan",
+                "Test2"
+            ],
+            "part": null,
+            "status": "passed",
+            "host": null,
+            "runtime_status": "finished",
+            "status_reason": null,
+            "counter": {
+                "passed": 1,
+                "failed": 0,
+                "total": 1
+            },
+            "suite_related": true,
+            "description": null,
+            "uid": "After Start",
+            "category": "testsuite",
+            "tags": {},
+            "type": "TestGroupReport",
+            "definition_name": "After Start",
+            "name": "After Start",
+            "status_override": null,
+            "hash": 0,
+            "env_status": null
+        },
+        {
+            "entries": [
+                {
                     "entries": [
                         {
-                            "category": "testcase",
+                            "definition_name": "basic_case <arg=0>",
+                            "status_reason": null,
+                            "entries": [],
                             "counter": {
-                                "failed": 0,
                                 "passed": 0,
+                                "failed": 0,
                                 "total": 1,
                                 "unknown": 1
                             },
-                            "description": null,
-                            "entries": [],
-                            "hash": 0,
-                            "definition_name": "basic_case <arg=0>",
                             "logs": [],
                             "name": "basic_case <arg=0>",
+                            "status_override": null,
+                            "description": null,
+                            "uid": "basic_case__arg_0",
+                            "hash": 0,
                             "parent_uids": [
                                 "InteractivePlan",
                                 "Test2",
                                 "BasicSuite",
                                 "basic_case"
                             ],
-                            "runtime_status": "ready",
-                            "status": "unknown",
-                            "status_override": null,
-                            "status_reason": null,
                             "suite_related": false,
-                            "tags": {},
                             "timer": {},
+                            "status": "unknown",
+                            "category": "testcase",
+                            "tags": {},
                             "type": "TestCaseReport",
-                            "uid": "basic_case__arg_0"
+                            "runtime_status": "ready"
                         },
                         {
-                            "category": "testcase",
+                            "definition_name": "basic_case <arg=1>",
+                            "status_reason": null,
+                            "entries": [],
                             "counter": {
-                                "failed": 0,
                                 "passed": 0,
+                                "failed": 0,
                                 "total": 1,
                                 "unknown": 1
                             },
-                            "description": null,
-                            "entries": [],
-                            "hash": 0,
-                            "definition_name": "basic_case <arg=1>",
                             "logs": [],
                             "name": "basic_case <arg=1>",
+                            "status_override": null,
+                            "description": null,
+                            "uid": "basic_case__arg_1",
+                            "hash": 0,
                             "parent_uids": [
                                 "InteractivePlan",
                                 "Test2",
                                 "BasicSuite",
                                 "basic_case"
                             ],
-                            "runtime_status": "ready",
-                            "status": "unknown",
-                            "status_override": null,
-                            "status_reason": null,
                             "suite_related": false,
-                            "tags": {},
                             "timer": {},
+                            "status": "unknown",
+                            "category": "testcase",
+                            "tags": {},
                             "type": "TestCaseReport",
-                            "uid": "basic_case__arg_1"
+                            "runtime_status": "ready"
                         },
                         {
-                            "category": "testcase",
+                            "definition_name": "basic_case <arg=2>",
+                            "status_reason": null,
+                            "entries": [],
                             "counter": {
-                                "failed": 0,
                                 "passed": 0,
+                                "failed": 0,
                                 "total": 1,
                                 "unknown": 1
                             },
-                            "description": null,
-                            "entries": [],
-                            "hash": 0,
-                            "definition_name": "basic_case <arg=2>",
                             "logs": [],
                             "name": "basic_case <arg=2>",
+                            "status_override": null,
+                            "description": null,
+                            "uid": "basic_case__arg_2",
+                            "hash": 0,
                             "parent_uids": [
                                 "InteractivePlan",
                                 "Test2",
                                 "BasicSuite",
                                 "basic_case"
                             ],
-                            "runtime_status": "ready",
-                            "status": "unknown",
-                            "status_override": null,
-                            "status_reason": null,
                             "suite_related": false,
-                            "tags": {},
                             "timer": {},
+                            "status": "unknown",
+                            "category": "testcase",
+                            "tags": {},
                             "type": "TestCaseReport",
-                            "uid": "basic_case__arg_2"
+                            "runtime_status": "ready"
                         }
                     ],
-                    "env_status": null,
+                    "logs": [],
+                    "strict_order": false,
                     "events": {},
                     "fix_spec_path": null,
-                    "hash": 0,
-                    "host": null,
-                    "definition_name": "basic_case",
-                    "logs": [],
-                    "name": "basic_case",
+                    "timer": {},
                     "parent_uids": [
                         "InteractivePlan",
                         "Test2",
                         "BasicSuite"
                     ],
                     "part": null,
-                    "runtime_status": "ready",
                     "status": "unknown",
-                    "status_override": null,
+                    "host": null,
+                    "runtime_status": "ready",
                     "status_reason": null,
-                    "strict_order": false,
+                    "counter": {
+                        "passed": 0,
+                        "failed": 0,
+                        "total": 3,
+                        "unknown": 3
+                    },
+                    "suite_related": false,
+                    "description": null,
+                    "uid": "basic_case",
+                    "category": "parametrization",
                     "tags": {},
-                    "timer": {},
                     "type": "TestGroupReport",
-                    "uid": "basic_case"
+                    "definition_name": "basic_case",
+                    "name": "basic_case",
+                    "status_override": null,
+                    "hash": 0,
+                    "env_status": null
                 }
             ],
-            "env_status": null,
+            "logs": [],
+            "strict_order": false,
             "events": {},
             "fix_spec_path": null,
-            "hash": 0,
-            "host": null,
-            "definition_name": "BasicSuite",
-            "logs": [],
-            "name": "BasicSuite",
+            "timer": {},
             "parent_uids": [
                 "InteractivePlan",
                 "Test2"
             ],
             "part": null,
-            "runtime_status": "ready",
             "status": "unknown",
-            "status_override": null,
+            "host": null,
+            "runtime_status": "ready",
             "status_reason": null,
-            "strict_order": false,
+            "counter": {
+                "passed": 0,
+                "failed": 0,
+                "total": 3,
+                "unknown": 3
+            },
+            "suite_related": false,
+            "description": null,
+            "uid": "BasicSuite",
+            "category": "testsuite",
             "tags": {},
-            "timer": {},
             "type": "TestGroupReport",
-            "uid": "BasicSuite"
+            "definition_name": "BasicSuite",
+            "name": "BasicSuite",
+            "status_override": null,
+            "hash": 0,
+            "env_status": null
         },
         {
-            "category": "testsuite",
-            "counter": {
-                "failed": 0,
-                "passed": 0,
-                "total": 1,
-                "unknown": 1
-            },
-            "description": null,
             "entries": [
                 {
-                    "category": "testcase",
+                    "definition_name": "send_and_receive_msg",
+                    "status_reason": null,
+                    "entries": [],
                     "counter": {
-                        "failed": 0,
                         "passed": 0,
+                        "failed": 0,
                         "total": 1,
                         "unknown": 1
                     },
-                    "description": "Client sends a message, server received and responds back.",
-                    "entries": [],
-                    "hash": 0,
-                    "definition_name": "send_and_receive_msg",
                     "logs": [],
                     "name": "send_and_receive_msg",
+                    "status_override": null,
+                    "description": "Client sends a message, server received and responds back.",
+                    "uid": "send_and_receive_msg",
+                    "hash": 0,
                     "parent_uids": [
                         "InteractivePlan",
                         "Test2",
                         "Custom_0"
                     ],
-                    "runtime_status": "ready",
-                    "status": "unknown",
-                    "status_override": null,
-                    "status_reason": null,
                     "suite_related": false,
-                    "tags": {},
                     "timer": {},
+                    "status": "unknown",
+                    "category": "testcase",
+                    "tags": {},
                     "type": "TestCaseReport",
-                    "uid": "send_and_receive_msg"
+                    "runtime_status": "ready"
                 }
             ],
-            "env_status": null,
+            "logs": [],
+            "strict_order": false,
             "events": {},
             "fix_spec_path": null,
-            "hash": 0,
-            "host": null,
-            "definition_name": "Custom_0",
-            "logs": [],
-            "name": "Custom_0",
+            "timer": {},
             "parent_uids": [
                 "InteractivePlan",
                 "Test2"
             ],
             "part": null,
-            "runtime_status": "ready",
             "status": "unknown",
-            "status_override": null,
+            "host": null,
+            "runtime_status": "ready",
             "status_reason": null,
-            "strict_order": false,
-            "tags": {},
-            "timer": {},
-            "type": "TestGroupReport",
-            "uid": "Custom_0"
-        },
-        {
-            "category": "testsuite",
             "counter": {
-                "failed": 0,
                 "passed": 0,
+                "failed": 0,
                 "total": 1,
                 "unknown": 1
             },
+            "suite_related": false,
             "description": null,
+            "uid": "Custom_0",
+            "category": "testsuite",
+            "tags": {},
+            "type": "TestGroupReport",
+            "definition_name": "Custom_0",
+            "name": "Custom_0",
+            "status_override": null,
+            "hash": 0,
+            "env_status": null
+        },
+        {
             "entries": [
                 {
-                    "category": "testcase",
+                    "definition_name": "send_and_receive_msg",
+                    "status_reason": null,
+                    "entries": [],
                     "counter": {
-                        "failed": 0,
                         "passed": 0,
+                        "failed": 0,
                         "total": 1,
                         "unknown": 1
                     },
-                    "description": "Client sends a message, server received and responds back.",
-                    "entries": [],
-                    "hash": 0,
-                    "definition_name": "send_and_receive_msg",
                     "logs": [],
                     "name": "send_and_receive_msg",
+                    "status_override": null,
+                    "description": "Client sends a message, server received and responds back.",
+                    "uid": "send_and_receive_msg",
+                    "hash": 0,
                     "parent_uids": [
                         "InteractivePlan",
                         "Test2",
                         "Custom_1"
                     ],
-                    "runtime_status": "ready",
-                    "status": "unknown",
-                    "status_override": null,
-                    "status_reason": null,
                     "suite_related": false,
-                    "tags": {},
                     "timer": {},
+                    "status": "unknown",
+                    "category": "testcase",
+                    "tags": {},
                     "type": "TestCaseReport",
-                    "uid": "send_and_receive_msg"
+                    "runtime_status": "ready"
                 }
             ],
-            "env_status": null,
+            "logs": [],
+            "strict_order": false,
             "events": {},
             "fix_spec_path": null,
-            "hash": 0,
-            "host": null,
-            "definition_name": "Custom_1",
-            "logs": [],
-            "name": "Custom_1",
+            "timer": {},
             "parent_uids": [
                 "InteractivePlan",
                 "Test2"
             ],
             "part": null,
-            "runtime_status": "ready",
             "status": "unknown",
-            "status_override": null,
+            "host": null,
+            "runtime_status": "ready",
             "status_reason": null,
-            "strict_order": false,
+            "counter": {
+                "passed": 0,
+                "failed": 0,
+                "total": 1,
+                "unknown": 1
+            },
+            "suite_related": false,
+            "description": null,
+            "uid": "Custom_1",
+            "category": "testsuite",
             "tags": {},
-            "timer": {},
             "type": "TestGroupReport",
-            "uid": "Custom_1"
+            "definition_name": "Custom_1",
+            "name": "Custom_1",
+            "status_override": null,
+            "hash": 0,
+            "env_status": null
         }
     ],
-    "env_status": "STARTED",
+    "logs": [],
+    "strict_order": false,
     "events": {},
     "fix_spec_path": null,
-    "hash": 0,
-    "host": null,
-    "definition_name": "Test2",
-    "logs": [],
-    "name": "Test2",
+    "timer": {
+        "setup": {
+            "start": "2023-11-28T01:56:24.908341+00:00",
+            "end": "2023-11-28T01:56:25.004204+00:00"
+        }
+    },
     "parent_uids": [
         "InteractivePlan"
     ],
     "part": null,
-    "runtime_status": "ready",
     "status": "unknown",
-    "status_override": null,
+    "host": null,
+    "runtime_status": "ready",
     "status_reason": null,
-    "strict_order": false,
+    "counter": {
+        "passed": 1,
+        "failed": 0,
+        "total": 6,
+        "unknown": 5
+    },
+    "suite_related": false,
+    "description": null,
+    "uid": "Test2",
+    "category": "multitest",
     "tags": {},
-    "timer": {},
     "type": "TestGroupReport",
-    "uid": "Test2"
+    "definition_name": "Test2",
+    "name": "Test2",
+    "status_override": null,
+    "hash": 0,
+    "env_status": "STARTED"
 }

--- a/tests/functional/testplan/runnable/interactive/reports/basic_top_level.data
+++ b/tests/functional/testplan/runnable/interactive/reports/basic_top_level.data
@@ -1,70 +1,126 @@
 {
-    "attachments": {},
     "category": "testplan",
-    "counter": {
-        "failed": 0,
-        "passed": 10,
-        "total": 10
-    },
-    "description": null,
+    "timer": {},
+    "timeout": null,
+    "label": null,
+    "tags_index": {},
     "entries": [
         {
-            "category": "multitest",
-            "counter": {
-                "failed": 0,
-                "passed": 5,
-                "total": 5
+            "timer": {
+                "setup": {
+                    "end": "2023-11-28T01:37:32.827827+00:00",
+                    "start": "2023-11-28T01:37:32.732003+00:00"
+                }
             },
+            "env_status": "STARTED",
+            "parent_uids": [
+                "InteractivePlan"
+            ],
+            "suite_related": false,
+            "status_reason": null,
+            "tags": {},
             "description": null,
             "entries": [
                 {
-                    "category": "testsuite",
-                    "counter": {
-                        "failed": 0,
-                        "passed": 3,
-                        "total": 3
-                    },
+                    "timer": {},
+                    "env_status": null,
+                    "parent_uids": [
+                        "InteractivePlan",
+                        "Test1"
+                    ],
+                    "suite_related": true,
+                    "status_reason": null,
+                    "tags": {},
                     "description": null,
                     "entries": [
                         {
-                            "category": "parametrization",
-                            "counter": {
-                                "failed": 0,
-                                "passed": 3,
-                                "total": 3
+                            "category": "testcase",
+                            "timer": {
+                                "run": {
+                                    "end": "2023-11-28T01:37:32.822326+00:00",
+                                    "start": "2023-11-28T01:37:32.822288+00:00"
+                                }
                             },
+                            "name": "accept_connection",
+                            "parent_uids": [
+                                "InteractivePlan",
+                                "Test1",
+                                "After Start"
+                            ],
+                            "status_override": null,
+                            "suite_related": true,
+                            "counter": {
+                                "passed": 1,
+                                "failed": 0,
+                                "total": 1
+                            },
+                            "logs": [],
+                            "uid": "accept_connection",
+                            "status_reason": null,
+                            "tags": {},
+                            "description": null,
+                            "definition_name": "accept_connection",
+                            "hash": 0,
+                            "type": "TestCaseReport",
+                            "entries": [],
+                            "runtime_status": "finished",
+                            "status": "passed"
+                        }
+                    ],
+                    "counter": {
+                        "passed": 1,
+                        "failed": 0,
+                        "total": 1
+                    },
+                    "runtime_status": "finished",
+                    "fix_spec_path": null,
+                    "logs": [],
+                    "status_override": null,
+                    "events": {},
+                    "category": "testsuite",
+                    "part": null,
+                    "uid": "After Start",
+                    "host": null,
+                    "definition_name": "After Start",
+                    "type": "TestGroupReport",
+                    "name": "After Start",
+                    "strict_order": false,
+                    "hash": 0,
+                    "status": "passed"
+                },
+                {
+                    "timer": {},
+                    "env_status": null,
+                    "parent_uids": [
+                        "InteractivePlan",
+                        "Test1"
+                    ],
+                    "suite_related": false,
+                    "status_reason": null,
+                    "tags": {},
+                    "description": null,
+                    "entries": [
+                        {
+                            "timer": {},
+                            "env_status": null,
+                            "parent_uids": [
+                                "InteractivePlan",
+                                "Test1",
+                                "BasicSuite"
+                            ],
+                            "suite_related": false,
+                            "status_reason": null,
+                            "tags": {},
                             "description": null,
                             "entries": [
                                 {
                                     "category": "testcase",
-                                    "counter": {
-                                        "failed": 0,
-                                        "passed": 1,
-                                        "total": 1
-                                    },
-                                    "description": null,
-                                    "entries": [
-                                        {
-                                            "category": "DEFAULT",
-                                            "description": "Passing assertion",
-                                            "file_path": "",
-                                            "first": 1,
-                                            "flag": "DEFAULT",
-                                            "label": "==",
-                                            "line_no": 0,
-                                            "machine_time": "",
-                                            "meta_type": "assertion",
-                                            "passed": true,
-                                            "second": 1,
-                                            "type": "Equal",
-                                            "type_actual": "int",
-                                            "type_expected": "int",
-                                            "utc_time": ""
+                                    "timer": {
+                                        "run": {
+                                            "end": "2023-11-28T01:37:33.128568+00:00",
+                                            "start": "2023-11-28T01:37:32.836496+00:00"
                                         }
-                                    ],
-                                    "hash": 0,
-                                    "definition_name": "basic_case <arg=0>",
-                                    "logs": [],
+                                    },
                                     "name": "basic_case <arg=0>",
                                     "parent_uids": [
                                         "InteractivePlan",
@@ -72,51 +128,51 @@
                                         "BasicSuite",
                                         "basic_case"
                                     ],
-                                    "runtime_status": "finished",
-                                    "status": "passed",
                                     "status_override": null,
-                                    "status_reason": null,
                                     "suite_related": false,
-                                    "tags": {},
-                                    "timer": {
-                                        "run": {
-                                            "end": "",
-                                            "start": ""
-                                        }
+                                    "counter": {
+                                        "passed": 1,
+                                        "failed": 0,
+                                        "total": 1
                                     },
+                                    "logs": [],
+                                    "uid": "basic_case__arg_0",
+                                    "status_reason": null,
+                                    "tags": {},
+                                    "description": null,
+                                    "definition_name": "basic_case <arg=0>",
+                                    "hash": 0,
                                     "type": "TestCaseReport",
-                                    "uid": "basic_case__arg_0"
+                                    "entries": [
+                                        {
+                                            "line_no": 47,
+                                            "category": "DEFAULT",
+                                            "type_actual": "int",
+                                            "type_expected": "int",
+                                            "file_path": "",
+                                            "label": "==",
+                                            "flag": "DEFAULT",
+                                            "passed": true,
+                                            "second": 1,
+                                            "first": 1,
+                                            "description": "Passing assertion",
+                                            "machine_time": "2023-11-28T09:37:32.836576+08:00",
+                                            "type": "Equal",
+                                            "meta_type": "assertion",
+                                            "utc_time": "2023-11-28T01:37:32.836568+00:00"
+                                        }
+                                    ],
+                                    "runtime_status": "finished",
+                                    "status": "passed"
                                 },
                                 {
                                     "category": "testcase",
-                                    "counter": {
-                                        "failed": 0,
-                                        "passed": 1,
-                                        "total": 1
-                                    },
-                                    "description": null,
-                                    "entries": [
-                                        {
-                                            "category": "DEFAULT",
-                                            "description": "Passing assertion",
-                                            "file_path": "",
-                                            "first": 1,
-                                            "flag": "DEFAULT",
-                                            "label": "==",
-                                            "line_no": 0,
-                                            "machine_time": "",
-                                            "meta_type": "assertion",
-                                            "passed": true,
-                                            "second": 1,
-                                            "type": "Equal",
-                                            "type_actual": "int",
-                                            "type_expected": "int",
-                                            "utc_time": ""
+                                    "timer": {
+                                        "run": {
+                                            "end": "2023-11-28T01:37:33.132432+00:00",
+                                            "start": "2023-11-28T01:37:33.129520+00:00"
                                         }
-                                    ],
-                                    "hash": 0,
-                                    "definition_name": "basic_case <arg=1>",
-                                    "logs": [],
+                                    },
                                     "name": "basic_case <arg=1>",
                                     "parent_uids": [
                                         "InteractivePlan",
@@ -124,51 +180,51 @@
                                         "BasicSuite",
                                         "basic_case"
                                     ],
-                                    "runtime_status": "finished",
-                                    "status": "passed",
                                     "status_override": null,
-                                    "status_reason": null,
                                     "suite_related": false,
-                                    "tags": {},
-                                    "timer": {
-                                        "run": {
-                                            "end": "",
-                                            "start": ""
-                                        }
+                                    "counter": {
+                                        "passed": 1,
+                                        "failed": 0,
+                                        "total": 1
                                     },
+                                    "logs": [],
+                                    "uid": "basic_case__arg_1",
+                                    "status_reason": null,
+                                    "tags": {},
+                                    "description": null,
+                                    "definition_name": "basic_case <arg=1>",
+                                    "hash": 0,
                                     "type": "TestCaseReport",
-                                    "uid": "basic_case__arg_1"
+                                    "entries": [
+                                        {
+                                            "line_no": 47,
+                                            "category": "DEFAULT",
+                                            "type_actual": "int",
+                                            "type_expected": "int",
+                                            "file_path": "",
+                                            "label": "==",
+                                            "flag": "DEFAULT",
+                                            "passed": true,
+                                            "second": 1,
+                                            "first": 1,
+                                            "description": "Passing assertion",
+                                            "machine_time": "2023-11-28T09:37:33.129578+08:00",
+                                            "type": "Equal",
+                                            "meta_type": "assertion",
+                                            "utc_time": "2023-11-28T01:37:33.129569+00:00"
+                                        }
+                                    ],
+                                    "runtime_status": "finished",
+                                    "status": "passed"
                                 },
                                 {
                                     "category": "testcase",
-                                    "counter": {
-                                        "failed": 0,
-                                        "passed": 1,
-                                        "total": 1
-                                    },
-                                    "description": null,
-                                    "entries": [
-                                        {
-                                            "category": "DEFAULT",
-                                            "description": "Passing assertion",
-                                            "file_path": "",
-                                            "first": 1,
-                                            "flag": "DEFAULT",
-                                            "label": "==",
-                                            "line_no": 0,
-                                            "machine_time": "",
-                                            "meta_type": "assertion",
-                                            "passed": true,
-                                            "second": 1,
-                                            "type": "Equal",
-                                            "type_actual": "int",
-                                            "type_expected": "int",
-                                            "utc_time": ""
+                                    "timer": {
+                                        "run": {
+                                            "end": "2023-11-28T01:37:33.136022+00:00",
+                                            "start": "2023-11-28T01:37:33.133301+00:00"
                                         }
-                                    ],
-                                    "hash": 0,
-                                    "definition_name": "basic_case <arg=2>",
-                                    "logs": [],
+                                    },
                                     "name": "basic_case <arg=2>",
                                     "parent_uids": [
                                         "InteractivePlan",
@@ -176,352 +232,429 @@
                                         "BasicSuite",
                                         "basic_case"
                                     ],
-                                    "runtime_status": "finished",
-                                    "status": "passed",
                                     "status_override": null,
-                                    "status_reason": null,
                                     "suite_related": false,
-                                    "tags": {},
-                                    "timer": {
-                                        "run": {
-                                            "end": "",
-                                            "start": ""
-                                        }
+                                    "counter": {
+                                        "passed": 1,
+                                        "failed": 0,
+                                        "total": 1
                                     },
+                                    "logs": [],
+                                    "uid": "basic_case__arg_2",
+                                    "status_reason": null,
+                                    "tags": {},
+                                    "description": null,
+                                    "definition_name": "basic_case <arg=2>",
+                                    "hash": 0,
                                     "type": "TestCaseReport",
-                                    "uid": "basic_case__arg_2"
+                                    "entries": [
+                                        {
+                                            "line_no": 47,
+                                            "category": "DEFAULT",
+                                            "type_actual": "int",
+                                            "type_expected": "int",
+                                            "file_path": "",
+                                            "label": "==",
+                                            "flag": "DEFAULT",
+                                            "passed": true,
+                                            "second": 1,
+                                            "first": 1,
+                                            "description": "Passing assertion",
+                                            "machine_time": "2023-11-28T09:37:33.133353+08:00",
+                                            "type": "Equal",
+                                            "meta_type": "assertion",
+                                            "utc_time": "2023-11-28T01:37:33.133348+00:00"
+                                        }
+                                    ],
+                                    "runtime_status": "finished",
+                                    "status": "passed"
                                 }
                             ],
-                            "env_status": null,
-                            "events": {},
+                            "counter": {
+                                "passed": 3,
+                                "failed": 0,
+                                "total": 3
+                            },
+                            "runtime_status": "finished",
                             "fix_spec_path": null,
-                            "hash": 0,
+                            "logs": [],
+                            "status_override": null,
+                            "events": {},
+                            "category": "parametrization",
+                            "part": null,
+                            "uid": "basic_case",
                             "host": null,
                             "definition_name": "basic_case",
-                            "logs": [],
-                            "name": "basic_case",
-                            "parent_uids": [
-                                "InteractivePlan",
-                                "Test1",
-                                "BasicSuite"
-                            ],
-                            "part": null,
-                            "runtime_status": "finished",
-                            "status": "passed",
-                            "status_override": null,
-                            "status_reason": null,
-                            "strict_order": false,
-                            "tags": {},
-                            "timer": {},
                             "type": "TestGroupReport",
-                            "uid": "basic_case"
+                            "name": "basic_case",
+                            "strict_order": false,
+                            "hash": 0,
+                            "status": "passed"
                         }
                     ],
-                    "env_status": null,
-                    "events": {},
+                    "counter": {
+                        "passed": 3,
+                        "failed": 0,
+                        "total": 3
+                    },
+                    "runtime_status": "finished",
                     "fix_spec_path": null,
-                    "hash": 0,
+                    "logs": [],
+                    "status_override": null,
+                    "events": {},
+                    "category": "testsuite",
+                    "part": null,
+                    "uid": "BasicSuite",
                     "host": null,
                     "definition_name": "BasicSuite",
-                    "logs": [],
+                    "type": "TestGroupReport",
                     "name": "BasicSuite",
+                    "strict_order": false,
+                    "hash": 0,
+                    "status": "passed"
+                },
+                {
+                    "timer": {},
+                    "env_status": null,
                     "parent_uids": [
                         "InteractivePlan",
                         "Test1"
                     ],
-                    "part": null,
-                    "runtime_status": "finished",
-                    "status": "passed",
-                    "status_override": null,
+                    "suite_related": false,
                     "status_reason": null,
-                    "strict_order": false,
                     "tags": {},
-                    "timer": {},
-                    "type": "TestGroupReport",
-                    "uid": "BasicSuite"
-                },
-                {
-                    "category": "testsuite",
-                    "counter": {
-                        "failed": 0,
-                        "passed": 1,
-                        "total": 1
-                    },
                     "description": null,
                     "entries": [
                         {
                             "category": "testcase",
-                            "counter": {
-                                "failed": 0,
-                                "passed": 1,
-                                "total": 1
-                            },
-                            "description": "Client sends a message, server received and responds back.",
-                            "entries": [
-                                {
-                                    "category": "DEFAULT",
-                                    "description": "Server received",
-                                    "file_path": "",
-                                    "first": "hello",
-                                    "flag": "DEFAULT",
-                                    "label": "==",
-                                    "line_no": 0,
-                                    "machine_time": "",
-                                    "meta_type": "assertion",
-                                    "passed": true,
-                                    "second": "hello",
-                                    "type": "Equal",
-                                    "type_actual": "str",
-                                    "type_expected": "str",
-                                    "utc_time": ""
-                                },
-                                {
-                                    "category": "DEFAULT",
-                                    "description": "Client received",
-                                    "file_path": "",
-                                    "first": "world",
-                                    "flag": "DEFAULT",
-                                    "label": "==",
-                                    "line_no": 0,
-                                    "machine_time": "",
-                                    "meta_type": "assertion",
-                                    "passed": true,
-                                    "second": "world",
-                                    "type": "Equal",
-                                    "type_actual": "str",
-                                    "type_expected": "str",
-                                    "utc_time": ""
+                            "timer": {
+                                "run": {
+                                    "end": "2023-11-28T01:37:33.142366+00:00",
+                                    "start": "2023-11-28T01:37:33.136925+00:00"
                                 }
-                            ],
-                            "hash": 0,
-                            "definition_name": "send_and_receive_msg",
-                            "logs": [],
+                            },
                             "name": "send_and_receive_msg",
                             "parent_uids": [
                                 "InteractivePlan",
                                 "Test1",
                                 "Custom_0"
                             ],
-                            "runtime_status": "finished",
-                            "status": "passed",
                             "status_override": null,
-                            "status_reason": null,
                             "suite_related": false,
-                            "tags": {},
-                            "timer": {
-                                "run": {
-                                    "end": "",
-                                    "start": ""
-                                }
+                            "counter": {
+                                "passed": 1,
+                                "failed": 0,
+                                "total": 1
                             },
+                            "logs": [],
+                            "uid": "send_and_receive_msg",
+                            "status_reason": null,
+                            "tags": {},
+                            "description": "Client sends a message, server received and responds back.",
+                            "definition_name": "send_and_receive_msg",
+                            "hash": 0,
                             "type": "TestCaseReport",
-                            "uid": "send_and_receive_msg"
+                            "entries": [
+                                {
+                                    "line_no": 62,
+                                    "category": "DEFAULT",
+                                    "type_actual": "str",
+                                    "type_expected": "str",
+                                    "file_path": "",
+                                    "label": "==",
+                                    "flag": "DEFAULT",
+                                    "passed": true,
+                                    "second": "hello",
+                                    "first": "hello",
+                                    "description": "Server received",
+                                    "machine_time": "2023-11-28T09:37:33.137081+08:00",
+                                    "type": "Equal",
+                                    "meta_type": "assertion",
+                                    "utc_time": "2023-11-28T01:37:33.137075+00:00"
+                                },
+                                {
+                                    "line_no": 66,
+                                    "category": "DEFAULT",
+                                    "type_actual": "str",
+                                    "type_expected": "str",
+                                    "file_path": "",
+                                    "label": "==",
+                                    "flag": "DEFAULT",
+                                    "passed": true,
+                                    "second": "world",
+                                    "first": "world",
+                                    "description": "Client received",
+                                    "machine_time": "2023-11-28T09:37:33.139719+08:00",
+                                    "type": "Equal",
+                                    "meta_type": "assertion",
+                                    "utc_time": "2023-11-28T01:37:33.139713+00:00"
+                                }
+                            ],
+                            "runtime_status": "finished",
+                            "status": "passed"
                         }
                     ],
-                    "env_status": null,
-                    "events": {},
+                    "counter": {
+                        "passed": 1,
+                        "failed": 0,
+                        "total": 1
+                    },
+                    "runtime_status": "finished",
                     "fix_spec_path": null,
-                    "hash": 0,
+                    "logs": [],
+                    "status_override": null,
+                    "events": {},
+                    "category": "testsuite",
+                    "part": null,
+                    "uid": "Custom_0",
                     "host": null,
                     "definition_name": "Custom_0",
-                    "logs": [],
+                    "type": "TestGroupReport",
                     "name": "Custom_0",
+                    "strict_order": false,
+                    "hash": 0,
+                    "status": "passed"
+                },
+                {
+                    "timer": {},
+                    "env_status": null,
                     "parent_uids": [
                         "InteractivePlan",
                         "Test1"
                     ],
-                    "part": null,
-                    "runtime_status": "finished",
-                    "status": "passed",
-                    "status_override": null,
+                    "suite_related": false,
                     "status_reason": null,
-                    "strict_order": false,
                     "tags": {},
-                    "timer": {},
-                    "type": "TestGroupReport",
-                    "uid": "Custom_0"
-                },
-                {
-                    "category": "testsuite",
-                    "counter": {
-                        "failed": 0,
-                        "passed": 1,
-                        "total": 1
-                    },
                     "description": null,
                     "entries": [
                         {
                             "category": "testcase",
-                            "counter": {
-                                "failed": 0,
-                                "passed": 1,
-                                "total": 1
-                            },
-                            "description": "Client sends a message, server received and responds back.",
-                            "entries": [
-                                {
-                                    "category": "DEFAULT",
-                                    "description": "Server received",
-                                    "file_path": "",
-                                    "first": "hello",
-                                    "flag": "DEFAULT",
-                                    "label": "==",
-                                    "line_no": 0,
-                                    "machine_time": "",
-                                    "meta_type": "assertion",
-                                    "passed": true,
-                                    "second": "hello",
-                                    "type": "Equal",
-                                    "type_actual": "str",
-                                    "type_expected": "str",
-                                    "utc_time": ""
-                                },
-                                {
-                                    "category": "DEFAULT",
-                                    "description": "Client received",
-                                    "file_path": "",
-                                    "first": "world",
-                                    "flag": "DEFAULT",
-                                    "label": "==",
-                                    "line_no": 0,
-                                    "machine_time": "",
-                                    "meta_type": "assertion",
-                                    "passed": true,
-                                    "second": "world",
-                                    "type": "Equal",
-                                    "type_actual": "str",
-                                    "type_expected": "str",
-                                    "utc_time": ""
+                            "timer": {
+                                "run": {
+                                    "end": "2023-11-28T01:37:33.149147+00:00",
+                                    "start": "2023-11-28T01:37:33.143734+00:00"
                                 }
-                            ],
-                            "hash": 0,
-                            "definition_name": "send_and_receive_msg",
-                            "logs": [],
+                            },
                             "name": "send_and_receive_msg",
                             "parent_uids": [
                                 "InteractivePlan",
                                 "Test1",
                                 "Custom_1"
                             ],
-                            "runtime_status": "finished",
-                            "status": "passed",
                             "status_override": null,
-                            "status_reason": null,
                             "suite_related": false,
-                            "tags": {},
-                            "timer": {
-                                "run": {
-                                    "end": "",
-                                    "start": ""
-                                }
+                            "counter": {
+                                "passed": 1,
+                                "failed": 0,
+                                "total": 1
                             },
+                            "logs": [],
+                            "uid": "send_and_receive_msg",
+                            "status_reason": null,
+                            "tags": {},
+                            "description": "Client sends a message, server received and responds back.",
+                            "definition_name": "send_and_receive_msg",
+                            "hash": 0,
                             "type": "TestCaseReport",
-                            "uid": "send_and_receive_msg"
+                            "entries": [
+                                {
+                                    "line_no": 62,
+                                    "category": "DEFAULT",
+                                    "type_actual": "str",
+                                    "type_expected": "str",
+                                    "file_path": "",
+                                    "label": "==",
+                                    "flag": "DEFAULT",
+                                    "passed": true,
+                                    "second": "hello",
+                                    "first": "hello",
+                                    "description": "Server received",
+                                    "machine_time": "2023-11-28T09:37:33.143891+08:00",
+                                    "type": "Equal",
+                                    "meta_type": "assertion",
+                                    "utc_time": "2023-11-28T01:37:33.143884+00:00"
+                                },
+                                {
+                                    "line_no": 66,
+                                    "category": "DEFAULT",
+                                    "type_actual": "str",
+                                    "type_expected": "str",
+                                    "file_path": "",
+                                    "label": "==",
+                                    "flag": "DEFAULT",
+                                    "passed": true,
+                                    "second": "world",
+                                    "first": "world",
+                                    "description": "Client received",
+                                    "machine_time": "2023-11-28T09:37:33.146491+08:00",
+                                    "type": "Equal",
+                                    "meta_type": "assertion",
+                                    "utc_time": "2023-11-28T01:37:33.146485+00:00"
+                                }
+                            ],
+                            "runtime_status": "finished",
+                            "status": "passed"
                         }
                     ],
-                    "env_status": null,
-                    "events": {},
+                    "counter": {
+                        "passed": 1,
+                        "failed": 0,
+                        "total": 1
+                    },
+                    "runtime_status": "finished",
                     "fix_spec_path": null,
-                    "hash": 0,
+                    "logs": [],
+                    "status_override": null,
+                    "events": {},
+                    "category": "testsuite",
+                    "part": null,
+                    "uid": "Custom_1",
                     "host": null,
                     "definition_name": "Custom_1",
-                    "logs": [],
-                    "name": "Custom_1",
-                    "parent_uids": [
-                        "InteractivePlan",
-                        "Test1"
-                    ],
-                    "part": null,
-                    "runtime_status": "finished",
-                    "status": "passed",
-                    "status_override": null,
-                    "status_reason": null,
-                    "strict_order": false,
-                    "tags": {},
-                    "timer": {},
                     "type": "TestGroupReport",
-                    "uid": "Custom_1"
+                    "name": "Custom_1",
+                    "strict_order": false,
+                    "hash": 0,
+                    "status": "passed"
                 }
             ],
-            "env_status": "STARTED",
-            "events": {},
+            "counter": {
+                "passed": 6,
+                "failed": 0,
+                "total": 6
+            },
+            "runtime_status": "finished",
             "fix_spec_path": null,
-            "hash": 0,
+            "logs": [],
+            "status_override": null,
+            "events": {},
+            "category": "multitest",
+            "part": null,
+            "uid": "Test1",
             "host": null,
             "definition_name": "Test1",
-            "logs": [],
+            "type": "TestGroupReport",
             "name": "Test1",
+            "strict_order": false,
+            "hash": 0,
+            "status": "passed"
+        },
+        {
+            "timer": {
+                "setup": {
+                    "end": "2023-11-28T01:37:33.252825+00:00",
+                    "start": "2023-11-28T01:37:33.156004+00:00"
+                }
+            },
+            "env_status": "STARTED",
             "parent_uids": [
                 "InteractivePlan"
             ],
-            "part": null,
-            "runtime_status": "finished",
-            "status": "passed",
-            "status_override": null,
+            "suite_related": false,
             "status_reason": null,
-            "strict_order": false,
             "tags": {},
-            "timer": {},
-            "type": "TestGroupReport",
-            "uid": "Test1"
-        },
-        {
-            "category": "multitest",
-            "counter": {
-                "failed": 0,
-                "passed": 5,
-                "total": 5
-            },
             "description": null,
             "entries": [
                 {
-                    "category": "testsuite",
-                    "counter": {
-                        "failed": 0,
-                        "passed": 3,
-                        "total": 3
-                    },
+                    "timer": {},
+                    "env_status": null,
+                    "parent_uids": [
+                        "InteractivePlan",
+                        "Test2"
+                    ],
+                    "suite_related": true,
+                    "status_reason": null,
+                    "tags": {},
                     "description": null,
                     "entries": [
                         {
-                            "category": "parametrization",
-                            "counter": {
-                                "failed": 0,
-                                "passed": 3,
-                                "total": 3
+                            "category": "testcase",
+                            "timer": {
+                                "run": {
+                                    "end": "2023-11-28T01:37:33.247217+00:00",
+                                    "start": "2023-11-28T01:37:33.247184+00:00"
+                                }
                             },
+                            "name": "accept_connection",
+                            "parent_uids": [
+                                "InteractivePlan",
+                                "Test2",
+                                "After Start"
+                            ],
+                            "status_override": null,
+                            "suite_related": true,
+                            "counter": {
+                                "passed": 1,
+                                "failed": 0,
+                                "total": 1
+                            },
+                            "logs": [],
+                            "uid": "accept_connection",
+                            "status_reason": null,
+                            "tags": {},
+                            "description": null,
+                            "definition_name": "accept_connection",
+                            "hash": 0,
+                            "type": "TestCaseReport",
+                            "entries": [],
+                            "runtime_status": "finished",
+                            "status": "passed"
+                        }
+                    ],
+                    "counter": {
+                        "passed": 1,
+                        "failed": 0,
+                        "total": 1
+                    },
+                    "runtime_status": "finished",
+                    "fix_spec_path": null,
+                    "logs": [],
+                    "status_override": null,
+                    "events": {},
+                    "category": "testsuite",
+                    "part": null,
+                    "uid": "After Start",
+                    "host": null,
+                    "definition_name": "After Start",
+                    "type": "TestGroupReport",
+                    "name": "After Start",
+                    "strict_order": false,
+                    "hash": 0,
+                    "status": "passed"
+                },
+                {
+                    "timer": {},
+                    "env_status": null,
+                    "parent_uids": [
+                        "InteractivePlan",
+                        "Test2"
+                    ],
+                    "suite_related": false,
+                    "status_reason": null,
+                    "tags": {},
+                    "description": null,
+                    "entries": [
+                        {
+                            "timer": {},
+                            "env_status": null,
+                            "parent_uids": [
+                                "InteractivePlan",
+                                "Test2",
+                                "BasicSuite"
+                            ],
+                            "suite_related": false,
+                            "status_reason": null,
+                            "tags": {},
                             "description": null,
                             "entries": [
                                 {
                                     "category": "testcase",
-                                    "counter": {
-                                        "failed": 0,
-                                        "passed": 1,
-                                        "total": 1
-                                    },
-                                    "description": null,
-                                    "entries": [
-                                        {
-                                            "category": "DEFAULT",
-                                            "description": "Passing assertion",
-                                            "file_path": "",
-                                            "first": 1,
-                                            "flag": "DEFAULT",
-                                            "label": "==",
-                                            "line_no": 0,
-                                            "machine_time": "",
-                                            "meta_type": "assertion",
-                                            "passed": true,
-                                            "second": 1,
-                                            "type": "Equal",
-                                            "type_actual": "int",
-                                            "type_expected": "int",
-                                            "utc_time": ""
+                                    "timer": {
+                                        "run": {
+                                            "end": "2023-11-28T01:37:33.263859+00:00",
+                                            "start": "2023-11-28T01:37:33.261016+00:00"
                                         }
-                                    ],
-                                    "hash": 0,
-                                    "definition_name": "basic_case <arg=0>",
-                                    "logs": [],
+                                    },
                                     "name": "basic_case <arg=0>",
                                     "parent_uids": [
                                         "InteractivePlan",
@@ -529,51 +662,51 @@
                                         "BasicSuite",
                                         "basic_case"
                                     ],
-                                    "runtime_status": "finished",
-                                    "status": "passed",
                                     "status_override": null,
-                                    "status_reason": null,
                                     "suite_related": false,
-                                    "tags": {},
-                                    "timer": {
-                                        "run": {
-                                            "end": "",
-                                            "start": ""
-                                        }
+                                    "counter": {
+                                        "passed": 1,
+                                        "failed": 0,
+                                        "total": 1
                                     },
+                                    "logs": [],
+                                    "uid": "basic_case__arg_0",
+                                    "status_reason": null,
+                                    "tags": {},
+                                    "description": null,
+                                    "definition_name": "basic_case <arg=0>",
+                                    "hash": 0,
                                     "type": "TestCaseReport",
-                                    "uid": "basic_case__arg_0"
+                                    "entries": [
+                                        {
+                                            "line_no": 47,
+                                            "category": "DEFAULT",
+                                            "type_actual": "int",
+                                            "type_expected": "int",
+                                            "file_path": "",
+                                            "label": "==",
+                                            "flag": "DEFAULT",
+                                            "passed": true,
+                                            "second": 1,
+                                            "first": 1,
+                                            "description": "Passing assertion",
+                                            "machine_time": "2023-11-28T09:37:33.261072+08:00",
+                                            "type": "Equal",
+                                            "meta_type": "assertion",
+                                            "utc_time": "2023-11-28T01:37:33.261067+00:00"
+                                        }
+                                    ],
+                                    "runtime_status": "finished",
+                                    "status": "passed"
                                 },
                                 {
                                     "category": "testcase",
-                                    "counter": {
-                                        "failed": 0,
-                                        "passed": 1,
-                                        "total": 1
-                                    },
-                                    "description": null,
-                                    "entries": [
-                                        {
-                                            "category": "DEFAULT",
-                                            "description": "Passing assertion",
-                                            "file_path": "",
-                                            "first": 1,
-                                            "flag": "DEFAULT",
-                                            "label": "==",
-                                            "line_no": 0,
-                                            "machine_time": "",
-                                            "meta_type": "assertion",
-                                            "passed": true,
-                                            "second": 1,
-                                            "type": "Equal",
-                                            "type_actual": "int",
-                                            "type_expected": "int",
-                                            "utc_time": ""
+                                    "timer": {
+                                        "run": {
+                                            "end": "2023-11-28T01:37:33.267536+00:00",
+                                            "start": "2023-11-28T01:37:33.264749+00:00"
                                         }
-                                    ],
-                                    "hash": 0,
-                                    "definition_name": "basic_case <arg=1>",
-                                    "logs": [],
+                                    },
                                     "name": "basic_case <arg=1>",
                                     "parent_uids": [
                                         "InteractivePlan",
@@ -581,51 +714,51 @@
                                         "BasicSuite",
                                         "basic_case"
                                     ],
-                                    "runtime_status": "finished",
-                                    "status": "passed",
                                     "status_override": null,
-                                    "status_reason": null,
                                     "suite_related": false,
-                                    "tags": {},
-                                    "timer": {
-                                        "run": {
-                                            "end": "",
-                                            "start": ""
-                                        }
+                                    "counter": {
+                                        "passed": 1,
+                                        "failed": 0,
+                                        "total": 1
                                     },
+                                    "logs": [],
+                                    "uid": "basic_case__arg_1",
+                                    "status_reason": null,
+                                    "tags": {},
+                                    "description": null,
+                                    "definition_name": "basic_case <arg=1>",
+                                    "hash": 0,
                                     "type": "TestCaseReport",
-                                    "uid": "basic_case__arg_1"
+                                    "entries": [
+                                        {
+                                            "line_no": 47,
+                                            "category": "DEFAULT",
+                                            "type_actual": "int",
+                                            "type_expected": "int",
+                                            "file_path": "",
+                                            "label": "==",
+                                            "flag": "DEFAULT",
+                                            "passed": true,
+                                            "second": 1,
+                                            "first": 1,
+                                            "description": "Passing assertion",
+                                            "machine_time": "2023-11-28T09:37:33.264809+08:00",
+                                            "type": "Equal",
+                                            "meta_type": "assertion",
+                                            "utc_time": "2023-11-28T01:37:33.264804+00:00"
+                                        }
+                                    ],
+                                    "runtime_status": "finished",
+                                    "status": "passed"
                                 },
                                 {
                                     "category": "testcase",
-                                    "counter": {
-                                        "failed": 0,
-                                        "passed": 1,
-                                        "total": 1
-                                    },
-                                    "description": null,
-                                    "entries": [
-                                        {
-                                            "category": "DEFAULT",
-                                            "description": "Passing assertion",
-                                            "file_path": "",
-                                            "first": 1,
-                                            "flag": "DEFAULT",
-                                            "label": "==",
-                                            "line_no": 0,
-                                            "machine_time": "",
-                                            "meta_type": "assertion",
-                                            "passed": true,
-                                            "second": 1,
-                                            "type": "Equal",
-                                            "type_actual": "int",
-                                            "type_expected": "int",
-                                            "utc_time": ""
+                                    "timer": {
+                                        "run": {
+                                            "end": "2023-11-28T01:37:33.271152+00:00",
+                                            "start": "2023-11-28T01:37:33.268423+00:00"
                                         }
-                                    ],
-                                    "hash": 0,
-                                    "definition_name": "basic_case <arg=2>",
-                                    "logs": [],
+                                    },
                                     "name": "basic_case <arg=2>",
                                     "parent_uids": [
                                         "InteractivePlan",
@@ -633,307 +766,341 @@
                                         "BasicSuite",
                                         "basic_case"
                                     ],
-                                    "runtime_status": "finished",
-                                    "status": "passed",
                                     "status_override": null,
-                                    "status_reason": null,
                                     "suite_related": false,
-                                    "tags": {},
-                                    "timer": {
-                                        "run": {
-                                            "end": "",
-                                            "start": ""
-                                        }
+                                    "counter": {
+                                        "passed": 1,
+                                        "failed": 0,
+                                        "total": 1
                                     },
+                                    "logs": [],
+                                    "uid": "basic_case__arg_2",
+                                    "status_reason": null,
+                                    "tags": {},
+                                    "description": null,
+                                    "definition_name": "basic_case <arg=2>",
+                                    "hash": 0,
                                     "type": "TestCaseReport",
-                                    "uid": "basic_case__arg_2"
+                                    "entries": [
+                                        {
+                                            "line_no": 47,
+                                            "category": "DEFAULT",
+                                            "type_actual": "int",
+                                            "type_expected": "int",
+                                            "file_path": "",
+                                            "label": "==",
+                                            "flag": "DEFAULT",
+                                            "passed": true,
+                                            "second": 1,
+                                            "first": 1,
+                                            "description": "Passing assertion",
+                                            "machine_time": "2023-11-28T09:37:33.268477+08:00",
+                                            "type": "Equal",
+                                            "meta_type": "assertion",
+                                            "utc_time": "2023-11-28T01:37:33.268473+00:00"
+                                        }
+                                    ],
+                                    "runtime_status": "finished",
+                                    "status": "passed"
                                 }
                             ],
-                            "env_status": null,
-                            "events": {},
+                            "counter": {
+                                "passed": 3,
+                                "failed": 0,
+                                "total": 3
+                            },
+                            "runtime_status": "finished",
                             "fix_spec_path": null,
-                            "hash": 0,
+                            "logs": [],
+                            "status_override": null,
+                            "events": {},
+                            "category": "parametrization",
+                            "part": null,
+                            "uid": "basic_case",
                             "host": null,
                             "definition_name": "basic_case",
-                            "logs": [],
-                            "name": "basic_case",
-                            "parent_uids": [
-                                "InteractivePlan",
-                                "Test2",
-                                "BasicSuite"
-                            ],
-                            "part": null,
-                            "runtime_status": "finished",
-                            "status": "passed",
-                            "status_override": null,
-                            "status_reason": null,
-                            "strict_order": false,
-                            "tags": {},
-                            "timer": {},
                             "type": "TestGroupReport",
-                            "uid": "basic_case"
+                            "name": "basic_case",
+                            "strict_order": false,
+                            "hash": 0,
+                            "status": "passed"
                         }
                     ],
-                    "env_status": null,
-                    "events": {},
+                    "counter": {
+                        "passed": 3,
+                        "failed": 0,
+                        "total": 3
+                    },
+                    "runtime_status": "finished",
                     "fix_spec_path": null,
-                    "hash": 0,
+                    "logs": [],
+                    "status_override": null,
+                    "events": {},
+                    "category": "testsuite",
+                    "part": null,
+                    "uid": "BasicSuite",
                     "host": null,
                     "definition_name": "BasicSuite",
-                    "logs": [],
+                    "type": "TestGroupReport",
                     "name": "BasicSuite",
+                    "strict_order": false,
+                    "hash": 0,
+                    "status": "passed"
+                },
+                {
+                    "timer": {},
+                    "env_status": null,
                     "parent_uids": [
                         "InteractivePlan",
                         "Test2"
                     ],
-                    "part": null,
-                    "runtime_status": "finished",
-                    "status": "passed",
-                    "status_override": null,
+                    "suite_related": false,
                     "status_reason": null,
-                    "strict_order": false,
                     "tags": {},
-                    "timer": {},
-                    "type": "TestGroupReport",
-                    "uid": "BasicSuite"
-                },
-                {
-                    "category": "testsuite",
-                    "counter": {
-                        "failed": 0,
-                        "passed": 1,
-                        "total": 1
-                    },
                     "description": null,
                     "entries": [
                         {
                             "category": "testcase",
-                            "counter": {
-                                "failed": 0,
-                                "passed": 1,
-                                "total": 1
-                            },
-                            "description": "Client sends a message, server received and responds back.",
-                            "entries": [
-                                {
-                                    "category": "DEFAULT",
-                                    "description": "Server received",
-                                    "file_path": "",
-                                    "first": "hello",
-                                    "flag": "DEFAULT",
-                                    "label": "==",
-                                    "line_no": 0,
-                                    "machine_time": "",
-                                    "meta_type": "assertion",
-                                    "passed": true,
-                                    "second": "hello",
-                                    "type": "Equal",
-                                    "type_actual": "str",
-                                    "type_expected": "str",
-                                    "utc_time": ""
-                                },
-                                {
-                                    "category": "DEFAULT",
-                                    "description": "Client received",
-                                    "file_path": "",
-                                    "first": "world",
-                                    "flag": "DEFAULT",
-                                    "label": "==",
-                                    "line_no": 0,
-                                    "machine_time": "",
-                                    "meta_type": "assertion",
-                                    "passed": true,
-                                    "second": "world",
-                                    "type": "Equal",
-                                    "type_actual": "str",
-                                    "type_expected": "str",
-                                    "utc_time": ""
+                            "timer": {
+                                "run": {
+                                    "end": "2023-11-28T01:37:33.277749+00:00",
+                                    "start": "2023-11-28T01:37:33.272092+00:00"
                                 }
-                            ],
-                            "hash": 0,
-                            "definition_name": "send_and_receive_msg",
-                            "logs": [],
+                            },
                             "name": "send_and_receive_msg",
                             "parent_uids": [
                                 "InteractivePlan",
                                 "Test2",
                                 "Custom_0"
                             ],
-                            "runtime_status": "finished",
-                            "status": "passed",
                             "status_override": null,
-                            "status_reason": null,
                             "suite_related": false,
-                            "tags": {},
-                            "timer": {
-                                "run": {
-                                    "end": "",
-                                    "start": ""
-                                }
+                            "counter": {
+                                "passed": 1,
+                                "failed": 0,
+                                "total": 1
                             },
+                            "logs": [],
+                            "uid": "send_and_receive_msg",
+                            "status_reason": null,
+                            "tags": {},
+                            "description": "Client sends a message, server received and responds back.",
+                            "definition_name": "send_and_receive_msg",
+                            "hash": 0,
                             "type": "TestCaseReport",
-                            "uid": "send_and_receive_msg"
+                            "entries": [
+                                {
+                                    "line_no": 62,
+                                    "category": "DEFAULT",
+                                    "type_actual": "str",
+                                    "type_expected": "str",
+                                    "file_path": "",
+                                    "label": "==",
+                                    "flag": "DEFAULT",
+                                    "passed": true,
+                                    "second": "hello",
+                                    "first": "hello",
+                                    "description": "Server received",
+                                    "machine_time": "2023-11-28T09:37:33.272240+08:00",
+                                    "type": "Equal",
+                                    "meta_type": "assertion",
+                                    "utc_time": "2023-11-28T01:37:33.272224+00:00"
+                                },
+                                {
+                                    "line_no": 66,
+                                    "category": "DEFAULT",
+                                    "type_actual": "str",
+                                    "type_expected": "str",
+                                    "file_path": "",
+                                    "label": "==",
+                                    "flag": "DEFAULT",
+                                    "passed": true,
+                                    "second": "world",
+                                    "first": "world",
+                                    "description": "Client received",
+                                    "machine_time": "2023-11-28T09:37:33.275067+08:00",
+                                    "type": "Equal",
+                                    "meta_type": "assertion",
+                                    "utc_time": "2023-11-28T01:37:33.275060+00:00"
+                                }
+                            ],
+                            "runtime_status": "finished",
+                            "status": "passed"
                         }
                     ],
-                    "env_status": null,
-                    "events": {},
+                    "counter": {
+                        "passed": 1,
+                        "failed": 0,
+                        "total": 1
+                    },
+                    "runtime_status": "finished",
                     "fix_spec_path": null,
-                    "hash": 0,
+                    "logs": [],
+                    "status_override": null,
+                    "events": {},
+                    "category": "testsuite",
+                    "part": null,
+                    "uid": "Custom_0",
                     "host": null,
                     "definition_name": "Custom_0",
-                    "logs": [],
+                    "type": "TestGroupReport",
                     "name": "Custom_0",
+                    "strict_order": false,
+                    "hash": 0,
+                    "status": "passed"
+                },
+                {
+                    "timer": {},
+                    "env_status": null,
                     "parent_uids": [
                         "InteractivePlan",
                         "Test2"
                     ],
-                    "part": null,
-                    "runtime_status": "finished",
-                    "status": "passed",
-                    "status_override": null,
+                    "suite_related": false,
                     "status_reason": null,
-                    "strict_order": false,
                     "tags": {},
-                    "timer": {},
-                    "type": "TestGroupReport",
-                    "uid": "Custom_0"
-                },
-                {
-                    "category": "testsuite",
-                    "counter": {
-                        "failed": 0,
-                        "passed": 1,
-                        "total": 1
-                    },
                     "description": null,
                     "entries": [
                         {
                             "category": "testcase",
-                            "counter": {
-                                "failed": 0,
-                                "passed": 1,
-                                "total": 1
-                            },
-                            "description": "Client sends a message, server received and responds back.",
-                            "entries": [
-                                {
-                                    "category": "DEFAULT",
-                                    "description": "Server received",
-                                    "file_path": "",
-                                    "first": "hello",
-                                    "flag": "DEFAULT",
-                                    "label": "==",
-                                    "line_no": 0,
-                                    "machine_time": "",
-                                    "meta_type": "assertion",
-                                    "passed": true,
-                                    "second": "hello",
-                                    "type": "Equal",
-                                    "type_actual": "str",
-                                    "type_expected": "str",
-                                    "utc_time": ""
-                                },
-                                {
-                                    "category": "DEFAULT",
-                                    "description": "Client received",
-                                    "file_path": "",
-                                    "first": "world",
-                                    "flag": "DEFAULT",
-                                    "label": "==",
-                                    "line_no": 0,
-                                    "machine_time": "",
-                                    "meta_type": "assertion",
-                                    "passed": true,
-                                    "second": "world",
-                                    "type": "Equal",
-                                    "type_actual": "str",
-                                    "type_expected": "str",
-                                    "utc_time": ""
+                            "timer": {
+                                "run": {
+                                    "end": "2023-11-28T01:37:33.284805+00:00",
+                                    "start": "2023-11-28T01:37:33.279347+00:00"
                                 }
-                            ],
-                            "hash": 0,
-                            "definition_name": "send_and_receive_msg",
-                            "logs": [],
+                            },
                             "name": "send_and_receive_msg",
                             "parent_uids": [
                                 "InteractivePlan",
                                 "Test2",
                                 "Custom_1"
                             ],
-                            "runtime_status": "finished",
-                            "status": "passed",
                             "status_override": null,
-                            "status_reason": null,
                             "suite_related": false,
-                            "tags": {},
-                            "timer": {
-                                "run": {
-                                    "end": "",
-                                    "start": ""
-                                }
+                            "counter": {
+                                "passed": 1,
+                                "failed": 0,
+                                "total": 1
                             },
+                            "logs": [],
+                            "uid": "send_and_receive_msg",
+                            "status_reason": null,
+                            "tags": {},
+                            "description": "Client sends a message, server received and responds back.",
+                            "definition_name": "send_and_receive_msg",
+                            "hash": 0,
                             "type": "TestCaseReport",
-                            "uid": "send_and_receive_msg"
+                            "entries": [
+                                {
+                                    "line_no": 62,
+                                    "category": "DEFAULT",
+                                    "type_actual": "str",
+                                    "type_expected": "str",
+                                    "file_path": "",
+                                    "label": "==",
+                                    "flag": "DEFAULT",
+                                    "passed": true,
+                                    "second": "hello",
+                                    "first": "hello",
+                                    "description": "Server received",
+                                    "machine_time": "2023-11-28T09:37:33.279453+08:00",
+                                    "type": "Equal",
+                                    "meta_type": "assertion",
+                                    "utc_time": "2023-11-28T01:37:33.279447+00:00"
+                                },
+                                {
+                                    "line_no": 66,
+                                    "category": "DEFAULT",
+                                    "type_actual": "str",
+                                    "type_expected": "str",
+                                    "file_path": "",
+                                    "label": "==",
+                                    "flag": "DEFAULT",
+                                    "passed": true,
+                                    "second": "world",
+                                    "first": "world",
+                                    "description": "Client received",
+                                    "machine_time": "2023-11-28T09:37:33.282080+08:00",
+                                    "type": "Equal",
+                                    "meta_type": "assertion",
+                                    "utc_time": "2023-11-28T01:37:33.282073+00:00"
+                                }
+                            ],
+                            "runtime_status": "finished",
+                            "status": "passed"
                         }
                     ],
-                    "env_status": null,
-                    "events": {},
+                    "counter": {
+                        "passed": 1,
+                        "failed": 0,
+                        "total": 1
+                    },
+                    "runtime_status": "finished",
                     "fix_spec_path": null,
-                    "hash": 0,
+                    "logs": [],
+                    "status_override": null,
+                    "events": {},
+                    "category": "testsuite",
+                    "part": null,
+                    "uid": "Custom_1",
                     "host": null,
                     "definition_name": "Custom_1",
-                    "logs": [],
-                    "name": "Custom_1",
-                    "parent_uids": [
-                        "InteractivePlan",
-                        "Test2"
-                    ],
-                    "part": null,
-                    "runtime_status": "finished",
-                    "status": "passed",
-                    "status_override": null,
-                    "status_reason": null,
-                    "strict_order": false,
-                    "tags": {},
-                    "timer": {},
                     "type": "TestGroupReport",
-                    "uid": "Custom_1"
+                    "name": "Custom_1",
+                    "strict_order": false,
+                    "hash": 0,
+                    "status": "passed"
                 }
             ],
-            "env_status": "STARTED",
-            "events": {},
+            "counter": {
+                "passed": 6,
+                "failed": 0,
+                "total": 6
+            },
+            "runtime_status": "finished",
             "fix_spec_path": null,
-            "hash": 0,
+            "logs": [],
+            "status_override": null,
+            "events": {},
+            "category": "multitest",
+            "part": null,
+            "uid": "Test2",
             "host": null,
             "definition_name": "Test2",
-            "logs": [],
-            "name": "Test2",
-            "parent_uids": [
-                "InteractivePlan"
-            ],
-            "part": null,
-            "runtime_status": "finished",
-            "status": "passed",
-            "status_override": null,
-            "status_reason": null,
-            "strict_order": false,
-            "tags": {},
-            "timer": {},
             "type": "TestGroupReport",
-            "uid": "Test2"
+            "name": "Test2",
+            "strict_order": false,
+            "hash": 0,
+            "status": "passed"
         }
     ],
-    "events": {},
-    "information": [],
-    "label": null,
+    "counter": {
+        "passed": 12,
+        "failed": 0,
+        "total": 12
+    },
     "logs": [],
-    "meta": {},
-    "name": "InteractivePlan",
+    "uid": "InteractivePlan",
     "runtime_status": "finished",
-    "status": "passed",
+    "events": {},
+    "information": [
+        [
+            "user",
+            "yifan"
+        ],
+        [
+            "command_line_string",
+            "script/run_pytest.py --tests oss/tests/functional/testplan/runnable/interactive/test_interactive.py::test_top_level_tests"
+        ],
+        [
+            "python_version",
+            "3.7.5"
+        ]
+    ],
+    "attachments": {},
     "status_override": null,
-    "tags_index": {},
-    "timeout": null,
-    "timer": {},
-    "uid": "InteractivePlan"
+    "description": null,
+    "name": "InteractivePlan",
+    "status": "passed",
+    "meta": {}
 }

--- a/tests/functional/testplan/runnable/interactive/reports/basic_top_level_reset.data
+++ b/tests/functional/testplan/runnable/interactive/reports/basic_top_level_reset.data
@@ -1,662 +1,813 @@
 {
+    "information": [
+        [
+            "user",
+            "yifan"
+        ],
+        [
+            "command_line_string",
+            "script/run_pytest.py --tests oss/tests/functional/testplan/runnable/interactive/test_interactive.py::test_top_level_tests"
+        ],
+        [
+            "python_version",
+            "3.7.5"
+        ]
+    ],
+    "timer": {},
+    "status_override": null,
     "attachments": {},
     "category": "testplan",
-    "counter": {
-        "failed": 0,
-        "passed": 0,
-        "total": 10,
-        "unknown": 10
-    },
-    "description": null,
+    "tags_index": {},
+    "status": "unknown",
     "entries": [
         {
-            "category": "multitest",
-            "counter": {
-                "failed": 0,
-                "passed": 0,
-                "total": 5,
-                "unknown": 5
-            },
-            "description": null,
             "entries": [
                 {
-                    "category": "testsuite",
-                    "counter": {
-                        "failed": 0,
-                        "passed": 0,
-                        "total": 3,
-                        "unknown": 3
-                    },
-                    "description": null,
                     "entries": [
                         {
-                            "category": "parametrization",
+                            "hash": 0,
+                            "type": "TestCaseReport",
+                            "status_override": null,
+                            "entries": [],
+                            "category": "testcase",
+                            "timer": {},
+                            "status": "unknown",
+                            "tags": {},
+                            "parent_uids": [
+                                "InteractivePlan",
+                                "Test1",
+                                "After Start"
+                            ],
+                            "description": null,
+                            "suite_related": true,
+                            "name": "accept_connection",
                             "counter": {
-                                "failed": 0,
                                 "passed": 0,
+                                "failed": 0,
+                                "total": 1,
+                                "unknown": 1
+                            },
+                            "status_reason": null,
+                            "uid": "accept_connection",
+                            "runtime_status": "ready",
+                            "logs": [],
+                            "definition_name": "accept_connection"
+                        }
+                    ],
+                    "strict_order": false,
+                    "status_override": null,
+                    "tags": {},
+                    "status": "unknown",
+                    "suite_related": true,
+                    "hash": 0,
+                    "fix_spec_path": null,
+                    "category": "testsuite",
+                    "events": {},
+                    "name": "After Start",
+                    "counter": {
+                        "passed": 0,
+                        "failed": 0,
+                        "total": 1,
+                        "unknown": 1
+                    },
+                    "status_reason": null,
+                    "host": null,
+                    "definition_name": "After Start",
+                    "env_status": null,
+                    "type": "TestGroupReport",
+                    "timer": {},
+                    "parent_uids": [
+                        "InteractivePlan",
+                        "Test1"
+                    ],
+                    "description": null,
+                    "part": null,
+                    "uid": "After Start",
+                    "runtime_status": "ready",
+                    "logs": []
+                },
+                {
+                    "entries": [
+                        {
+                            "entries": [
+                                {
+                                    "hash": 0,
+                                    "type": "TestCaseReport",
+                                    "status_override": null,
+                                    "entries": [],
+                                    "category": "testcase",
+                                    "timer": {},
+                                    "status": "unknown",
+                                    "tags": {},
+                                    "parent_uids": [
+                                        "InteractivePlan",
+                                        "Test1",
+                                        "BasicSuite",
+                                        "basic_case"
+                                    ],
+                                    "description": null,
+                                    "suite_related": false,
+                                    "name": "basic_case <arg=0>",
+                                    "counter": {
+                                        "passed": 0,
+                                        "failed": 0,
+                                        "total": 1,
+                                        "unknown": 1
+                                    },
+                                    "status_reason": null,
+                                    "uid": "basic_case__arg_0",
+                                    "runtime_status": "ready",
+                                    "logs": [],
+                                    "definition_name": "basic_case <arg=0>"
+                                },
+                                {
+                                    "hash": 0,
+                                    "type": "TestCaseReport",
+                                    "status_override": null,
+                                    "entries": [],
+                                    "category": "testcase",
+                                    "timer": {},
+                                    "status": "unknown",
+                                    "tags": {},
+                                    "parent_uids": [
+                                        "InteractivePlan",
+                                        "Test1",
+                                        "BasicSuite",
+                                        "basic_case"
+                                    ],
+                                    "description": null,
+                                    "suite_related": false,
+                                    "name": "basic_case <arg=1>",
+                                    "counter": {
+                                        "passed": 0,
+                                        "failed": 0,
+                                        "total": 1,
+                                        "unknown": 1
+                                    },
+                                    "status_reason": null,
+                                    "uid": "basic_case__arg_1",
+                                    "runtime_status": "ready",
+                                    "logs": [],
+                                    "definition_name": "basic_case <arg=1>"
+                                },
+                                {
+                                    "hash": 0,
+                                    "type": "TestCaseReport",
+                                    "status_override": null,
+                                    "entries": [],
+                                    "category": "testcase",
+                                    "timer": {},
+                                    "status": "unknown",
+                                    "tags": {},
+                                    "parent_uids": [
+                                        "InteractivePlan",
+                                        "Test1",
+                                        "BasicSuite",
+                                        "basic_case"
+                                    ],
+                                    "description": null,
+                                    "suite_related": false,
+                                    "name": "basic_case <arg=2>",
+                                    "counter": {
+                                        "passed": 0,
+                                        "failed": 0,
+                                        "total": 1,
+                                        "unknown": 1
+                                    },
+                                    "status_reason": null,
+                                    "uid": "basic_case__arg_2",
+                                    "runtime_status": "ready",
+                                    "logs": [],
+                                    "definition_name": "basic_case <arg=2>"
+                                }
+                            ],
+                            "strict_order": false,
+                            "status_override": null,
+                            "tags": {},
+                            "status": "unknown",
+                            "suite_related": false,
+                            "hash": 0,
+                            "fix_spec_path": null,
+                            "category": "parametrization",
+                            "events": {},
+                            "name": "basic_case",
+                            "counter": {
+                                "passed": 0,
+                                "failed": 0,
                                 "total": 3,
                                 "unknown": 3
                             },
-                            "description": null,
-                            "entries": [
-                                {
-                                    "category": "testcase",
-                                    "counter": {
-                                        "failed": 0,
-                                        "passed": 0,
-                                        "total": 1,
-                                        "unknown": 1
-                                    },
-                                    "description": null,
-                                    "entries": [],
-                                    "hash": 0,
-                                    "definition_name": "basic_case <arg=0>",
-                                    "logs": [],
-                                    "name": "basic_case <arg=0>",
-                                    "parent_uids": [
-                                        "InteractivePlan",
-                                        "Test1",
-                                        "BasicSuite",
-                                        "basic_case"
-                                    ],
-                                    "runtime_status": "ready",
-                                    "status": "unknown",
-                                    "status_override": null,
-                                    "status_reason": null,
-                                    "suite_related": false,
-                                    "tags": {},
-                                    "timer": {},
-                                    "type": "TestCaseReport",
-                                    "uid": "basic_case__arg_0"
-                                },
-                                {
-                                    "category": "testcase",
-                                    "counter": {
-                                        "failed": 0,
-                                        "passed": 0,
-                                        "total": 1,
-                                        "unknown": 1
-                                    },
-                                    "description": null,
-                                    "entries": [],
-                                    "hash": 0,
-                                    "definition_name": "basic_case <arg=1>",
-                                    "logs": [],
-                                    "name": "basic_case <arg=1>",
-                                    "parent_uids": [
-                                        "InteractivePlan",
-                                        "Test1",
-                                        "BasicSuite",
-                                        "basic_case"
-                                    ],
-                                    "runtime_status": "ready",
-                                    "status": "unknown",
-                                    "status_override": null,
-                                    "status_reason": null,
-                                    "suite_related": false,
-                                    "tags": {},
-                                    "timer": {},
-                                    "type": "TestCaseReport",
-                                    "uid": "basic_case__arg_1"
-                                },
-                                {
-                                    "category": "testcase",
-                                    "counter": {
-                                        "failed": 0,
-                                        "passed": 0,
-                                        "total": 1,
-                                        "unknown": 1
-                                    },
-                                    "description": null,
-                                    "entries": [],
-                                    "hash": 0,
-                                    "definition_name": "basic_case <arg=2>",
-                                    "logs": [],
-                                    "name": "basic_case <arg=2>",
-                                    "parent_uids": [
-                                        "InteractivePlan",
-                                        "Test1",
-                                        "BasicSuite",
-                                        "basic_case"
-                                    ],
-                                    "runtime_status": "ready",
-                                    "status": "unknown",
-                                    "status_override": null,
-                                    "status_reason": null,
-                                    "suite_related": false,
-                                    "tags": {},
-                                    "timer": {},
-                                    "type": "TestCaseReport",
-                                    "uid": "basic_case__arg_2"
-                                }
-                            ],
-                            "env_status": null,
-                            "events": {},
-                            "fix_spec_path": null,
-                            "hash": 0,
+                            "status_reason": null,
                             "host": null,
                             "definition_name": "basic_case",
-                            "logs": [],
-                            "name": "basic_case",
+                            "env_status": null,
+                            "type": "TestGroupReport",
+                            "timer": {},
                             "parent_uids": [
                                 "InteractivePlan",
                                 "Test1",
                                 "BasicSuite"
                             ],
+                            "description": null,
                             "part": null,
+                            "uid": "basic_case",
                             "runtime_status": "ready",
-                            "status": "unknown",
-                            "status_override": null,
-                            "status_reason": null,
-                            "strict_order": false,
-                            "tags": {},
-                            "timer": {},
-                            "type": "TestGroupReport",
-                            "uid": "basic_case"
+                            "logs": []
                         }
                     ],
-                    "env_status": null,
-                    "events": {},
-                    "fix_spec_path": null,
+                    "strict_order": false,
+                    "status_override": null,
+                    "tags": {},
+                    "status": "unknown",
+                    "suite_related": false,
                     "hash": 0,
+                    "fix_spec_path": null,
+                    "category": "testsuite",
+                    "events": {},
+                    "name": "BasicSuite",
+                    "counter": {
+                        "passed": 0,
+                        "failed": 0,
+                        "total": 3,
+                        "unknown": 3
+                    },
+                    "status_reason": null,
                     "host": null,
                     "definition_name": "BasicSuite",
-                    "logs": [],
-                    "name": "BasicSuite",
+                    "env_status": null,
+                    "type": "TestGroupReport",
+                    "timer": {},
                     "parent_uids": [
                         "InteractivePlan",
                         "Test1"
                     ],
+                    "description": null,
                     "part": null,
+                    "uid": "BasicSuite",
                     "runtime_status": "ready",
-                    "status": "unknown",
-                    "status_override": null,
-                    "status_reason": null,
-                    "strict_order": false,
-                    "tags": {},
-                    "timer": {},
-                    "type": "TestGroupReport",
-                    "uid": "BasicSuite"
+                    "logs": []
                 },
                 {
-                    "category": "testsuite",
-                    "counter": {
-                        "failed": 0,
-                        "passed": 0,
-                        "total": 1,
-                        "unknown": 1
-                    },
-                    "description": null,
                     "entries": [
                         {
-                            "category": "testcase",
-                            "counter": {
-                                "failed": 0,
-                                "passed": 0,
-                                "total": 1,
-                                "unknown": 1
-                            },
-                            "description": "Client sends a message, server received and responds back.",
-                            "entries": [],
                             "hash": 0,
-                            "definition_name": "send_and_receive_msg",
-                            "logs": [],
-                            "name": "send_and_receive_msg",
+                            "type": "TestCaseReport",
+                            "status_override": null,
+                            "entries": [],
+                            "category": "testcase",
+                            "timer": {},
+                            "status": "unknown",
+                            "tags": {},
                             "parent_uids": [
                                 "InteractivePlan",
                                 "Test1",
                                 "Custom_0"
                             ],
-                            "runtime_status": "ready",
-                            "status": "unknown",
-                            "status_override": null,
-                            "status_reason": null,
+                            "description": "Client sends a message, server received and responds back.",
                             "suite_related": false,
-                            "tags": {},
-                            "timer": {},
-                            "type": "TestCaseReport",
-                            "uid": "send_and_receive_msg"
+                            "name": "send_and_receive_msg",
+                            "counter": {
+                                "passed": 0,
+                                "failed": 0,
+                                "total": 1,
+                                "unknown": 1
+                            },
+                            "status_reason": null,
+                            "uid": "send_and_receive_msg",
+                            "runtime_status": "ready",
+                            "logs": [],
+                            "definition_name": "send_and_receive_msg"
                         }
                     ],
-                    "env_status": null,
-                    "events": {},
-                    "fix_spec_path": null,
+                    "strict_order": false,
+                    "status_override": null,
+                    "tags": {},
+                    "status": "unknown",
+                    "suite_related": false,
                     "hash": 0,
+                    "fix_spec_path": null,
+                    "category": "testsuite",
+                    "events": {},
+                    "name": "Custom_0",
+                    "counter": {
+                        "passed": 0,
+                        "failed": 0,
+                        "total": 1,
+                        "unknown": 1
+                    },
+                    "status_reason": null,
                     "host": null,
                     "definition_name": "Custom_0",
-                    "logs": [],
-                    "name": "Custom_0",
+                    "env_status": null,
+                    "type": "TestGroupReport",
+                    "timer": {},
                     "parent_uids": [
                         "InteractivePlan",
                         "Test1"
                     ],
+                    "description": null,
                     "part": null,
+                    "uid": "Custom_0",
                     "runtime_status": "ready",
-                    "status": "unknown",
-                    "status_override": null,
-                    "status_reason": null,
-                    "strict_order": false,
-                    "tags": {},
-                    "timer": {},
-                    "type": "TestGroupReport",
-                    "uid": "Custom_0"
+                    "logs": []
                 },
                 {
-                    "category": "testsuite",
-                    "counter": {
-                        "failed": 0,
-                        "passed": 0,
-                        "total": 1,
-                        "unknown": 1
-                    },
-                    "description": null,
                     "entries": [
                         {
-                            "category": "testcase",
-                            "counter": {
-                                "failed": 0,
-                                "passed": 0,
-                                "total": 1,
-                                "unknown": 1
-                            },
-                            "description": "Client sends a message, server received and responds back.",
-                            "entries": [],
                             "hash": 0,
-                            "definition_name": "send_and_receive_msg",
-                            "logs": [],
-                            "name": "send_and_receive_msg",
+                            "type": "TestCaseReport",
+                            "status_override": null,
+                            "entries": [],
+                            "category": "testcase",
+                            "timer": {},
+                            "status": "unknown",
+                            "tags": {},
                             "parent_uids": [
                                 "InteractivePlan",
                                 "Test1",
                                 "Custom_1"
                             ],
-                            "runtime_status": "ready",
-                            "status": "unknown",
-                            "status_override": null,
-                            "status_reason": null,
+                            "description": "Client sends a message, server received and responds back.",
                             "suite_related": false,
-                            "tags": {},
-                            "timer": {},
-                            "type": "TestCaseReport",
-                            "uid": "send_and_receive_msg"
+                            "name": "send_and_receive_msg",
+                            "counter": {
+                                "passed": 0,
+                                "failed": 0,
+                                "total": 1,
+                                "unknown": 1
+                            },
+                            "status_reason": null,
+                            "uid": "send_and_receive_msg",
+                            "runtime_status": "ready",
+                            "logs": [],
+                            "definition_name": "send_and_receive_msg"
                         }
                     ],
-                    "env_status": null,
-                    "events": {},
-                    "fix_spec_path": null,
+                    "strict_order": false,
+                    "status_override": null,
+                    "tags": {},
+                    "status": "unknown",
+                    "suite_related": false,
                     "hash": 0,
+                    "fix_spec_path": null,
+                    "category": "testsuite",
+                    "events": {},
+                    "name": "Custom_1",
+                    "counter": {
+                        "passed": 0,
+                        "failed": 0,
+                        "total": 1,
+                        "unknown": 1
+                    },
+                    "status_reason": null,
                     "host": null,
                     "definition_name": "Custom_1",
-                    "logs": [],
-                    "name": "Custom_1",
+                    "env_status": null,
+                    "type": "TestGroupReport",
+                    "timer": {},
                     "parent_uids": [
                         "InteractivePlan",
                         "Test1"
                     ],
+                    "description": null,
                     "part": null,
+                    "uid": "Custom_1",
                     "runtime_status": "ready",
-                    "status": "unknown",
-                    "status_override": null,
-                    "status_reason": null,
-                    "strict_order": false,
-                    "tags": {},
-                    "timer": {},
-                    "type": "TestGroupReport",
-                    "uid": "Custom_1"
+                    "logs": []
                 }
             ],
-            "env_status": "STOPPED",
-            "events": {},
-            "fix_spec_path": null,
+            "strict_order": false,
+            "status_override": null,
+            "tags": {},
+            "status": "unknown",
+            "suite_related": false,
             "hash": 0,
+            "fix_spec_path": null,
+            "category": "multitest",
+            "events": {},
+            "name": "Test1",
+            "counter": {
+                "passed": 0,
+                "failed": 0,
+                "total": 6,
+                "unknown": 6
+            },
+            "status_reason": null,
             "host": null,
             "definition_name": "Test1",
-            "logs": [],
-            "name": "Test1",
+            "env_status": "STOPPED",
+            "type": "TestGroupReport",
+            "timer": {},
             "parent_uids": [
                 "InteractivePlan"
             ],
+            "description": null,
             "part": null,
+            "uid": "Test1",
             "runtime_status": "ready",
-            "status": "unknown",
-            "status_override": null,
-            "status_reason": null,
-            "strict_order": false,
-            "tags": {},
-            "timer": {},
-            "type": "TestGroupReport",
-            "uid": "Test1"
+            "logs": []
         },
         {
-            "category": "multitest",
-            "counter": {
-                "failed": 0,
-                "passed": 0,
-                "total": 5,
-                "unknown": 5
-            },
-            "description": null,
             "entries": [
                 {
-                    "category": "testsuite",
-                    "counter": {
-                        "failed": 0,
-                        "passed": 0,
-                        "total": 3,
-                        "unknown": 3
-                    },
-                    "description": null,
                     "entries": [
                         {
-                            "category": "parametrization",
+                            "hash": 0,
+                            "type": "TestCaseReport",
+                            "status_override": null,
+                            "entries": [],
+                            "category": "testcase",
+                            "timer": {},
+                            "status": "unknown",
+                            "tags": {},
+                            "parent_uids": [
+                                "InteractivePlan",
+                                "Test2",
+                                "After Start"
+                            ],
+                            "description": null,
+                            "suite_related": true,
+                            "name": "accept_connection",
                             "counter": {
-                                "failed": 0,
                                 "passed": 0,
+                                "failed": 0,
+                                "total": 1,
+                                "unknown": 1
+                            },
+                            "status_reason": null,
+                            "uid": "accept_connection",
+                            "runtime_status": "ready",
+                            "logs": [],
+                            "definition_name": "accept_connection"
+                        }
+                    ],
+                    "strict_order": false,
+                    "status_override": null,
+                    "tags": {},
+                    "status": "unknown",
+                    "suite_related": true,
+                    "hash": 0,
+                    "fix_spec_path": null,
+                    "category": "testsuite",
+                    "events": {},
+                    "name": "After Start",
+                    "counter": {
+                        "passed": 0,
+                        "failed": 0,
+                        "total": 1,
+                        "unknown": 1
+                    },
+                    "status_reason": null,
+                    "host": null,
+                    "definition_name": "After Start",
+                    "env_status": null,
+                    "type": "TestGroupReport",
+                    "timer": {},
+                    "parent_uids": [
+                        "InteractivePlan",
+                        "Test2"
+                    ],
+                    "description": null,
+                    "part": null,
+                    "uid": "After Start",
+                    "runtime_status": "ready",
+                    "logs": []
+                },
+                {
+                    "entries": [
+                        {
+                            "entries": [
+                                {
+                                    "hash": 0,
+                                    "type": "TestCaseReport",
+                                    "status_override": null,
+                                    "entries": [],
+                                    "category": "testcase",
+                                    "timer": {},
+                                    "status": "unknown",
+                                    "tags": {},
+                                    "parent_uids": [
+                                        "InteractivePlan",
+                                        "Test2",
+                                        "BasicSuite",
+                                        "basic_case"
+                                    ],
+                                    "description": null,
+                                    "suite_related": false,
+                                    "name": "basic_case <arg=0>",
+                                    "counter": {
+                                        "passed": 0,
+                                        "failed": 0,
+                                        "total": 1,
+                                        "unknown": 1
+                                    },
+                                    "status_reason": null,
+                                    "uid": "basic_case__arg_0",
+                                    "runtime_status": "ready",
+                                    "logs": [],
+                                    "definition_name": "basic_case <arg=0>"
+                                },
+                                {
+                                    "hash": 0,
+                                    "type": "TestCaseReport",
+                                    "status_override": null,
+                                    "entries": [],
+                                    "category": "testcase",
+                                    "timer": {},
+                                    "status": "unknown",
+                                    "tags": {},
+                                    "parent_uids": [
+                                        "InteractivePlan",
+                                        "Test2",
+                                        "BasicSuite",
+                                        "basic_case"
+                                    ],
+                                    "description": null,
+                                    "suite_related": false,
+                                    "name": "basic_case <arg=1>",
+                                    "counter": {
+                                        "passed": 0,
+                                        "failed": 0,
+                                        "total": 1,
+                                        "unknown": 1
+                                    },
+                                    "status_reason": null,
+                                    "uid": "basic_case__arg_1",
+                                    "runtime_status": "ready",
+                                    "logs": [],
+                                    "definition_name": "basic_case <arg=1>"
+                                },
+                                {
+                                    "hash": 0,
+                                    "type": "TestCaseReport",
+                                    "status_override": null,
+                                    "entries": [],
+                                    "category": "testcase",
+                                    "timer": {},
+                                    "status": "unknown",
+                                    "tags": {},
+                                    "parent_uids": [
+                                        "InteractivePlan",
+                                        "Test2",
+                                        "BasicSuite",
+                                        "basic_case"
+                                    ],
+                                    "description": null,
+                                    "suite_related": false,
+                                    "name": "basic_case <arg=2>",
+                                    "counter": {
+                                        "passed": 0,
+                                        "failed": 0,
+                                        "total": 1,
+                                        "unknown": 1
+                                    },
+                                    "status_reason": null,
+                                    "uid": "basic_case__arg_2",
+                                    "runtime_status": "ready",
+                                    "logs": [],
+                                    "definition_name": "basic_case <arg=2>"
+                                }
+                            ],
+                            "strict_order": false,
+                            "status_override": null,
+                            "tags": {},
+                            "status": "unknown",
+                            "suite_related": false,
+                            "hash": 0,
+                            "fix_spec_path": null,
+                            "category": "parametrization",
+                            "events": {},
+                            "name": "basic_case",
+                            "counter": {
+                                "passed": 0,
+                                "failed": 0,
                                 "total": 3,
                                 "unknown": 3
                             },
-                            "description": null,
-                            "entries": [
-                                {
-                                    "category": "testcase",
-                                    "counter": {
-                                        "failed": 0,
-                                        "passed": 0,
-                                        "total": 1,
-                                        "unknown": 1
-                                    },
-                                    "description": null,
-                                    "entries": [],
-                                    "hash": 0,
-                                    "definition_name": "basic_case <arg=0>",
-                                    "logs": [],
-                                    "name": "basic_case <arg=0>",
-                                    "parent_uids": [
-                                        "InteractivePlan",
-                                        "Test2",
-                                        "BasicSuite",
-                                        "basic_case"
-                                    ],
-                                    "runtime_status": "ready",
-                                    "status": "unknown",
-                                    "status_override": null,
-                                    "status_reason": null,
-                                    "suite_related": false,
-                                    "tags": {},
-                                    "timer": {},
-                                    "type": "TestCaseReport",
-                                    "uid": "basic_case__arg_0"
-                                },
-                                {
-                                    "category": "testcase",
-                                    "counter": {
-                                        "failed": 0,
-                                        "passed": 0,
-                                        "total": 1,
-                                        "unknown": 1
-                                    },
-                                    "description": null,
-                                    "entries": [],
-                                    "hash": 0,
-                                    "definition_name": "basic_case <arg=1>",
-                                    "logs": [],
-                                    "name": "basic_case <arg=1>",
-                                    "parent_uids": [
-                                        "InteractivePlan",
-                                        "Test2",
-                                        "BasicSuite",
-                                        "basic_case"
-                                    ],
-                                    "runtime_status": "ready",
-                                    "status": "unknown",
-                                    "status_override": null,
-                                    "status_reason": null,
-                                    "suite_related": false,
-                                    "tags": {},
-                                    "timer": {},
-                                    "type": "TestCaseReport",
-                                    "uid": "basic_case__arg_1"
-                                },
-                                {
-                                    "category": "testcase",
-                                    "counter": {
-                                        "failed": 0,
-                                        "passed": 0,
-                                        "total": 1,
-                                        "unknown": 1
-                                    },
-                                    "description": null,
-                                    "entries": [],
-                                    "hash": 0,
-                                    "definition_name": "basic_case <arg=2>",
-                                    "logs": [],
-                                    "name": "basic_case <arg=2>",
-                                    "parent_uids": [
-                                        "InteractivePlan",
-                                        "Test2",
-                                        "BasicSuite",
-                                        "basic_case"
-                                    ],
-                                    "runtime_status": "ready",
-                                    "status": "unknown",
-                                    "status_override": null,
-                                    "status_reason": null,
-                                    "suite_related": false,
-                                    "tags": {},
-                                    "timer": {},
-                                    "type": "TestCaseReport",
-                                    "uid": "basic_case__arg_2"
-                                }
-                            ],
-                            "env_status": null,
-                            "events": {},
-                            "fix_spec_path": null,
-                            "hash": 0,
+                            "status_reason": null,
                             "host": null,
                             "definition_name": "basic_case",
-                            "logs": [],
-                            "name": "basic_case",
+                            "env_status": null,
+                            "type": "TestGroupReport",
+                            "timer": {},
                             "parent_uids": [
                                 "InteractivePlan",
                                 "Test2",
                                 "BasicSuite"
                             ],
+                            "description": null,
                             "part": null,
+                            "uid": "basic_case",
                             "runtime_status": "ready",
-                            "status": "unknown",
-                            "status_override": null,
-                            "status_reason": null,
-                            "strict_order": false,
-                            "tags": {},
-                            "timer": {},
-                            "type": "TestGroupReport",
-                            "uid": "basic_case"
+                            "logs": []
                         }
                     ],
-                    "env_status": null,
-                    "events": {},
-                    "fix_spec_path": null,
+                    "strict_order": false,
+                    "status_override": null,
+                    "tags": {},
+                    "status": "unknown",
+                    "suite_related": false,
                     "hash": 0,
+                    "fix_spec_path": null,
+                    "category": "testsuite",
+                    "events": {},
+                    "name": "BasicSuite",
+                    "counter": {
+                        "passed": 0,
+                        "failed": 0,
+                        "total": 3,
+                        "unknown": 3
+                    },
+                    "status_reason": null,
                     "host": null,
                     "definition_name": "BasicSuite",
-                    "logs": [],
-                    "name": "BasicSuite",
+                    "env_status": null,
+                    "type": "TestGroupReport",
+                    "timer": {},
                     "parent_uids": [
                         "InteractivePlan",
                         "Test2"
                     ],
+                    "description": null,
                     "part": null,
+                    "uid": "BasicSuite",
                     "runtime_status": "ready",
-                    "status": "unknown",
-                    "status_override": null,
-                    "status_reason": null,
-                    "strict_order": false,
-                    "tags": {},
-                    "timer": {},
-                    "type": "TestGroupReport",
-                    "uid": "BasicSuite"
+                    "logs": []
                 },
                 {
-                    "category": "testsuite",
-                    "counter": {
-                        "failed": 0,
-                        "passed": 0,
-                        "total": 1,
-                        "unknown": 1
-                    },
-                    "description": null,
                     "entries": [
                         {
-                            "category": "testcase",
-                            "counter": {
-                                "failed": 0,
-                                "passed": 0,
-                                "total": 1,
-                                "unknown": 1
-                            },
-                            "description": "Client sends a message, server received and responds back.",
-                            "entries": [],
                             "hash": 0,
-                            "definition_name": "send_and_receive_msg",
-                            "logs": [],
-                            "name": "send_and_receive_msg",
+                            "type": "TestCaseReport",
+                            "status_override": null,
+                            "entries": [],
+                            "category": "testcase",
+                            "timer": {},
+                            "status": "unknown",
+                            "tags": {},
                             "parent_uids": [
                                 "InteractivePlan",
                                 "Test2",
                                 "Custom_0"
                             ],
-                            "runtime_status": "ready",
-                            "status": "unknown",
-                            "status_override": null,
-                            "status_reason": null,
+                            "description": "Client sends a message, server received and responds back.",
                             "suite_related": false,
-                            "tags": {},
-                            "timer": {},
-                            "type": "TestCaseReport",
-                            "uid": "send_and_receive_msg"
+                            "name": "send_and_receive_msg",
+                            "counter": {
+                                "passed": 0,
+                                "failed": 0,
+                                "total": 1,
+                                "unknown": 1
+                            },
+                            "status_reason": null,
+                            "uid": "send_and_receive_msg",
+                            "runtime_status": "ready",
+                            "logs": [],
+                            "definition_name": "send_and_receive_msg"
                         }
                     ],
-                    "env_status": null,
-                    "events": {},
-                    "fix_spec_path": null,
+                    "strict_order": false,
+                    "status_override": null,
+                    "tags": {},
+                    "status": "unknown",
+                    "suite_related": false,
                     "hash": 0,
+                    "fix_spec_path": null,
+                    "category": "testsuite",
+                    "events": {},
+                    "name": "Custom_0",
+                    "counter": {
+                        "passed": 0,
+                        "failed": 0,
+                        "total": 1,
+                        "unknown": 1
+                    },
+                    "status_reason": null,
                     "host": null,
                     "definition_name": "Custom_0",
-                    "logs": [],
-                    "name": "Custom_0",
+                    "env_status": null,
+                    "type": "TestGroupReport",
+                    "timer": {},
                     "parent_uids": [
                         "InteractivePlan",
                         "Test2"
                     ],
+                    "description": null,
                     "part": null,
+                    "uid": "Custom_0",
                     "runtime_status": "ready",
-                    "status": "unknown",
-                    "status_override": null,
-                    "status_reason": null,
-                    "strict_order": false,
-                    "tags": {},
-                    "timer": {},
-                    "type": "TestGroupReport",
-                    "uid": "Custom_0"
+                    "logs": []
                 },
                 {
-                    "category": "testsuite",
-                    "counter": {
-                        "failed": 0,
-                        "passed": 0,
-                        "total": 1,
-                        "unknown": 1
-                    },
-                    "description": null,
                     "entries": [
                         {
-                            "category": "testcase",
-                            "counter": {
-                                "failed": 0,
-                                "passed": 0,
-                                "total": 1,
-                                "unknown": 1
-                            },
-                            "description": "Client sends a message, server received and responds back.",
-                            "entries": [],
                             "hash": 0,
-                            "definition_name": "send_and_receive_msg",
-                            "logs": [],
-                            "name": "send_and_receive_msg",
+                            "type": "TestCaseReport",
+                            "status_override": null,
+                            "entries": [],
+                            "category": "testcase",
+                            "timer": {},
+                            "status": "unknown",
+                            "tags": {},
                             "parent_uids": [
                                 "InteractivePlan",
                                 "Test2",
                                 "Custom_1"
                             ],
-                            "runtime_status": "ready",
-                            "status": "unknown",
-                            "status_override": null,
-                            "status_reason": null,
+                            "description": "Client sends a message, server received and responds back.",
                             "suite_related": false,
-                            "tags": {},
-                            "timer": {},
-                            "type": "TestCaseReport",
-                            "uid": "send_and_receive_msg"
+                            "name": "send_and_receive_msg",
+                            "counter": {
+                                "passed": 0,
+                                "failed": 0,
+                                "total": 1,
+                                "unknown": 1
+                            },
+                            "status_reason": null,
+                            "uid": "send_and_receive_msg",
+                            "runtime_status": "ready",
+                            "logs": [],
+                            "definition_name": "send_and_receive_msg"
                         }
                     ],
-                    "env_status": null,
-                    "events": {},
-                    "fix_spec_path": null,
+                    "strict_order": false,
+                    "status_override": null,
+                    "tags": {},
+                    "status": "unknown",
+                    "suite_related": false,
                     "hash": 0,
+                    "fix_spec_path": null,
+                    "category": "testsuite",
+                    "events": {},
+                    "name": "Custom_1",
+                    "counter": {
+                        "passed": 0,
+                        "failed": 0,
+                        "total": 1,
+                        "unknown": 1
+                    },
+                    "status_reason": null,
                     "host": null,
                     "definition_name": "Custom_1",
-                    "logs": [],
-                    "name": "Custom_1",
+                    "env_status": null,
+                    "type": "TestGroupReport",
+                    "timer": {},
                     "parent_uids": [
                         "InteractivePlan",
                         "Test2"
                     ],
+                    "description": null,
                     "part": null,
+                    "uid": "Custom_1",
                     "runtime_status": "ready",
-                    "status": "unknown",
-                    "status_override": null,
-                    "status_reason": null,
-                    "strict_order": false,
-                    "tags": {},
-                    "timer": {},
-                    "type": "TestGroupReport",
-                    "uid": "Custom_1"
+                    "logs": []
                 }
             ],
-            "env_status": "STOPPED",
-            "events": {},
-            "fix_spec_path": null,
+            "strict_order": false,
+            "status_override": null,
+            "tags": {},
+            "status": "unknown",
+            "suite_related": false,
             "hash": 0,
+            "fix_spec_path": null,
+            "category": "multitest",
+            "events": {},
+            "name": "Test2",
+            "counter": {
+                "passed": 0,
+                "failed": 0,
+                "total": 6,
+                "unknown": 6
+            },
+            "status_reason": null,
             "host": null,
             "definition_name": "Test2",
-            "logs": [],
-            "name": "Test2",
+            "env_status": "STOPPED",
+            "type": "TestGroupReport",
+            "timer": {},
             "parent_uids": [
                 "InteractivePlan"
             ],
+            "description": null,
             "part": null,
+            "uid": "Test2",
             "runtime_status": "ready",
-            "status": "unknown",
-            "status_override": null,
-            "status_reason": null,
-            "strict_order": false,
-            "tags": {},
-            "timer": {},
-            "type": "TestGroupReport",
-            "uid": "Test2"
+            "logs": []
         }
     ],
     "events": {},
-    "information": [],
+    "description": null,
     "label": null,
-    "logs": [],
-    "meta": {},
     "name": "InteractivePlan",
-    "runtime_status": "ready",
-    "status": "unknown",
-    "status_override": null,
-    "tags_index": {},
+    "counter": {
+        "passed": 0,
+        "failed": 0,
+        "total": 12,
+        "unknown": 12
+    },
     "timeout": null,
-    "timer": {},
-    "uid": "InteractivePlan"
+    "uid": "InteractivePlan",
+    "runtime_status": "ready",
+    "meta": {},
+    "logs": []
 }

--- a/tests/functional/testplan/runnable/interactive/test_api.py
+++ b/tests/functional/testplan/runnable/interactive/test_api.py
@@ -677,7 +677,7 @@ def test_environment_control(plan):
     rsp = requests.put(mtest_url, json=mtest_json)
     assert rsp.status_code == 200
     updated_json = rsp.json()
-    test_api.compare_json(updated_json, mtest_json)
+    test_api.compare_json(updated_json, mtest_json, ignored_keys=["timer"])
     assert updated_json["hash"] != mtest_json["hash"]
 
     # Wait for the environment to become STOPPED.

--- a/tests/functional/testplan/runnable/interactive/test_interactive.py
+++ b/tests/functional/testplan/runnable/interactive/test_interactive.py
@@ -106,15 +106,6 @@ def test_top_level_tests():
         # TESTS AND ASSIGNED RUNNERS
         assert list(plan.interactive.all_tests()) == ["Test1", "Test2"]
 
-        # OPERATE TEST DRIVERS (start/stop)
-        resources = [
-            res.uid() for res in plan.interactive.test("Test2").resources
-        ]
-
-        assert resources == ["server", "client"]
-        for resource in plan.interactive.test("Test2").resources:
-            assert resource.status == resource.STATUS.NONE
-
         plan.interactive.start_test_resources("Test2")  # START
 
         for resource in plan.interactive.test("Test2").resources:

--- a/tests/functional/testplan/runnable/interactive/test_interactive.py
+++ b/tests/functional/testplan/runnable/interactive/test_interactive.py
@@ -110,12 +110,16 @@ def test_top_level_tests():
         resources = [
             res.uid() for res in plan.interactive.test("Test2").resources
         ]
+
         assert resources == ["server", "client"]
         for resource in plan.interactive.test("Test2").resources:
             assert resource.status == resource.STATUS.NONE
+
         plan.interactive.start_test_resources("Test2")  # START
+
         for resource in plan.interactive.test("Test2").resources:
             assert resource.status == resource.STATUS.STARTED
+
         plan.interactive.stop_test_resources("Test2")  # STOP
         for resource in plan.interactive.test("Test2").resources:
             assert resource.status == resource.STATUS.STOPPED
@@ -126,6 +130,7 @@ def test_top_level_tests():
         BTLReset = load_from_json(
             Path(__file__).parent / "reports" / "basic_top_level_reset.data"
         )
+
         assert (
             compare(
                 BTLReset,
@@ -176,11 +181,12 @@ def test_top_level_tests():
         BRSTest2 = load_from_json(
             Path(__file__).parent / "reports" / "basic_run_suite_test2.data"
         )
+
         assert (
             compare(
                 BRSTest2,
                 plan.i.test_report("Test2"),
-                ignore=["hash", "information"],
+                ignore=["hash", "information", "timer"],
             )[0]
             is True
         )
@@ -203,6 +209,7 @@ def test_top_level_tests():
                     "utc_time",
                     "file_path",
                     "line_no",
+                    "timer",
                 ],
             )[0]
             is True

--- a/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
+++ b/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
@@ -453,3 +453,53 @@ def test_multitest_driver_startup_mode(mockplan):
     assert custom_driver_2.pre_stop_fn_cnt == 2
     assert custom_driver_2.post_stop_cnt == 2
     assert custom_driver_2.post_stop_fn_cnt == 2
+
+
+class EnvBuilder:
+    class DummyDriver(Driver):
+        def starting(self):
+            pass
+
+        def stopping(self):
+            pass
+
+    def __init__(self):
+        self.a = self.DummyDriver(name="a")
+        self.b = self.DummyDriver(name="b")
+
+    def env_func(self):
+        return [self.a, self.b]
+
+    def init_ctx_func(self):
+        return {"dummy_ctx": "dummy_value"}
+
+    def dp_func(self):
+        return {self.a: self.b}
+
+
+@testsuite
+class EnvBuilderTest:
+    @testcase
+    def test_env_builder(self, env, result):
+        result.equal(len(env), 2)
+        result.equal(env["dummy_ctx"], "dummy_value")
+
+
+def test_env_builder(mockplan):
+    env_builder = EnvBuilder()
+    mt = MultiTest(
+        name="EnvBuilderTest",
+        suites=EnvBuilderTest(),
+        environment=env_builder.env_func,
+        initial_context=env_builder.init_ctx_func,
+        dependencies=env_builder.dp_func,
+    )
+    mockplan.add(mt)
+    assert len(mt.resources) == 0
+    assert "dummy_ctx" not in mt.resources
+    assert mt.resources._orig_dependency is None
+
+    assert mockplan.run().success is True
+    assert len(mt.resources) == 2
+    assert mt.resources["dummy_ctx"] == "dummy_value"
+    assert mt.resources._rt_dependency.processed == ["b", "a"]

--- a/tests/functional/testplan/testing/multitest/test_pre_post_steps.py
+++ b/tests/functional/testplan/testing/multitest/test_pre_post_steps.py
@@ -61,21 +61,21 @@ def test_pre_post_steps(mockplan):
                 category=ReportCategories.MULTITEST,
                 entries=[
                     TestGroupReport(
-                        name="Before/After Step Checks",
+                        name="Before Start",
                         category=ReportCategories.TESTSUITE,
                         entries=[
                             TestCaseReport(
-                                name="before_start - check_func_1",
+                                name="check_func_1",
                                 entries=[{"type": "Equal", "passed": True}],
                             ),
-                            TestCaseReport(name="after_start - check_func_2"),
-                            TestCaseReport(name="before_stop - check_func_3"),
+                        ],
+                    ),
+                    TestGroupReport(
+                        name="After Start",
+                        category=ReportCategories.TESTSUITE,
+                        entries=[
                             TestCaseReport(
-                                name="after_stop - check_func_4",
-                                entries=[
-                                    {"type": "Equal", "passed": False},
-                                    {"type": "Attachment"},
-                                ],
+                                name="check_func_2",
                             ),
                         ],
                     ),
@@ -87,6 +87,26 @@ def test_pre_post_steps(mockplan):
                             TestCaseReport(
                                 name="teardown",
                                 entries=[{"type": "Attachment"}],
+                            ),
+                        ],
+                    ),
+                    TestGroupReport(
+                        name="Before Stop",
+                        category=ReportCategories.TESTSUITE,
+                        entries=[
+                            TestCaseReport(name="check_func_3"),
+                        ],
+                    ),
+                    TestGroupReport(
+                        name="After Stop",
+                        category=ReportCategories.TESTSUITE,
+                        entries=[
+                            TestCaseReport(
+                                name="check_func_4",
+                                entries=[
+                                    {"type": "Equal", "passed": False},
+                                    {"type": "Attachment"},
+                                ],
                             ),
                         ],
                     ),
@@ -119,10 +139,10 @@ def test_empty_pre_post_steps(mockplan):
                 category=ReportCategories.MULTITEST,
                 entries=[
                     TestGroupReport(
-                        name="Before/After Step Checks",
+                        name="After Start",
                         category=ReportCategories.TESTSUITE,
                         entries=[
-                            TestCaseReport(name="after_start - check_func_2"),
+                            TestCaseReport(name="check_func_2"),
                         ],
                     ),
                     TestGroupReport(

--- a/tests/unit/testplan/test_plan_base.py
+++ b/tests/unit/testplan/test_plan_base.py
@@ -53,7 +53,7 @@ class DummyTest(Test):
             self.__class__.__name__, self.name
         )
 
-    def main_batch_steps(self):
+    def add_main_batch_steps(self):
         self._add_step(self.run_tests)
 
 

--- a/tests/unit/testplan/testing/test_base.py
+++ b/tests/unit/testplan/testing/test_base.py
@@ -90,9 +90,11 @@ def test_time_information():
     assert task_uid == "Dummy"
     assert len(plan.resources["runner"]._input) == 1
     resources = plan.resources["runner"]._input[task_uid].resources
-    assert len(resources) == 2 and "drv1" in resources and "drv2" in resources
+    assert len(resources) == 0
 
     res = plan.run()
+
+    assert len(resources) == 2 and "drv1" in resources and "drv2" in resources
     assert res.run is True
 
     test_report = res.report["Dummy"]

--- a/tests/unit/testplan/testing/test_base.py
+++ b/tests/unit/testplan/testing/test_base.py
@@ -33,23 +33,23 @@ class DummyTest(Test):
             time.sleep(0.5)  # 500ms for execution
             self._result.report.status_override = Status.PASSED
 
-    def pre_resource_steps(self):
+    def add_pre_resource_steps(self):
         self._add_step(lambda: self.result.report.timer.start("flag1"))
-        super(DummyTest, self).pre_resource_steps()
+        super(DummyTest, self).add_pre_resource_steps()
 
-    def pre_main_steps(self):
-        super(DummyTest, self).pre_main_steps()
+    def add_pre_main_steps(self):
+        super(DummyTest, self).add_pre_main_steps()
         self._add_step(lambda: self.result.report.timer.start("flag2"))
 
-    def main_batch_steps(self):
+    def add_main_batch_steps(self):
         self._add_step(self.run_tests)
 
-    def post_main_steps(self):
+    def add_post_main_steps(self):
         self._add_step(lambda: self.result.report.timer.end("flag2"))
-        super(DummyTest, self).post_main_steps()
+        super(DummyTest, self).add_post_main_steps()
 
-    def post_resource_steps(self):
-        super(DummyTest, self).post_resource_steps()
+    def add_post_resource_steps(self):
+        super(DummyTest, self).add_post_resource_steps()
         self._add_step(lambda: self.result.report.timer.end("flag1"))
 
 


### PR DESCRIPTION
## Bug / Requirement Description
- Make environment/dependencies/initial_context take callable
- Interactive mode start/stop_env to use defined step
- before/after_start/stop hook will append entry to report separately

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [x] Test
- [x] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
