### PR TITLE
Fix default assertion pane message

### DIFF
--- a/doc/newsfragments/2675_changed.assertion_pane_default.rst
+++ b/doc/newsfragments/2675_changed.assertion_pane_default.rst
@@ -1,0 +1,1 @@
+Selecting entries on the navigation with no child entries will display a message about no entries.

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
@@ -23208,12 +23208,12 @@ ZeroDivisionError: integer division or modulo by zero
       </Nav>
       <ErrorBoundary>
         <Message
-          message="Please select an entry."
+          message="No entries to be displayed."
         >
           <h1
             className="message_1s94nt7"
           >
-            Please select an entry.
+            No entries to be displayed.
           </h1>
         </Message>
       </ErrorBoundary>

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/InteractiveReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/InteractiveReport.test.js.snap
@@ -79,7 +79,7 @@ exports[`InteractiveReport Handles environment being started 1`] = `
     >
       <ErrorBoundary>
         <Message
-          message="Please select an entry."
+          message="No entries to be displayed."
         />
       </ErrorBoundary>
     </ContextProvider>
@@ -168,7 +168,7 @@ exports[`InteractiveReport Parially refreshes the report on update. 1`] = `
     >
       <ErrorBoundary>
         <Message
-          message="Please select an entry."
+          message="No entries to be displayed."
         />
       </ErrorBoundary>
     </ContextProvider>
@@ -739,7 +739,7 @@ exports[`InteractiveReport handles individual parametrizations being run 1`] = `
     >
       <ErrorBoundary>
         <Message
-          message="Please select an entry."
+          message="No entries to be displayed."
         />
       </ErrorBoundary>
     </ContextProvider>
@@ -826,7 +826,7 @@ exports[`InteractiveReport handles individual test suites being run 1`] = `
     >
       <ErrorBoundary>
         <Message
-          message="Please select an entry."
+          message="No entries to be displayed."
         />
       </ErrorBoundary>
     </ContextProvider>
@@ -913,7 +913,7 @@ exports[`InteractiveReport handles individual testcases being run 1`] = `
     >
       <ErrorBoundary>
         <Message
-          message="Please select an entry."
+          message="No entries to be displayed."
         />
       </ErrorBoundary>
     </ContextProvider>
@@ -1000,7 +1000,7 @@ exports[`InteractiveReport handles tests being run 1`] = `
     >
       <ErrorBoundary>
         <Message
-          message="Please select an entry."
+          message="No entries to be displayed."
         />
       </ErrorBoundary>
     </ContextProvider>

--- a/testplan/web_ui/testing/src/Report/reportUtils.js
+++ b/testplan/web_ui/testing/src/Report/reportUtils.js
@@ -222,7 +222,7 @@ const GetCenterPane = (
     );
   } else if (reportFetchMessage !== null) {
     return <Message message={reportFetchMessage} />;
-  } else if (selectedEntry.entries.length > 0 ) {
+  } else if (selectedEntry && selectedEntry.entries.length > 0 ) {
     return <Message message="Please select an entry." />;
   } else {
     return <Message message="No entries to be displayed." />;

--- a/testplan/web_ui/testing/src/Report/reportUtils.js
+++ b/testplan/web_ui/testing/src/Report/reportUtils.js
@@ -188,8 +188,8 @@ const GetCenterPane = (
   selectedEntries,
   displayTime
 ) => {
-  const selectiedEntry = _.last(selectedEntries);
-  const logs = selectiedEntry?.logs || [];
+  const selectedEntry = _.last(selectedEntries);
+  const logs = selectedEntry?.logs || [];
   const selectedDescription = selectedEntries
     .slice(-1)
     .map((element) => {
@@ -209,12 +209,12 @@ const GetCenterPane = (
   ) {
     return (
       <AssertionPane
-        key={selectiedEntry ? selectiedEntry.hash || selectiedEntry.uid : null}
+        key={selectedEntry ? selectedEntry.hash || selectedEntry.uid : null}
         assertions={assertions}
         logs={logs}
         descriptionEntries={selectedDescription}
         left={state.navWidth}
-        testcaseUid={selectiedEntry.uid}
+        testcaseUid={selectedEntry.uid}
         filter={state.filter}
         displayPath={state.displayPath}
         reportUid={reportUid}
@@ -222,8 +222,10 @@ const GetCenterPane = (
     );
   } else if (reportFetchMessage !== null) {
     return <Message message={reportFetchMessage} />;
-  } else {
+  } else if (selectedEntry.entries.length > 0 ) {
     return <Message message="Please select an entry." />;
+  } else {
+    return <Message message="No entries to be displayed." />;
   }
 };
 


### PR DESCRIPTION
## Bug / Requirement Description
Assertion pane displays "Please select an entry." whenever there is nothing to display which is wrong in the case there are still children entries.

## Solution description
In case there are no child entry of the selected entry, the default message will make a note of this very fact.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
