### PR TITLE
fix internal test

### DIFF
--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -554,10 +554,6 @@ class Test(Runnable):
             # TODO: use synthesized instead of suite_related
             # category=ReportCategories.SYNTHESIZED,
         )
-        if self.result.report.has_uid(label):
-            self.result.report[label] = suite_report
-        else:
-            self.result.report.append(suite_report)
 
         case_report = TestCaseReport(
             name=hook.__name__,
@@ -593,6 +589,11 @@ class Test(Runnable):
         case_report.pass_if_empty()
         case_report.runtime_status = RuntimeStatus.FINISHED
         suite_report.runtime_status = RuntimeStatus.FINISHED
+
+        if self.result.report.has_uid(label):
+            self.result.report[label] = suite_report
+        else:
+            self.result.report.append(suite_report)
 
     def _dry_run_resource_hook(self, hook, label):
 


### PR DESCRIPTION
## Bug / Requirement Description
Do not append hook testsuite yet until hook finished executing, otherwise test_clean_runpath_if_passed fails

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
