### PR TITLE
Ensure stop of drivers upon a startup exceptions

### DIFF
--- a/doc/newsfragments/2809_changed.fix_repeated_startup_issue.rst
+++ b/doc/newsfragments/2809_changed.fix_repeated_startup_issue.rst
@@ -1,0 +1,1 @@
+Fixed a bug whereas failed startup would leave drivers in wrong status.

--- a/testplan/runnable/interactive/base.py
+++ b/testplan/runnable/interactive/base.py
@@ -489,6 +489,7 @@ class TestRunnerIHandler(entity.Entity):
 
         exceptions = self.test(test_uid).resources.start_exceptions
         if exceptions:
+            self.test(test_uid).stop_test_resources()
             self._set_env_status(test_uid, entity.ResourceStatus.STOPPED)
             raise RuntimeError(
                 "Exception raised during starting drivers: {}".format(


### PR DESCRIPTION
## Bug / Requirement Description
The following scenario leaves the drivers in wrong status. Start up an environment with three drivers, first successful, second fails with exception, third is skipped. In interactive mode, the control allows another startup attempt whereas the failed driver appears starting and it is now reports success for the overall startup even though that driver is stuck in starting status.

## Solution description
Enforce proper shutdown upon an exception in interactive mode.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
