### PR TITLE
--xfail-tests to support testsuite setup/teardown failure

### DIFF
--- a/doc/newsfragments/2873_changed.fix_setup_xfail.rst
+++ b/doc/newsfragments/2873_changed.fix_setup_xfail.rst
@@ -1,0 +1,1 @@
+--xfail-tests to support testsuite setup/teardown failure.

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -287,7 +287,11 @@ class Environment:
                 # Resource status should be STOPPED even it failed to stop
                 resource.force_stopped()
             else:
-                if resource.async_start:
+                if (
+                    resource.async_start
+                    and resource.status == resource.STATUS.STOPPING
+                ):
+                    # the 2nd clause to avoid StatusTransitionException: On status change from None to STOPPED
                     resources_to_wait_for.append(resource)
 
         # Wait resources status to be STOPPED.

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -572,6 +572,8 @@ class Test(Runnable):
             self.log_testcase_status(case_report)
 
         case_report.pass_if_empty()
+        pattern = ":".join([self.name, label, hook.__name__])
+        self._xfail(pattern, case_report)
         case_report.runtime_status = RuntimeStatus.FINISHED
         suite_report.runtime_status = RuntimeStatus.FINISHED
 
@@ -648,6 +650,13 @@ class Test(Runnable):
         """
 
         self._discover_path = path
+
+    def _xfail(self, pattern, report):
+        """Utility xfail a report entry if found in xfail_tests"""
+        if getattr(self.cfg, "xfail_tests", None):
+            found = self.cfg.xfail_tests.get(pattern)
+            if found:
+                report.xfail(strict=found["strict"])
 
 
 class ProcessRunnerTestConfig(TestConfig):
@@ -1091,34 +1100,32 @@ class ProcessRunnerTest(Test):
         Apply xfail tests specified via --xfail-tests or @test_plan(xfail_tests=...).
         """
 
-        def _xfail(pattern, report):
-            if getattr(self.cfg, "xfail_tests", None):
-                found = self.cfg.xfail_tests.get(pattern)
-                if found:
-                    report.xfail(strict=found["strict"])
-
         test_report = self.result.report
         pattern = f"{test_report.name}:*:*"
-        _xfail(pattern, test_report)
+        self._xfail(pattern, test_report)
 
         for suite_report in test_report.entries:
             pattern = f"{test_report.name}:{suite_report.name}:*"
-            _xfail(pattern, suite_report)
+            self._xfail(pattern, suite_report)
 
             for case_report in suite_report.entries:
                 pattern = f"{test_report.name}:{suite_report.name}:{case_report.name}"
-                _xfail(pattern, case_report)
+                self._xfail(pattern, case_report)
 
     def add_pre_resource_steps(self):
         """Runnable steps to be executed before environment starts."""
         super(ProcessRunnerTest, self).add_pre_resource_steps()
         self._add_step(self.make_runpath_dirs)
 
+    def add_post_resource_steps(self):
+        """Runnable steps to run after environment stopped."""
+        self._add_step(self.apply_xfail_tests)
+        super(ProcessRunnerTest, self).add_post_resource_steps()
+
     def add_main_batch_steps(self):
         """Runnable steps to be executed while environment is running."""
         self._add_step(self.run_tests)
         self._add_step(self.update_test_report)
-        self._add_step(self.apply_xfail_tests)
         self._add_step(self.propagate_tag_indices)
         self._add_step(self.log_test_results, top_down=False)
 

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -628,10 +628,14 @@ class MultiTest(testing_base.Test):
         super(MultiTest, self).add_pre_resource_steps()
         self._add_step(self.make_runpath_dirs)
 
+    def add_post_resource_steps(self):
+        """Runnable steps to run after environment stopped."""
+        self._add_step(self.apply_xfail_tests)
+        super(MultiTest, self).add_post_resource_steps()
+
     def add_main_batch_steps(self):
         """Runnable steps to be executed while environment is running."""
         self._add_step(self.run_tests)
-        self._add_step(self.apply_xfail_tests)
         self._add_step(self.propagate_tag_indices)
 
     def should_run(self):
@@ -666,19 +670,13 @@ class MultiTest(testing_base.Test):
         Testcase level xfail already applied during test execution.
         """
 
-        def _xfail(pattern, report):
-            if getattr(self.cfg, "xfail_tests", None):
-                found = self.cfg.xfail_tests.get(pattern)
-                if found:
-                    report.xfail(strict=found["strict"])
-
         test_report = self.result.report
         pattern = f"{test_report.name}:*:*"
-        _xfail(pattern, test_report)
+        self._xfail(pattern, test_report)
 
         for suite_report in test_report.entries:
             pattern = f"{test_report.name}:{suite_report.name}:*"
-            _xfail(pattern, suite_report)
+            self._xfail(pattern, suite_report)
 
     @property
     def _thread_pool_size(self):
@@ -1096,6 +1094,14 @@ class MultiTest(testing_base.Test):
         method_report.extend(case_result.serialized_entries)
         method_report.attachments.extend(case_result.attachments)
         method_report.pass_if_empty()
+        pattern = ":".join(
+            [
+                self.name,
+                testsuite.name,
+                method_name,
+            ]
+        )
+        self._xfail(pattern, method_report)
         method_report.runtime_status = RuntimeStatus.FINISHED
 
         return method_report


### PR DESCRIPTION
1) Be able to xfail testsuite setup & teardown
2) Avoid StatusTransitionException: On status change from None to STOPPED 
3) Move apply_xfail_tests to later in steps

## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
