### PR TITLE
Fix/RuntimeStatus serialization

### DIFF
--- a/doc/newsfragments/2910_changed.fix_runtimestatus_serialization.rst
+++ b/doc/newsfragments/2910_changed.fix_runtimestatus_serialization.rst
@@ -1,0 +1,1 @@
+Fix a serialization bug of one Testplan internal class.

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -101,13 +101,13 @@ class RuntimeStatus(Enum):
     def to_json_compatible(self) -> Optional[str]:
         if self.name == "NONE":
             return None
-        return self.name.lower().replace("_", "-")
+        return self.name.lower()
 
     @classmethod
     def from_json_compatible(cls, s: Optional[str]) -> Self:
         if s is None:
             return cls.NONE
-        return cls[s.replace("-", "_").upper()]
+        return cls[s.upper()]
 
 
 class Status(Enum):

--- a/tests/unit/testplan/report/test_testing.py
+++ b/tests/unit/testplan/report/test_testing.py
@@ -596,6 +596,11 @@ def test_runtime_status_basic_op():
     assert RuntimeStatus.NOT_RUN < RuntimeStatus.NONE
     assert not RuntimeStatus.NONE
 
+    assert RuntimeStatus.NOT_RUN.to_json_compatible() == "not_run"
+    assert (
+        RuntimeStatus.from_json_compatible("not_run") == RuntimeStatus.NOT_RUN
+    )
+
 
 def test_runtime_status_setting(dummy_test_plan_report):
     for status in list(RuntimeStatus)[:-1]:


### PR DESCRIPTION
## Bug / Requirement Description
We only have "not_run" in js code, not "not-run".

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
