### PR TITLE
Relax pandas version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ black~=22.0
 kazoo
 confluent-kafka
 plotly
-pandas<2
+pandas
 numpy
 sphinx-click
 doit


### PR DESCRIPTION
## Bug / Requirement Description
Plotly issue seems to be gone that blocked the pandas 2.x versions.

## Solution description
Relaxing the pandas dependency.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
