### PR TITLE
Fix report serialization issue with remote driver

### DIFF
--- a/doc/newsfragments/2968_changed.fix_timer_serialization.rst
+++ b/doc/newsfragments/2968_changed.fix_timer_serialization.rst
@@ -1,0 +1,1 @@
+Fix exception in exporter stage when RemoteDriver is used.

--- a/examples/RemoteDriver/Basic/test_plan.py
+++ b/examples/RemoteDriver/Basic/test_plan.py
@@ -55,7 +55,7 @@ class TCPTestsuite:
         result.equal(received, response, "Client received")
 
 
-@test_plan(name="RemoteDriverBasic")
+@test_plan(name="RemoteDriverBasic", json_path="report.json")
 def main(plan):
 
     # remote_service represents the RPyC server that runs on remote host

--- a/testplan/common/report/log.py
+++ b/testplan/common/report/log.py
@@ -10,8 +10,7 @@ import logging
 import datetime
 import weakref
 
-from dateutil.tz import tzutc
-
+from datetime import timezone
 from testplan.common.utils import strings
 
 LOGGER = logging.getLogger(__name__)
@@ -31,7 +30,7 @@ class ReportLogHandler(logging.Handler):
             if report is not None:
                 created = datetime.datetime.utcfromtimestamp(
                     record.created
-                ).replace(tzinfo=tzutc())
+                ).replace(tzinfo=timezone.utc)
                 report.logs.append(
                     {
                         "message": self.format(record),

--- a/testplan/common/utils/timing.py
+++ b/testplan/common/utils/timing.py
@@ -21,7 +21,7 @@ from typing import (
     Union,
 )
 
-import pytz
+from datetime import timezone
 
 PollInterval = Union[float, Tuple[float, float]]
 
@@ -269,7 +269,7 @@ def retry_until_timeout(
 
 def utcnow() -> datetime.datetime:
     """Timezone aware UTC now."""
-    return datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
+    return datetime.datetime.utcnow().replace(tzinfo=timezone.utc)
 
 
 _Interval = collections.namedtuple("_Interval", "start end")

--- a/testplan/report/testing/schemas.py
+++ b/testplan/report/testing/schemas.py
@@ -12,7 +12,9 @@ from testplan.common.report.schemas import (
     BaseReportGroupSchema,
     ReportLogSchema,
     TimerField,
+    ReportLinkSchema,
 )
+
 from testplan.common.report import Status, RuntimeStatus
 from testplan.common.serialization import fields as custom_fields
 from testplan.common.serialization.schemas import load_tree_data
@@ -215,9 +217,11 @@ class ShallowTestGroupReportSchema(Schema):
     hash = fields.Integer(dump_only=True)
     env_status = fields.String(allow_none=True)
     strict_order = fields.Bool()
+    children = fields.List(fields.Nested(ReportLinkSchema))
 
     @post_load
     def make_testgroup_report(self, data, **kwargs):
+        children = data.pop("children", [])
         timer = data.pop("timer")
         logs = data.pop("logs", [])
 
@@ -226,6 +230,7 @@ class ShallowTestGroupReportSchema(Schema):
 
         group_report.timer = timer
         group_report.logs = logs
+        group_report.children = children
 
         return group_report
 

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -23,7 +23,6 @@ from typing import (
     Union,
 )
 
-import pytz
 from schema import And, Or, Use
 
 from testplan import defaults
@@ -1043,13 +1042,13 @@ class TestRunner(Runnable):
 
     def add_post_resource_steps(self):
         """Runnable steps to be executed after resources stopped."""
-        self._add_step(self._stop_remote_services)
         self._add_step(self._create_result)
         self._add_step(self._log_test_status)
         self._add_step(self.timer.end, "run")  # needs to happen before export
         self._add_step(self._pre_exporters)
         self._add_step(self._invoke_exporters)
         self._add_step(self._post_exporters)
+        self._add_step(self._stop_remote_services)
         self._add_step(self._close_file_logger)
         super(TestRunner, self).add_post_resource_steps()
         self._add_step(self._stop_resource_monitor)

--- a/tests/unit/testplan/report/test_testing.py
+++ b/tests/unit/testplan/report/test_testing.py
@@ -408,6 +408,7 @@ def dummy_test_plan_report_with_binary_asserts():
 
 def test_report_serialization(dummy_test_plan_report):
     """Serialized & deserialized reports should be equal."""
+
     data = dummy_test_plan_report.serialize()
     deserialized_report = TestReport.deserialize(data)
     check_report(actual=deserialized_report, expected=dummy_test_plan_report)
@@ -415,6 +416,7 @@ def test_report_serialization(dummy_test_plan_report):
 
 def test_report_json_serialization(dummy_test_plan_report):
     """JSON Serialized & deserialized reports should be equal."""
+
     test_plan_schema = TestReportSchema()
     data = test_plan_schema.dumps(dummy_test_plan_report)
     deserialized_report = test_plan_schema.loads(data)


### PR DESCRIPTION
## Bug / Requirement Description
By the time exporter serialize timer of remote driver, rpyc server already died 

## Solution description
Change step order, and avoid setting timezone info on remote side, and get rid of dateutil dependency.

## Checklist:
- [ ] Test
- [x] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
