### PR TITLE
Fixed typo in sync request timeout

### DIFF
--- a/doc/newsfragments/2858_changed.rpyc_typo.rst
+++ b/doc/newsfragments/2858_changed.rpyc_typo.rst
@@ -1,0 +1,1 @@
+Fixed a typo in an rpyc default config field override.

--- a/testplan/common/remote/remote_service.py
+++ b/testplan/common/remote/remote_service.py
@@ -81,9 +81,9 @@ class RemoteService(Resource, RemoteResource):
 
         self.proc: Optional[subprocess.Popen] = None
         # This mirrors the way default config is assigned, we only change
-        # snyc_request_timeout and pass it for the Connection object implicitly
+        # sync_request_timeout and pass it for the Connection object implicitly
         self.rpyc_config = rpyc.core.protocol.DEFAULT_CONFIG.copy()
-        self.rpyc_config["snyc_request_timeout"] = None
+        self.rpyc_config["sync_request_timeout"] = None
         self.rpyc_connection: Connection = None
         self.rpyc_port: Optional[int] = None
         self.rpyc_pid: Optional[int] = None


### PR DESCRIPTION
## Bug / Requirement Description
There is a typo in sync request timeout field reference.

## Solution description
Fix the typo.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
