### PR TITLE
Migrate class-based assertion type components to functional

### DIFF
--- a/testplan/web_ui/testing/src/AssertionPane/Assertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/Assertion.js
@@ -33,7 +33,16 @@ import XMLCheckAssertion from "./AssertionTypes/XMLCheckAssertion";
 /**
  * Component to render one assertion.
  */
-function Assertion(props) {
+function Assertion({
+  assertion,
+  displayPath,
+  expand,
+  filter,
+  index,
+  uid,
+  reportUid,
+  toggleExpand,
+}) {
   /**
    * Get the component object of the assertion.
    * @param {String} props - Assertion type props.
@@ -43,7 +52,7 @@ function Assertion(props) {
    */
   const assertionComponent = (assertionType) => {
     let graphAssertion;
-    if (props.assertion.discrete_chart) {
+    if (assertion.discrete_chart) {
       graphAssertion = DiscreteChartAssertion;
     } else {
       graphAssertion = XYGraphAssertion;
@@ -82,26 +91,26 @@ function Assertion(props) {
   };
 
   let isAssertionGroup = false;
-  let assertionType = props.assertion.type;
+  let assertionType = assertion.type;
   switch (assertionType) {
     case "Group":
       isAssertionGroup = true;
       assertionType = (
         <AssertionGroup
-          assertionGroupUid={props.uid}
-          entries={props.assertion.entries}
-          filter={props.filter}
-          reportUid={props.reportUid}
-          displayPath={props.displayPath}
+          assertionGroupUid={uid}
+          entries={assertion.entries}
+          filter={filter}
+          reportUid={reportUid}
+          displayPath={displayPath}
         />
       );
       break;
     case "Summary":
       assertionType = (
         <SummaryBaseAssertion
-          assertion={props.assertion}
-          assertionGroupUid={props.uid}
-          filter={props.filter}
+          assertion={assertion}
+          assertionGroupUid={uid}
+          filter={filter}
         />
       );
       break;
@@ -110,8 +119,8 @@ function Assertion(props) {
       if (AssertionTypeComponent) {
         assertionType = (
           <AssertionTypeComponent
-            assertion={props.assertion}
-            reportUid={props.reportUid}
+            assertion={assertion}
+            reportUid={reportUid}
           />
         );
       } else {
@@ -123,14 +132,14 @@ function Assertion(props) {
   return (
     <Card className={css(styles.card)}>
       <AssertionHeader
-        assertion={props.assertion}
-        uid={props.uid}
-        toggleExpand={props.toggleExpand}
-        index={props.index}
-        displayPath={props.displayPath}
+        assertion={assertion}
+        uid={uid}
+        toggleExpand={toggleExpand}
+        index={index}
+        displayPath={displayPath}
       />
       <Collapse
-        isOpen={props.expand === EXPAND_STATUS.EXPAND}
+        isOpen={expand === EXPAND_STATUS.EXPAND}
         className={css(styles.collapseDiv)}
         style={{ paddingRight: isAssertionGroup ? null : "1.25rem" }}
       >
@@ -142,7 +151,7 @@ function Assertion(props) {
                 : styles.assertionCardBody
             )}
           >
-            {props.expand === EXPAND_STATUS.EXPAND
+            {expand === EXPAND_STATUS.EXPAND
               ? assertionType
               : null}
           </CardBody>

--- a/testplan/web_ui/testing/src/AssertionPane/Assertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/Assertion.js
@@ -1,4 +1,3 @@
-import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Card, CardBody, Collapse } from "reactstrap";
 import { css, StyleSheet } from "aphrodite";
@@ -34,36 +33,7 @@ import XMLCheckAssertion from "./AssertionTypes/XMLCheckAssertion";
 /**
  * Component to render one assertion.
  */
-class Assertion extends Component {
-  shouldComponentUpdate(nextProps, nextState) {
-    const timeInfoIsEqual = (arr1, arr2) => {
-      if (arr1 === undefined && arr2 === undefined) {
-        return true;
-      } else if (
-        arr1 !== undefined &&
-        arr2 !== undefined &&
-        arr1.length === arr2.length
-      ) {
-        return true;
-      } else {
-        return false;
-      }
-    };
-
-    // If we used a PureComponent it would do a shallow prop comparison which
-    // might suffice and we wouldn't need to include this.
-    return (
-      nextProps.assertion !== this.props.assertion ||
-      nextProps.expand !== this.props.expand ||
-      // Inside the group assertions may need to be updated
-      nextProps.assertion.type === "Group" ||
-      !timeInfoIsEqual(
-        nextProps.assertion.timeInfoArray,
-        this.props.timeInfoArray
-      )
-    );
-  }
-
+function Assertion(props) {
   /**
    * Get the component object of the assertion.
    * @param {String} props - Assertion type props.
@@ -71,9 +41,9 @@ class Assertion extends Component {
    * assertion is implemented.
    * @public
    */
-  assertionComponent(assertionType) {
+  const assertionComponent = (assertionType) => {
     let graphAssertion;
-    if (this.props.assertion.discrete_chart) {
+    if (props.assertion.discrete_chart) {
       graphAssertion = DiscreteChartAssertion;
     } else {
       graphAssertion = XYGraphAssertion;
@@ -109,79 +79,77 @@ class Assertion extends Component {
       return BasicAssertion;
     }
     return null;
-  }
+  };
 
-  render() {
-    let isAssertionGroup = false;
-    let assertionType = this.props.assertion.type;
-    switch (assertionType) {
-      case "Group":
-        isAssertionGroup = true;
+  let isAssertionGroup = false;
+  let assertionType = props.assertion.type;
+  switch (assertionType) {
+    case "Group":
+      isAssertionGroup = true;
+      assertionType = (
+        <AssertionGroup
+          assertionGroupUid={props.uid}
+          entries={props.assertion.entries}
+          filter={props.filter}
+          reportUid={props.reportUid}
+          displayPath={props.displayPath}
+        />
+      );
+      break;
+    case "Summary":
+      assertionType = (
+        <SummaryBaseAssertion
+          assertion={props.assertion}
+          assertionGroupUid={props.uid}
+          filter={props.filter}
+        />
+      );
+      break;
+    default: {
+      const AssertionTypeComponent = assertionComponent(assertionType);
+      if (AssertionTypeComponent) {
         assertionType = (
-          <AssertionGroup
-            assertionGroupUid={this.props.uid}
-            entries={this.props.assertion.entries}
-            filter={this.props.filter}
-            reportUid={this.props.reportUid}
-            displayPath={this.props.displayPath}
+          <AssertionTypeComponent
+            assertion={props.assertion}
+            reportUid={props.reportUid}
           />
         );
-        break;
-      case "Summary":
-        assertionType = (
-          <SummaryBaseAssertion
-            assertion={this.props.assertion}
-            assertionGroupUid={this.props.uid}
-            filter={this.props.filter}
-          />
-        );
-        break;
-      default: {
-        const AssertionTypeComponent = this.assertionComponent(assertionType);
-        if (AssertionTypeComponent) {
-          assertionType = (
-            <AssertionTypeComponent
-              assertion={this.props.assertion}
-              reportUid={this.props.reportUid}
-            />
-          );
-        } else {
-          assertionType = <NotImplementedAssertion />;
-        }
+      } else {
+        assertionType = <NotImplementedAssertion />;
       }
     }
+  };
 
-    return (
-      <Card className={css(styles.card)}>
-        <AssertionHeader
-          assertion={this.props.assertion}
-          uid={this.props.uid}
-          toggleExpand={this.props.toggleExpand}
-          index={this.props.index}
-          displayPath={this.props.displayPath}
-        />
-        <Collapse
-          isOpen={this.props.expand === EXPAND_STATUS.EXPAND}
-          className={css(styles.collapseDiv)}
-          style={{ paddingRight: isAssertionGroup ? null : "1.25rem" }}
-        >
-          <ErrorBoundary>
-            <CardBody
-              className={css(
-                isAssertionGroup
-                  ? styles.groupCardBody
-                  : styles.assertionCardBody
-              )}
-            >
-              {this.props.expand === EXPAND_STATUS.EXPAND
-                ? assertionType
-                : null}
-            </CardBody>
-          </ErrorBoundary>
-        </Collapse>
-      </Card>
-    );
-  }
+  return (
+    <Card className={css(styles.card)}>
+      <AssertionHeader
+        assertion={props.assertion}
+        uid={props.uid}
+        toggleExpand={props.toggleExpand}
+        index={props.index}
+        displayPath={props.displayPath}
+      />
+      <Collapse
+        isOpen={props.expand === EXPAND_STATUS.EXPAND}
+        className={css(styles.collapseDiv)}
+        style={{ paddingRight: isAssertionGroup ? null : "1.25rem" }}
+      >
+        <ErrorBoundary>
+          <CardBody
+            className={css(
+              isAssertionGroup
+                ? styles.groupCardBody
+                : styles.assertionCardBody
+            )}
+          >
+            {props.expand === EXPAND_STATUS.EXPAND
+              ? assertionType
+              : null}
+          </CardBody>
+        </ErrorBoundary>
+      </Collapse>
+    </Card>
+  );
 }
 
 Assertion.propTypes = {

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionHeader.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionHeader.js
@@ -13,7 +13,12 @@ library.add(faLayerGroup);
 /**
  * Header component of an assertion.
  */
-function AssertionHeader(props) {
+function AssertionHeader({
+  assertion,
+  displayPath,
+  uid,
+  toggleExpand,
+}) {
   const [isUTCTooltipOpen, setIsUTCTooltipOpen] = useState(false);
   const [isPathTooltipOpen, setIsPathTooltipOpen] = useState(false);
   const [isDurationTooltipOpen, setIsDurationTooltipOpen] = useState(false);
@@ -44,15 +49,15 @@ function AssertionHeader(props) {
   };
 
   const cardHeaderColorStyle =
-    props.assertion.passed === undefined
+    assertion.passed === undefined
       ? styles.cardHeaderColorLog
-      : props.assertion.passed
+      : assertion.passed
       ? styles.cardHeaderColorPassed
       : styles.cardHeaderColorFailed;
 
-  const timeInfoArray = props.assertion.timeInfoArray || [];
+  const timeInfoArray = assertion.timeInfoArray || [];
   let component =
-    props.assertion.utc_time === undefined ? (
+    assertion.utc_time === undefined ? (
       <span className={css(styles.cardHeaderAlignRight)}>
         <FontAwesomeIcon // Should be a nested assertion group
           size="sm"
@@ -110,37 +115,37 @@ function AssertionHeader(props) {
       </>
     );
 
-  let pathButton = props.displayPath ? (
+  let pathButton = displayPath ? (
     <>
       <Button
         size="small"
         className={css(styles.cardHeaderAlignRight, styles.timeInfo)}
         onClick={() => {
-          navigator.clipboard.writeText(getPath(props.assertion));
+          navigator.clipboard.writeText(getPath(assertion));
         }}
         style={{ order: 2, marginLeft: "10px" }}
       >
         <span
-          id={`tooltip_path_${props.uid}`}
+          id={`tooltip_path_${uid}`}
           className={css(cardHeaderColorStyle)}
         >
-          {renderPath(props.assertion)}
+          {renderPath(assertion)}
         </span>
       </Button>
       <Tooltip
         isOpen={isPathTooltipOpen}
-        target={`tooltip_path_${props.uid}`}
+        target={`tooltip_path_${uid}`}
         toggle={togglePathTooltip}
       >
-        {getPath(props.assertion)}
+        {getPath(assertion)}
       </Tooltip>
     </>
   ) : (
     <></>
   );
 
-  const description = props.assertion.description ? (
-    props.assertion.type === "Log" ? (
+  const description = assertion.description ? (
+    assertion.type === "Log" ? (
       <Linkify
         options={{
           target: "_blank",
@@ -149,31 +154,30 @@ function AssertionHeader(props) {
           },
         }}
       >
-        {props.assertion.description}
+        {assertion.description}
       </Linkify>
     ) : (
-      props.assertion.description + " "
+      assertion.description + " "
     )
   ) : (
     ""
   );
 
-  //console.log("AssertionHeader has been rendered.");
   return (
     <CardHeader className={css(styles.cardHeader, cardHeaderColorStyle)}>
       <div style={{ display: "flex" }}>
         <span
           className={css(styles.button)}
-          onClick={props.toggleExpand}
+          onClick={toggleExpand}
           style={{
             order: 1,
             flexGrow: 4,
             padding: ".125rem 0.75rem",
-            ...props.assertion.custom_style,
+            ...assertion.custom_style,
           }}
         >
           <span style={{ fontWeight: "bold" }}>{description}</span>
-          <span>({props.assertion.type})</span>
+          <span>({assertion.type})</span>
         </span>
 
         {component}

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionHeader.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionHeader.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { useState } from "react";
 import PropTypes from "prop-types";
 import { css, StyleSheet } from "aphrodite";
 import { CardHeader, Tooltip } from "reactstrap";
@@ -13,190 +13,178 @@ library.add(faLayerGroup);
 /**
  * Header component of an assertion.
  */
-class AssertionHeader extends Component {
-  constructor(props) {
-    super(props);
+function AssertionHeader(props) {
+  const [isUTCTooltipOpen, setIsUTCTooltipOpen] = useState(false);
+  const [isPathTooltipOpen, setIsPathTooltipOpen] = useState(false);
+  const [isDurationTooltipOpen, setIsDurationTooltipOpen] = useState(false);
 
-    this.state = {
-      isUTCTooltipOpen: false,
-      isPathTooltipOpen: false,
-      isDurationTooltipOpen: false,
-    };
-    this.toggleUTCTooltip = this.toggleUTCTooltip.bind(this);
-    this.togglePathTooltip = this.togglePathTooltip.bind(this);
-    this.toggleDurationTooltip = this.toggleDurationTooltip.bind(this);
-  }
+    // this.toggleUTCTooltip = this.toggleUTCTooltip.bind(this);
+    // this.togglePathTooltip = this.togglePathTooltip.bind(this);
+    // this.toggleDurationTooltip = this.toggleDurationTooltip.bind(this);
 
   /**
    * Toggle the visibility of tooltip of file path.
    */
-  togglePathTooltip() {
-    this.setState((prevState) => ({
-      isPathTooltipOpen: !prevState.isPathTooltipOpen,
-    }));
-  }
+  const togglePathTooltip = () => {
+    setIsPathTooltipOpen(!isPathTooltipOpen);
+  };
 
   /**
    * Toggle the visibility of tooltip of assertion start time.
    */
-  toggleUTCTooltip() {
-    this.setState((prevState) => ({
-      isUTCTooltipOpen: !prevState.isUTCTooltipOpen,
-    }));
-  }
+  const toggleUTCTooltip = () => {
+    setIsUTCTooltipOpen(!isUTCTooltipOpen);
+  };
 
   /**
    * Toggle the visibility of tooltip of duration between assertions.
    */
-  toggleDurationTooltip() {
-    this.setState((prevState) => ({
-      isDurationTooltipOpen: !prevState.isDurationTooltipOpen,
-    }));
-  }
+  const toggleDurationTooltip = () => {
+    setIsDurationTooltipOpen(!isDurationTooltipOpen);
+  };
 
-  render() {
-    const cardHeaderColorStyle =
-      this.props.assertion.passed === undefined
-        ? styles.cardHeaderColorLog
-        : this.props.assertion.passed
-        ? styles.cardHeaderColorPassed
-        : styles.cardHeaderColorFailed;
+  const cardHeaderColorStyle =
+    props.assertion.passed === undefined
+      ? styles.cardHeaderColorLog
+      : props.assertion.passed
+      ? styles.cardHeaderColorPassed
+      : styles.cardHeaderColorFailed;
 
-    const timeInfoArray = this.props.assertion.timeInfoArray || [];
-    let component =
-      this.props.assertion.utc_time === undefined ? (
-        <span className={css(styles.cardHeaderAlignRight)}>
-          <FontAwesomeIcon // Should be a nested assertion group
-            size="sm"
-            key="faLayerGroup"
-            icon="layer-group"
-            className={css(styles.icon)}
-          />
-        </span>
-      ) : timeInfoArray.length === 0 ? (
-        <span className={css(styles.cardHeaderAlignRight)}></span>
-      ) : (
-        <>
-          <span
-            className={css(styles.cardHeaderAlignRight, styles.timeInfo)}
-            id={`tooltip_duration_${timeInfoArray[0]}`}
-            style={{ order: 4, display: "inline-flex", alignItems: "center" }}
-          >
-            {timeInfoArray[2]}
-          </span>
-          <span
-            className={css(styles.cardHeaderAlignRight)}
-            style={{ order: 3 }}
-          >
-            &nbsp;&nbsp;
-          </span>
-          <span
-            className={css(styles.cardHeaderAlignRight, styles.timeInfo)}
-            id={`tooltip_utc_${timeInfoArray[0]}`}
-            style={{ order: 6, display: "inline-flex", alignItems: "center" }}
-          >
-            {timeInfoArray[1]}
-          </span>
-          <span
-            className={css(styles.cardHeaderAlignRight)}
-            style={{ order: 5 }}
-          >
-            &nbsp;&nbsp;
-          </span>
-          <Tooltip
-            placement="bottom"
-            isOpen={this.state.isUTCTooltipOpen}
-            target={`tooltip_utc_${timeInfoArray[0]}`}
-            toggle={this.toggleUTCTooltip}
-          >
-            {"Assertion start time"}
-          </Tooltip>
-          <Tooltip
-            placement="bottom"
-            isOpen={this.state.isDurationTooltipOpen}
-            target={`tooltip_duration_${timeInfoArray[0]}`}
-            toggle={this.toggleDurationTooltip}
-          >
-            {"Time elapsed since last assertion"}
-          </Tooltip>
-        </>
-      );
-
-    let pathButton = this.props.displayPath ? (
+  const timeInfoArray = props.assertion.timeInfoArray || [];
+  let component =
+    props.assertion.utc_time === undefined ? (
+      <span className={css(styles.cardHeaderAlignRight)}>
+        <FontAwesomeIcon // Should be a nested assertion group
+          size="sm"
+          key="faLayerGroup"
+          icon="layer-group"
+          className={css(styles.icon)}
+        />
+      </span>
+    ) : timeInfoArray.length === 0 ? (
+      <span className={css(styles.cardHeaderAlignRight)}></span>
+    ) : (
       <>
-        <Button
-          size="small"
+        <span
           className={css(styles.cardHeaderAlignRight, styles.timeInfo)}
-          onClick={() => {
-            navigator.clipboard.writeText(getPath(this.props.assertion));
-          }}
-          style={{ order: 2, marginLeft: "10px" }}
+          id={`tooltip_duration_${timeInfoArray[0]}`}
+          style={{ order: 4, display: "inline-flex", alignItems: "center" }}
         >
-          <span
-            id={`tooltip_path_${this.props.uid}`}
-            className={css(cardHeaderColorStyle)}
-          >
-            {renderPath(this.props.assertion)}
-          </span>
-        </Button>
+          {timeInfoArray[2]}
+        </span>
+        <span
+          className={css(styles.cardHeaderAlignRight)}
+          style={{ order: 3 }}
+        >
+          &nbsp;&nbsp;
+        </span>
+        <span
+          className={css(styles.cardHeaderAlignRight, styles.timeInfo)}
+          id={`tooltip_utc_${timeInfoArray[0]}`}
+          style={{ order: 6, display: "inline-flex", alignItems: "center" }}
+        >
+          {timeInfoArray[1]}
+        </span>
+        <span
+          className={css(styles.cardHeaderAlignRight)}
+          style={{ order: 5 }}
+        >
+          &nbsp;&nbsp;
+        </span>
         <Tooltip
-          isOpen={this.state.isPathTooltipOpen}
-          target={`tooltip_path_${this.props.uid}`}
-          toggle={this.togglePathTooltip}
+          placement="bottom"
+          isOpen={isUTCTooltipOpen}
+          target={`tooltip_utc_${timeInfoArray[0]}`}
+          toggle={toggleUTCTooltip}
         >
-          {getPath(this.props.assertion)}
+          {"Assertion start time"}
+        </Tooltip>
+        <Tooltip
+          placement="bottom"
+          isOpen={isDurationTooltipOpen}
+          target={`tooltip_duration_${timeInfoArray[0]}`}
+          toggle={toggleDurationTooltip}
+        >
+          {"Time elapsed since last assertion"}
         </Tooltip>
       </>
-    ) : (
-      <></>
     );
 
-    const description = this.props.assertion.description ? (
-      this.props.assertion.type === "Log" ? (
-        <Linkify
-          options={{
-            target: "_blank",
-            validate: {
-              url: (value) => /^https?:\/\//.test(value),
-            },
+  let pathButton = props.displayPath ? (
+    <>
+      <Button
+        size="small"
+        className={css(styles.cardHeaderAlignRight, styles.timeInfo)}
+        onClick={() => {
+          navigator.clipboard.writeText(getPath(props.assertion));
+        }}
+        style={{ order: 2, marginLeft: "10px" }}
+      >
+        <span
+          id={`tooltip_path_${props.uid}`}
+          className={css(cardHeaderColorStyle)}
+        >
+          {renderPath(props.assertion)}
+        </span>
+      </Button>
+      <Tooltip
+        isOpen={isPathTooltipOpen}
+        target={`tooltip_path_${props.uid}`}
+        toggle={togglePathTooltip}
+      >
+        {getPath(props.assertion)}
+      </Tooltip>
+    </>
+  ) : (
+    <></>
+  );
+
+  const description = props.assertion.description ? (
+    props.assertion.type === "Log" ? (
+      <Linkify
+        options={{
+          target: "_blank",
+          validate: {
+            url: (value) => /^https?:\/\//.test(value),
+          },
+        }}
+      >
+        {props.assertion.description}
+      </Linkify>
+    ) : (
+      props.assertion.description + " "
+    )
+  ) : (
+    ""
+  );
+
+  //console.log("AssertionHeader has been rendered.");
+  return (
+    <CardHeader className={css(styles.cardHeader, cardHeaderColorStyle)}>
+      <div style={{ display: "flex" }}>
+        <span
+          className={css(styles.button)}
+          onClick={props.toggleExpand}
+          style={{
+            order: 1,
+            flexGrow: 4,
+            padding: ".125rem 0.75rem",
+            ...props.assertion.custom_style,
           }}
         >
-          {this.props.assertion.description}
-        </Linkify>
-      ) : (
-        this.props.assertion.description + " "
-      )
-    ) : (
-      ""
-    );
+          <span style={{ fontWeight: "bold" }}>{description}</span>
+          <span>({props.assertion.type})</span>
+        </span>
 
-    return (
-      <CardHeader className={css(styles.cardHeader, cardHeaderColorStyle)}>
-        <div style={{ display: "flex" }}>
-          <span
-            className={css(styles.button)}
-            onClick={this.props.toggleExpand}
-            style={{
-              order: 1,
-              flexGrow: 4,
-              padding: ".125rem 0.75rem",
-              ...this.props.assertion.custom_style,
-            }}
-          >
-            <span style={{ fontWeight: "bold" }}>{description}</span>
-            <span>({this.props.assertion.type})</span>
-          </span>
-
-          {component}
-          {pathButton}
-          {/*
-            TODO will be implemented when complete permalink feature
-            linkIcon
-          */}
-        </div>
-      </CardHeader>
-    );
-  }
+        {component}
+        {pathButton}
+        {/*
+          TODO will be implemented when complete permalink feature
+          linkIcon
+        */}
+      </div>
+    </CardHeader>
+  );
 }
 
 AssertionHeader.propTypes = {

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionSummary.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionSummary.js
@@ -6,7 +6,7 @@ import AssertionGroup from "./AssertionGroup";
  */
 
 function SummaryBaseAssertion({
-    assertion, assertionGroupUid, filter, displayPath
+    assertion, assertionGroupUid, displayPath, filter
   }) {
   // Go through categories e.g Category: DEFAULT
   return assertion.entries.map((category) => {
@@ -51,7 +51,6 @@ function SummaryBaseAssertion({
       );
     });
 
-    console.log("AssertionSummary has been rendered.");
     return (
       <div key={category.description}>
         <Row>

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionSummary.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionSummary.js
@@ -1,4 +1,3 @@
-import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Col, Row } from "reactstrap";
 import AssertionGroup from "./AssertionGroup";
@@ -6,68 +5,66 @@ import AssertionGroup from "./AssertionGroup";
  * Component used to render a large test case when summarize = true
  */
 
-class SummaryBaseAssertion extends Component {
-  render() {
-    let data = this.props.assertion;
-    let summaries = data.entries;
+function SummaryBaseAssertion({
+    assertion, assertionGroupUid, filter, displayPath
+  }) {
+  // Go through categories e.g Category: DEFAULT
+  return assertion.entries.map((category) => {
+    let category_description = category.description;
 
-    // Go through categories e.g Category: DEFAULT
-    return summaries.map((category) => {
-      let category_description = category.description;
+    // Go through assertion types e.g Assertion type: Equal
+    let assertions_types = category.entries.map((assertions_types) => {
+      let description = (
+        <Row>
+          <Col sm={{ offset: 1 }} style={{ fontSize: "small" }}>
+            <strong>{assertions_types.description}</strong>
+          </Col>
+        </Row>
+      );
 
-      // Go through assertion types e.g Assertion type: Equal
-      let assertions_types = category.entries.map((assertions_types) => {
-        let description = (
+      // State how many assertions are being displayed e.g 5 of 500
+      // Create an AssertionGroup for each grouped type of assertion
+      // e.g all result.Equal() in Category: DEFAULT
+      let entries = assertions_types.entries.map((single_assertion_group) => (
+        <div key={single_assertion_group.description}>
           <Row>
-            <Col sm={{ offset: 1 }} style={{ fontSize: "small" }}>
-              <strong>{assertions_types.description}</strong>
+            <Col sm={{ offset: 1 }}>{single_assertion_group.description}</Col>
+          </Row>
+          <Row>
+            <Col sm={{ offset: 2 }}>
+              <AssertionGroup
+                assertionGroupUid={assertionGroupUid}
+                entries={single_assertion_group.entries}
+                filter={filter}
+                displayPath={displayPath}
+              />
             </Col>
           </Row>
-        );
-
-        // State how many assertions are being displayed e.g 5 of 500
-        // Create an AssertionGroup for each grouped type of assertion
-        // e.g all result.Equal() in Category: DEFAULT
-        let entries = assertions_types.entries.map((single_assertion_group) => (
-          <div key={single_assertion_group.description}>
-            <Row>
-              <Col sm={{ offset: 1 }}>{single_assertion_group.description}</Col>
-            </Row>
-            <Row>
-              <Col sm={{ offset: 2 }}>
-                <AssertionGroup
-                  assertionGroupUid={this.props.assertionGroupUid}
-                  entries={single_assertion_group.entries}
-                  filter={this.props.filter}
-                  displayPath={this.props.displayPath}
-                />
-              </Col>
-            </Row>
-          </div>
-        ));
-
-        return (
-          <div key={assertions_types.description}>
-            {description}
-            {entries}
-          </div>
-        );
-      });
+        </div>
+      ));
 
       return (
-        <div key={category.description}>
-          <Row>
-            <Col lg="14" style={{ fontSize: "small" }}>
-              <strong>{category_description}</strong>
-            </Col>
-          </Row>
-          <Row>
-            <Col lg="12">{assertions_types}</Col>
-          </Row>
+        <div key={assertions_types.description}>
+          {description}
+          {entries}
         </div>
       );
     });
-  }
+
+    console.log("AssertionSummary has been rendered.");
+    return (
+      <div key={category.description}>
+        <Row>
+          <Col lg="14" style={{ fontSize: "small" }}>
+            <strong>{category_description}</strong>
+          </Col>
+        </Row>
+        <Row>
+          <Col lg="12">{assertions_types}</Col>
+        </Row>
+      </div>
+    );
+  });
 }
 
 SummaryBaseAssertion.propTypes = {

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/BasicAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/BasicAssertion.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from "react";
+import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import { css, StyleSheet } from "aphrodite";
 import { Col, Row } from "reactstrap";
@@ -39,7 +39,6 @@ function BasicAssertion({ assertion }) {
     postContent,
   } = prepareBasicContent(assertion);
 
-  console.log("BasicAssertion has been rendered.");
   return (
     <Fragment>
       <Row>

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/BasicAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/BasicAssertion.js
@@ -27,60 +27,59 @@ import { prepareBasicContent } from "./basicAssertionUtils";
  * the data to be displayed. It returns an object that fills the aforementioned
  * grid with data.
  */
-class BasicAssertion extends Component {
-  render() {
-    const {
-      preTitle,
-      preContent,
-      leftTitle,
-      rightTitle,
-      leftContent,
-      rightContent,
-      postTitle,
-      postContent,
-    } = prepareBasicContent(this.props.assertion);
+function BasicAssertion({ assertion }) {
+  const {
+    preTitle,
+    preContent,
+    leftTitle,
+    rightTitle,
+    leftContent,
+    rightContent,
+    postTitle,
+    postContent,
+  } = prepareBasicContent(assertion);
 
-    return (
-      <Fragment>
-        <Row>
-          <Col lg="12">
-            <strong>{preTitle}</strong>
-          </Col>
-        </Row>
-        <Row>
-          <Col lg="12" className={css(styles.contentSpan)}>
-            {preContent}
-          </Col>
-        </Row>
-        <Row>
-          <Col lg="6">
-            <strong>{leftTitle}</strong>
-          </Col>
-          <Col lg="6">
-            <strong>{rightTitle}</strong>
-          </Col>
-        </Row>
-        <Row>
-          <Col lg="6" className={css(styles.contentSpan)}>
-            <span>{leftContent}</span>
-          </Col>
-          <Col lg="6" className={css(styles.contentSpan)}>
-            <span>{rightContent}</span>
-          </Col>
-        </Row>
-        <Row>
-          <Col lg="12">
-            <strong>{postTitle}</strong>
-          </Col>
-        </Row>
-        <Row>
-          <Col lg="12" className={css(styles.contentSpan)}>
-            {postContent}
-          </Col>
-        </Row>
-      </Fragment>
-    );
-  }
+  console.log("BasicAssertion has been rendered.");
+  return (
+    <Fragment>
+      <Row>
+        <Col lg="12">
+          <strong>{preTitle}</strong>
+        </Col>
+      </Row>
+      <Row>
+        <Col lg="12" className={css(styles.contentSpan)}>
+          {preContent}
+        </Col>
+      </Row>
+      <Row>
+        <Col lg="6">
+          <strong>{leftTitle}</strong>
+        </Col>
+        <Col lg="6">
+          <strong>{rightTitle}</strong>
+        </Col>
+      </Row>
+      <Row>
+        <Col lg="6" className={css(styles.contentSpan)}>
+          <span>{leftContent}</span>
+        </Col>
+        <Col lg="6" className={css(styles.contentSpan)}>
+          <span>{rightContent}</span>
+        </Col>
+      </Row>
+      <Row>
+        <Col lg="12">
+          <strong>{postTitle}</strong>
+        </Col>
+      </Row>
+      <Row>
+        <Col lg="12" className={css(styles.contentSpan)}>
+          {postContent}
+        </Col>
+      </Row>
+    </Fragment>
+  );
 }
 
 BasicAssertion.propTypes = {

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/CopyButton.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/CopyButton.js
@@ -1,4 +1,3 @@
-import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Button } from "reactstrap";
 import CopyToClipboard from "react-copy-html-to-clipboard";
@@ -6,16 +5,16 @@ import CopyToClipboard from "react-copy-html-to-clipboard";
 /**
  * Component that renders the buttons of copy html to clipboard.
  */
-class CopyButton extends Component {
-  render() {
-    return (
-      <CopyToClipboard text={this.props.value} options={{ asHtml: true }}>
-        <Button outline color="secondary" size="sm" active={false}>
-          Copy
-        </Button>
-      </CopyToClipboard>
-    );
-  }
+function CopyButton({ value }) {
+
+  console.log("CopyButton has been rendered.");
+  return (
+    <CopyToClipboard text={value} options={{ asHtml: true }}>
+      <Button outline color="secondary" size="sm" active={false}>
+        Copy
+      </Button>
+    </CopyToClipboard>
+  );
 }
 
 CopyButton.propTypes = {

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/CopyButton.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/CopyButton.js
@@ -6,8 +6,6 @@ import CopyToClipboard from "react-copy-html-to-clipboard";
  * Component that renders the buttons of copy html to clipboard.
  */
 function CopyButton({ value }) {
-
-  console.log("CopyButton has been rendered.");
   return (
     <CopyToClipboard text={value} options={{ asHtml: true }}>
       <Button outline color="secondary" size="sm" active={false}>

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/DictButtonGroup.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/DictButtonGroup.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { useState } from "react";
 import PropTypes from "prop-types";
 import { Button, ButtonGroup } from "reactstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -23,142 +23,87 @@ library.add(faSortAmountUp, faSortAmountDown);
  * dictAssertionUtils' {@link sortFlattenedJSON} function is called to sort
  * the table data to be displayed.
  */
-class DictButtonGroup extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      selectedSortType: this.props.defaultSortType || SORT_TYPES.NONE,
-      selectedFilterOptions: this.props.defaultFilterOptions || [],
-      sortedData: this.props.flattenedDict,
-    };
-    this.sortAndFilterData = this.sortAndFilterData.bind(this);
+function DictButtonGroup(props) {
+  const [selectedSortType, setSelectedSortType] = useState(
+    props.defaultSortType || SORT_TYPES.NONE
+  );
+  const [selectedFilterOptions, setSelectedFilterOptions] = useState(
+    props.defaultFilterOptions || []
+  );
+  const [sortedData, setSortedData] = useState(props.flattenedDict);
+  
+  const noSort = () => {
+    let sortedData = props.flattenedDict;
+    props.setRowData(sortedData);
+    setSelectedSortType(SORT_TYPES.NONE);
+    setSortedData(sortedData);
+  };
 
-    this.uid = this.props.uid || uniqueId();
-    this.buttonMap = {};
-
-    this.buttonMap[SORT_TYPES.NONE] = {
-      display: "Original order",
-      onClick: this.noSort.bind(this),
-    };
-
-    this.buttonMap[SORT_TYPES.ALPHABETICAL] = {
-      display: (
-        <FontAwesomeIcon
-          size="sm"
-          key="faSortAmountDown"
-          icon="sort-amount-down"
-        />
-      ),
-      onClick: this.sortByChar.bind(this),
-    };
-
-    this.buttonMap[SORT_TYPES.REVERSE_ALPHABETICAL] = {
-      display: (
-        <FontAwesomeIcon size="sm" key="faSortAmountUp" icon="sort-amount-up" />
-      ),
-      onClick: this.sortByCharReverse.bind(this),
-    };
-
-    this.buttonMap[SORT_TYPES.BY_STATUS] = {
-      display: "Status",
-      onClick: this.sortByStatus.bind(this),
-    };
-
-    this.buttonMap[FILTER_OPTIONS.FAILURES_ONLY] = {
-      display: "Failures only",
-      onClick: this.filterFailure.bind(this),
-    };
-
-    this.buttonMap[FILTER_OPTIONS.EXCLUDE_IGNORABLE] = {
-      display: "Hide ignored items",
-      onClick: this.filterIgnorable.bind(this),
-    };
-  }
-
-  noSort() {
-    let sortedData = this.props.flattenedDict;
-    this.props.setRowData(sortedData);
-    this.setState({
-      selectedSortType: SORT_TYPES.NONE,
-      sortedData: sortedData,
-    });
-  }
-
-  sortByChar() {
-    let sortedData = this.sortAndFilterData(
+  const sortByChar = () => {
+    let sortedData = sortAndFilterData(
       SORT_TYPES.ALPHABETICAL,
-      this.state.selectedFilterOptions
+      selectedFilterOptions
     );
-    this.props.setRowData(sortedData);
-    this.setState({
-      selectedSortType: SORT_TYPES.ALPHABETICAL,
-      sortedData: sortedData,
-    });
-  }
+    props.setRowData(sortedData);
+    setSelectedSortType(SORT_TYPES.ALPHABETICAL);
+    setSortedData(sortedData);
+  };
 
-  sortByCharReverse() {
-    let sortedData = this.sortAndFilterData(
+  const sortByCharReverse = () => {
+    let sortedData = sortAndFilterData(
       SORT_TYPES.REVERSE_ALPHABETICAL,
-      this.state.selectedFilterOptions
+      selectedFilterOptions
     );
-    this.props.setRowData(sortedData);
-    this.setState({
-      selectedSortType: SORT_TYPES.REVERSE_ALPHABETICAL,
-      sortedData: sortedData,
-    });
-  }
+    props.setRowData(sortedData);
+    setSelectedSortType(SORT_TYPES.REVERSE_ALPHABETICAL);
+    setSortedData(sortedData);
+  };
 
-  sortByStatus() {
-    let sortedData = this.sortAndFilterData(
+  const sortByStatus = () => {
+    let sortedData = sortAndFilterData(
       SORT_TYPES.BY_STATUS,
-      this.state.selectedFilterOptions
+      selectedFilterOptions
     );
-    this.props.setRowData(sortedData);
-    this.setState({
-      selectedSortType: SORT_TYPES.BY_STATUS,
-      sortedData: sortedData,
-    });
-  }
+    props.setRowData(sortedData);
+    setSelectedSortType(SORT_TYPES.BY_STATUS);
+    setSortedData(sortedData);
+  };
 
-  filterFailure() {
-    let filterOptions = this.state.selectedFilterOptions;
+  const filterFailure = () => {
+    let filterOptions = selectedFilterOptions;
     filterOptions =
       filterOptions.indexOf(FILTER_OPTIONS.FAILURES_ONLY) >= 0
         ? filterOptions.filter((opt) => opt !== FILTER_OPTIONS.FAILURES_ONLY)
         : filterOptions.concat([FILTER_OPTIONS.FAILURES_ONLY]);
-    let sortedData = this.sortAndFilterData(
-      this.state.selectedSortType,
+    let sortedData = sortAndFilterData(
+      selectedSortType,
       filterOptions
     );
-    this.props.setRowData(sortedData);
-    this.setState({
-      selectedFilterOptions: filterOptions,
-      sortedData: sortedData,
-    });
-  }
+    props.setRowData(sortedData);
+    setSelectedFilterOptions(filterOptions);
+    setSortedData(sortedData);
+  };
 
-  filterIgnorable() {
-    let filterOptions = this.state.selectedFilterOptions;
+  const filterIgnorable = () => {
+    let filterOptions = selectedFilterOptions;
     filterOptions =
       filterOptions.indexOf(FILTER_OPTIONS.EXCLUDE_IGNORABLE) >= 0
         ? filterOptions.filter(
             (opt) => opt !== FILTER_OPTIONS.EXCLUDE_IGNORABLE
           )
         : filterOptions.concat([FILTER_OPTIONS.EXCLUDE_IGNORABLE]);
-    let sortedData = this.sortAndFilterData(
-      this.state.selectedSortType,
+    let sortedData = sortAndFilterData(
+      selectedSortType,
       filterOptions
     );
-    this.props.setRowData(sortedData);
-    this.setState({
-      selectedFilterOptions: filterOptions,
-      sortedData: sortedData,
-    });
-  }
+    props.setRowData(sortedData);
+    setSelectedFilterOptions(filterOptions);
+    setSortedData(sortedData);
+  };
 
-  sortAndFilterData(SortType, filterOptions) {
+  const sortAndFilterData = (SortType, filterOptions) => {
     let sortedData = sortFlattenedJSON(
-      this.props.flattenedDict,
+      props.flattenedDict,
       0,
       SortType === SORT_TYPES.REVERSE_ALPHABETICAL,
       SortType === SORT_TYPES.BY_STATUS
@@ -170,60 +115,99 @@ class DictButtonGroup extends Component {
       sortedData = sortedData.filter((line) => line[2] !== "Ignored");
     }
     return sortedData;
-  }
+  };
 
-  render() {
-    let buttonGroup = [];
+  const uid = props.uid || uniqueId();
+  let buttonMap = {};
 
-    this.props.sortTypeList.forEach(
-      function (sortType) {
+  buttonMap[SORT_TYPES.NONE] = {
+    display: "Original order",
+    onClick: noSort,
+  };
+
+  buttonMap[SORT_TYPES.ALPHABETICAL] = {
+    display: (
+      <FontAwesomeIcon
+        size="sm"
+        key="faSortAmountDown"
+        icon="sort-amount-down"
+      />
+    ),
+    onClick: sortByChar,
+  };
+
+  buttonMap[SORT_TYPES.REVERSE_ALPHABETICAL] = {
+    display: (
+      <FontAwesomeIcon size="sm" key="faSortAmountUp" icon="sort-amount-up" />
+    ),
+    onClick: sortByCharReverse,
+  };
+
+  buttonMap[SORT_TYPES.BY_STATUS] = {
+    display: "Status",
+    onClick: sortByStatus,
+  };
+
+  buttonMap[FILTER_OPTIONS.FAILURES_ONLY] = {
+    display: "Failures only",
+    onClick: filterFailure,
+  };
+
+  buttonMap[FILTER_OPTIONS.EXCLUDE_IGNORABLE] = {
+    display: "Hide ignored items",
+    onClick: filterIgnorable,
+  };
+
+  let buttonGroup = [];
+
+  props.sortTypeList.forEach(
+    (sortType) => {
+      buttonGroup.push(
+        <Button
+          key={uid + "-" + sortType.toString()}
+          outline
+          color="secondary"
+          size="sm"
+          onClick={buttonMap[sortType]["onClick"]}
+          active={selectedSortType === sortType}
+        >
+          {buttonMap[sortType]["display"]}
+        </Button>
+      );
+    }
+  );
+
+  if (props.filterOptionList) {
+    props.filterOptionList.forEach(
+      (filterOption) => {
         buttonGroup.push(
           <Button
-            key={this.uid + "-" + sortType.toString()}
+            key={uid + "-" + filterOption.toString()}
             outline
             color="secondary"
             size="sm"
-            onClick={this.buttonMap[sortType]["onClick"]}
-            active={this.state.selectedSortType === sortType}
+            onClick={buttonMap[filterOption]["onClick"]}
+            active={
+              selectedFilterOptions.indexOf(filterOption) >= 0
+            }
           >
-            {this.buttonMap[sortType]["display"]}
+            {buttonMap[filterOption]["display"]}
           </Button>
         );
-      }.bind(this)
-    );
-
-    if (this.props.filterOptionList) {
-      this.props.filterOptionList.forEach(
-        function (filterOption) {
-          buttonGroup.push(
-            <Button
-              key={this.uid + "-" + filterOption.toString()}
-              outline
-              color="secondary"
-              size="sm"
-              onClick={this.buttonMap[filterOption]["onClick"]}
-              active={
-                this.state.selectedFilterOptions.indexOf(filterOption) >= 0
-              }
-            >
-              {this.buttonMap[filterOption]["display"]}
-            </Button>
-          );
-        }.bind(this)
-      );
-    }
-
-    let copyButton = (
-      <CopyButton value={flattenedDictToDOM(this.state.sortedData)} />
-    );
-
-    return (
-      <ButtonGroup style={{ paddingBottom: ".5rem" }}>
-        {buttonGroup}
-        {copyButton}
-      </ButtonGroup>
+      }
     );
   }
+
+  let copyButton = (
+    <CopyButton value={flattenedDictToDOM(sortedData)} />
+  );
+
+  return (
+    <ButtonGroup style={{ paddingBottom: ".5rem" }}>
+      {buttonGroup}
+      {copyButton}
+    </ButtonGroup>
+  );
 }
 
 DictButtonGroup.propTypes = {

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/DictButtonGroup.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/DictButtonGroup.js
@@ -23,18 +23,26 @@ library.add(faSortAmountUp, faSortAmountDown);
  * dictAssertionUtils' {@link sortFlattenedJSON} function is called to sort
  * the table data to be displayed.
  */
-function DictButtonGroup(props) {
+function DictButtonGroup({
+    defaultSortType,
+    defaultFilterOptions,
+    flattenedDict,
+    uid,
+    setRowData,
+    sortTypeList,
+    filterOptionList,
+}) {
   const [selectedSortType, setSelectedSortType] = useState(
-    props.defaultSortType || SORT_TYPES.NONE
+    defaultSortType || SORT_TYPES.NONE
   );
   const [selectedFilterOptions, setSelectedFilterOptions] = useState(
-    props.defaultFilterOptions || []
+    defaultFilterOptions || []
   );
-  const [sortedData, setSortedData] = useState(props.flattenedDict);
+  const [sortedData, setSortedData] = useState(flattenedDict);
   
   const noSort = () => {
-    let sortedData = props.flattenedDict;
-    props.setRowData(sortedData);
+    let sortedData = flattenedDict;
+    setRowData(sortedData);
     setSelectedSortType(SORT_TYPES.NONE);
     setSortedData(sortedData);
   };
@@ -44,7 +52,7 @@ function DictButtonGroup(props) {
       SORT_TYPES.ALPHABETICAL,
       selectedFilterOptions
     );
-    props.setRowData(sortedData);
+    setRowData(sortedData);
     setSelectedSortType(SORT_TYPES.ALPHABETICAL);
     setSortedData(sortedData);
   };
@@ -54,7 +62,7 @@ function DictButtonGroup(props) {
       SORT_TYPES.REVERSE_ALPHABETICAL,
       selectedFilterOptions
     );
-    props.setRowData(sortedData);
+    setRowData(sortedData);
     setSelectedSortType(SORT_TYPES.REVERSE_ALPHABETICAL);
     setSortedData(sortedData);
   };
@@ -64,7 +72,7 @@ function DictButtonGroup(props) {
       SORT_TYPES.BY_STATUS,
       selectedFilterOptions
     );
-    props.setRowData(sortedData);
+    setRowData(sortedData);
     setSelectedSortType(SORT_TYPES.BY_STATUS);
     setSortedData(sortedData);
   };
@@ -79,7 +87,7 @@ function DictButtonGroup(props) {
       selectedSortType,
       filterOptions
     );
-    props.setRowData(sortedData);
+    setRowData(sortedData);
     setSelectedFilterOptions(filterOptions);
     setSortedData(sortedData);
   };
@@ -96,14 +104,14 @@ function DictButtonGroup(props) {
       selectedSortType,
       filterOptions
     );
-    props.setRowData(sortedData);
+    setRowData(sortedData);
     setSelectedFilterOptions(filterOptions);
     setSortedData(sortedData);
   };
 
   const sortAndFilterData = (SortType, filterOptions) => {
     let sortedData = sortFlattenedJSON(
-      props.flattenedDict,
+      flattenedDict,
       0,
       SortType === SORT_TYPES.REVERSE_ALPHABETICAL,
       SortType === SORT_TYPES.BY_STATUS
@@ -117,7 +125,7 @@ function DictButtonGroup(props) {
     return sortedData;
   };
 
-  const uid = props.uid || uniqueId();
+  const buttonUid = uid || uniqueId();
   let buttonMap = {};
 
   buttonMap[SORT_TYPES.NONE] = {
@@ -160,11 +168,11 @@ function DictButtonGroup(props) {
 
   let buttonGroup = [];
 
-  props.sortTypeList.forEach(
+  sortTypeList.forEach(
     (sortType) => {
       buttonGroup.push(
         <Button
-          key={uid + "-" + sortType.toString()}
+          key={buttonUid + "-" + sortType.toString()}
           outline
           color="secondary"
           size="sm"
@@ -177,12 +185,12 @@ function DictButtonGroup(props) {
     }
   );
 
-  if (props.filterOptionList) {
-    props.filterOptionList.forEach(
+  if (filterOptionList) {
+    filterOptionList.forEach(
       (filterOption) => {
         buttonGroup.push(
           <Button
-            key={uid + "-" + filterOption.toString()}
+            key={buttonUid + "-" + filterOption.toString()}
             outline
             color="secondary"
             size="sm"

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/GraphAssertions/DiscreteChartAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/GraphAssertions/DiscreteChartAssertion.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { useState } from "react";
 import PropTypes from "prop-types";
 import "react-vis/dist/style.css";
 import * as GraphUtil from "./graphUtils";
@@ -6,63 +6,53 @@ import { RadialChart, Hint, DiscreteColorLegend } from "react-vis";
 
 /**
  * Component that are used to render a Chart (Data visualisations that don't
- * require an XY axis). Class currently only will render radial charts
+ * require an XY axis). Currently will only render radial charts
  * correctly (not generalised for other charts).
  */
-class DiscreteChartAssertion extends Component {
-  constructor(props) {
-    super(props);
-    this.components = {
-      Pie: RadialChart,
-    };
+function  DiscreteChartAssertion({ assertion }) {
+  const [value, setValue] = useState(null);
 
-    this.state = {
-      value: null,
-    };
-  }
+  const components = {Pie: RadialChart};
+  const data = assertion.graph_data;
+  const graph_type = assertion.graph_type;
+  const GraphComponent = components[graph_type];
+  const series_options = assertion.series_options;
+  let series_colours = GraphUtil.returnColour(series_options, data);
+  let plots = [];
+  let legend = [];
 
-  render() {
-    let data = this.props.assertion.graph_data;
-    const graph_type = this.props.assertion.graph_type;
-    const GraphComponent = this.components[graph_type];
-    const series_options = this.props.assertion.series_options;
-    let series_colours = GraphUtil.returnColour(series_options, data);
-    let plots = [];
-    let legend = [];
-
-    for (let key in data) {
-      plots.push(
-        <GraphComponent
-          colorType={series_colours[key]}
-          key={key}
-          data={data[key]}
-          width={400}
-          height={300}
-          onValueMouseOver={(v) => this.setState({ value: { Label: v.name } })}
-          onSeriesMouseOut={(v) => this.setState({ value: null })}
-        >
-          {this.state.value !== null && <Hint value={this.state.value} />}
-        </GraphComponent>
-      );
-
-      legend = data[key].map((slice) => {
-        return { title: slice.name, color: slice.color };
-      });
-    }
-
-    return (
-      <div>
-        {plots}
-        <DiscreteColorLegend
-          orientation="horizontal"
-          width={750}
-          items={legend}
-        />
-        <br />
-        <p>(Hover over chart to see labels)</p>
-      </div>
+  for (let key in data) {
+    plots.push(
+      <GraphComponent
+        colorType={series_colours[key]}
+        key={key}
+        data={data[key]}
+        width={400}
+        height={300}
+        onValueMouseOver={(v) => setValue({ Label: v.name })}
+        onSeriesMouseOut={(v) => setValue(null)}
+      >
+        {value !== null && <Hint value={value} />}
+      </GraphComponent>
     );
+
+    legend = data[key].map((slice) => {
+      return { title: slice.name, color: slice.color };
+    });
   }
+
+  return (
+    <div>
+      {plots}
+      <DiscreteColorLegend
+        orientation="horizontal"
+        width={750}
+        items={legend}
+      />
+      <br />
+      <p>(Hover over chart to see labels)</p>
+    </div>
+  );
 }
 DiscreteChartAssertion.propTypes = {
   /** Assertion being rendered */

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/GraphAssertions/XYGraphAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/GraphAssertions/XYGraphAssertion.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { useState } from "react";
 import PropTypes from "prop-types";
 import "react-vis/dist/style.css";
 import * as GraphUtil from "./graphUtils";
@@ -32,33 +32,20 @@ const components = {
  * Component that are used to render a Graph (Data visualisations that require
  * an XY axis).
  */
-class XYGraphAssertion extends Component {
-  constructor(props) {
-    super(props);
+function XYGraphAssertion({ assertion }) {
+    const [lastDrawLocation, setLastDrawLocation] = useState(null);
 
-    this.state = {
-      series_colour: {},
-      lastDrawLocation: null,
-    };
-
-    let data = this.props.assertion.graph_data;
-    const series_options = this.props.assertion.series_options;
-    let plot_colours = GraphUtil.returnColour(series_options, data);
-    this.state.series_colour = plot_colours;
-  }
-
-  render() {
-    const data = this.props.assertion.graph_data;
-    const graph_options = this.props.assertion.graph_options;
-    const { lastDrawLocation } = this.state;
-    const graph_type = this.props.assertion.graph_type;
+    const data = assertion.graph_data;
+    const seriesColour = GraphUtil.returnColour(assertion.series_options, data);
+    const graph_options = assertion.graph_options;
+    const graph_type = assertion.graph_type;
     const GraphComponent = components[graph_type];
 
     let legend = [];
     let plots = [];
 
     for (let key in data) {
-      let series_colour = this.state.series_colour[key];
+      let series_colour = seriesColour[key];
       plots.push(
         <GraphComponent
           key={key}
@@ -117,15 +104,13 @@ class XYGraphAssertion extends Component {
           {plots}
 
           <Highlight
-            onBrushEnd={(area) => this.setState({ lastDrawLocation: area })}
+            onBrushEnd={(area) => setLastDrawLocation(area)}
             onDrag={(area) => {
-              this.setState({
-                lastDrawLocation: {
-                  bottom: lastDrawLocation.bottom + (area.top - area.bottom),
-                  left: lastDrawLocation.left - (area.right - area.left),
-                  right: lastDrawLocation.right - (area.right - area.left),
-                  top: lastDrawLocation.top + (area.top - area.bottom),
-                },
+              setLastDrawLocation({
+                bottom: lastDrawLocation.bottom + (area.top - area.bottom),
+                left: lastDrawLocation.left - (area.right - area.left),
+                right: lastDrawLocation.right - (area.right - area.left),
+                top: lastDrawLocation.top + (area.top - area.bottom),
               });
             }}
           />
@@ -138,7 +123,6 @@ class XYGraphAssertion extends Component {
       </div>
     );
   }
-}
 
 XYGraphAssertion.propTypes = {
   /** Assertion being rendered */

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/NotImplementedAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/NotImplementedAssertion.js
@@ -12,7 +12,6 @@ library.add(faFrown);
  * the given assertion.
  */
 function NotImplementedAssertion() {
-
   return (
     <Fragment>
       <FontAwesomeIcon

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/NotImplementedAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/NotImplementedAssertion.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from "react";
+import { Fragment } from "react";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFrown } from "@fortawesome/free-solid-svg-icons";
@@ -11,22 +11,21 @@ library.add(faFrown);
  * Component that is rendered when there is no defined rendering mechanism for
  * the given assertion.
  */
-class NotImplementedAssertion extends Component {
-  render() {
-    return (
-      <Fragment>
-        <FontAwesomeIcon
-          size="lg"
-          key="faFrown"
-          icon="frown"
-          className={css(styles.icon)}
-        />
-        Currently there is no rendering mechanism for this type of assertion.
-        Please contact <strong>the developers</strong> if you would like to have
-        it implemented.
-      </Fragment>
-    );
-  }
+function NotImplementedAssertion() {
+
+  return (
+    <Fragment>
+      <FontAwesomeIcon
+        size="lg"
+        key="faFrown"
+        icon="frown"
+        className={css(styles.icon)}
+      />
+      Currently there is no rendering mechanism for this type of assertion.
+      Please contact <strong>the developers</strong> if you would like to have
+      it implemented.
+    </Fragment>
+  );
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Bug / Requirement Description
Official website (react.dev) states Component class as a legacy API and recommends defining components as functions instead of classes.
Functional components are simpler and less verbose than class components. They are also generally faster to render and easier to test.

## Solution description
Assertion and its underlaying components are functional (AssertionHeader. NotImplemented, BasicAssertion, CopyButton, etc...)
Snapshots should not be impacted as functionality won't change.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
