### PR TITLE
WebUI: Added option to show time information in timezone where the tests were run

### DIFF
--- a/doc/newsfragments/2904_new.time_information.rst
+++ b/doc/newsfragments/2904_new.time_information.rst
@@ -1,1 +1,1 @@
-Users can now switch between Server time and UTC when enabling time information enabled on the WebUI. Additionally, the time information has been moved to the left side before the assertion title.
+Users can now switch between UTC and Server time when enabling time information on the WebUI (Defaults to server time). Additionally, the time information has been moved to the left side before the assertion title.

--- a/doc/newsfragments/2904_new.time_information.rst
+++ b/doc/newsfragments/2904_new.time_information.rst
@@ -1,0 +1,1 @@
+Users can now switch between Server time and UTC when enabling time information enabled on the WebUI. Additionally, the time information has been moved to the left side before the assertion title.

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionHeader.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionHeader.js
@@ -53,7 +53,7 @@ function AssertionHeader({
 
   const timeInfoArray = assertion.timeInfoArray || [];
   let component =
-    assertion.utc_time === undefined ? (
+    assertion.machine_time === undefined ? (
       <span className={css(styles.cardHeaderAlignRight)}>
         <FontAwesomeIcon // Should be a nested assertion group
           size="sm"
@@ -69,20 +69,20 @@ function AssertionHeader({
         <span
           className={css(styles.cardHeaderAlignRight, styles.timeInfo)}
           id={`tooltip_duration_${timeInfoArray[0]}`}
-          style={{ order: 4, display: "inline-flex", alignItems: "center" }}
+          style={{ order: 3, display: "inline-flex", alignItems: "center" }}
         >
           {timeInfoArray[2]}
         </span>
         <span
           className={css(styles.cardHeaderAlignRight)}
-          style={{ order: 3 }}
+          style={{ order: 2 }}
         >
           &nbsp;&nbsp;
         </span>
         <span
           className={css(styles.cardHeaderAlignRight, styles.timeInfo)}
           id={`tooltip_utc_${timeInfoArray[0]}`}
-          style={{ order: 6, display: "inline-flex", alignItems: "center" }}
+          style={{ order: 1, display: "inline-flex", alignItems: "center" }}
         >
           {timeInfoArray[1]}
         </span>
@@ -119,7 +119,7 @@ function AssertionHeader({
         onClick={() => {
           navigator.clipboard.writeText(getPath(assertion));
         }}
-        style={{ order: 2, marginLeft: "10px" }}
+        style={{ order: 6, marginLeft: "10px" }}
       >
         <span
           id={`tooltip_path_${uid}`}
@@ -166,7 +166,7 @@ function AssertionHeader({
           className={css(styles.button)}
           onClick={toggleExpand}
           style={{
-            order: 1,
+            order: 4,
             flexGrow: 4,
             padding: ".125rem 0.75rem",
             ...assertion.custom_style,

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionHeader.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionHeader.js
@@ -250,8 +250,7 @@ const styles = StyleSheet.create({
   },
 
   timeInfo: {
-    padding: "4px 0px",
-    fontFamily: "Roboto, Helvetica, Arial, sans-serif",
+    padding: "2px 0px",
   },
 
   cardHeaderPath: {

--- a/testplan/web_ui/testing/src/AssertionPane/__tests__/__snapshots__/AssertionHeader.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/__tests__/__snapshots__/AssertionHeader.test.js.snap
@@ -17,7 +17,7 @@ exports[`AssertionHeader shallow renders the correct HTML structure 1`] = `
       style={
         Object {
           "flexGrow": 4,
-          "order": 1,
+          "order": 4,
           "padding": ".125rem 0.75rem",
         }
       }

--- a/testplan/web_ui/testing/src/Common/__tests__/utils.test.js
+++ b/testplan/web_ui/testing/src/Common/__tests__/utils.test.js
@@ -38,8 +38,8 @@ describe("Common/utils", () => {
       const ms = 999;
       var millisecondsFormatted = formatMilliseconds(ms);
       var secondsFormatted = formatSeconds(ms / 1000);
-      expect(millisecondsFormatted).toEqual("999ms");
-      expect(secondsFormatted).toEqual("999ms");
+      expect(millisecondsFormatted).toEqual("0.999s");
+      expect(secondsFormatted).toEqual("0.999s");
     });
 
     it("returns seconds and milliseconds if the input is less than a minute", () => {
@@ -48,8 +48,8 @@ describe("Common/utils", () => {
       const millisecondsInput = s + ms;
       var millisecondsFormatted = formatMilliseconds(millisecondsInput);
       var secondsFormatted = formatSeconds(millisecondsInput / 1000);
-      expect(millisecondsFormatted).toEqual("59s 999ms");
-      expect(secondsFormatted).toEqual("59s 999ms");
+      expect(millisecondsFormatted).toEqual("59.999s");
+      expect(secondsFormatted).toEqual("59.999s");
     });
 
     it("returns minutes and seconds if the input is less than an hour", () => {
@@ -59,8 +59,8 @@ describe("Common/utils", () => {
       const millisecondsInput = m + s + ms;
       var millisecondsFormatted = formatMilliseconds(millisecondsInput);
       var secondsFormatted = formatSeconds(millisecondsInput / 1000);
-      expect(millisecondsFormatted).toEqual("59m 59s");
-      expect(secondsFormatted).toEqual("59m 59s");
+      expect(millisecondsFormatted).toEqual("59m 59.999s");
+      expect(secondsFormatted).toEqual("59m 59.999s");
     });
 
     it("returns hours and minutes if the input is at least an hour", () => {
@@ -71,8 +71,8 @@ describe("Common/utils", () => {
       const millisecondsInput = h + m + s + ms;
       var millisecondsFormatted = formatMilliseconds(millisecondsInput);
       var secondsFormatted = formatSeconds(millisecondsInput / 1000);
-      expect(millisecondsFormatted).toEqual("59h 59m");
-      expect(secondsFormatted).toEqual("59h 59m");
+      expect(millisecondsFormatted).toEqual("59h 59m 59.999s");
+      expect(secondsFormatted).toEqual("59h 59m 59.999s");
     });
 
     it("returns hours only if the input is at least an hour and zero minutes", () => {
@@ -83,8 +83,8 @@ describe("Common/utils", () => {
       const millisecondsInput = h + m + s + ms;
       var millisecondsFormatted = formatMilliseconds(millisecondsInput);
       var secondsFormatted = formatSeconds(millisecondsInput / 1000);
-      expect(millisecondsFormatted).toEqual("59h");
-      expect(secondsFormatted).toEqual("59h");
+      expect(millisecondsFormatted).toEqual("59h 0m 59.999s");
+      expect(secondsFormatted).toEqual("59h 0m 59.999s");
     });
 
     it("returns minutes only if the input is less than an hour and zero seconds", () => {
@@ -94,8 +94,8 @@ describe("Common/utils", () => {
       const millisecondsInput = m + s + ms;
       var millisecondsFormatted = formatMilliseconds(millisecondsInput);
       var secondsFormatted = formatSeconds(millisecondsInput / 1000);
-      expect(millisecondsFormatted).toEqual("59m");
-      expect(secondsFormatted).toEqual("59m");
+      expect(millisecondsFormatted).toEqual("59m 0.999s");
+      expect(secondsFormatted).toEqual("59m 0.999s");
     });
 
     it("returns seconds only if the input is less than a minute and zero milliseconds", () => {
@@ -104,8 +104,8 @@ describe("Common/utils", () => {
       const millisecondsInput = s + ms;
       var millisecondsFormatted = formatMilliseconds(millisecondsInput);
       var secondsFormatted = formatSeconds(millisecondsInput / 1000);
-      expect(millisecondsFormatted).toEqual("59s");
-      expect(secondsFormatted).toEqual("59s");
+      expect(millisecondsFormatted).toEqual("59.000s");
+      expect(secondsFormatted).toEqual("59.000s");
     });
   });
 });

--- a/testplan/web_ui/testing/src/Common/__tests__/utils.test.js
+++ b/testplan/web_ui/testing/src/Common/__tests__/utils.test.js
@@ -34,7 +34,7 @@ describe("Common/utils", () => {
   });
 
   describe("formatMilliseconds and formatSeconds", () => {
-    it("returns milliseconds only if the input is less than a second", () => {
+    it("returns s.SSS if the input is just less than a second", () => {
       const ms = 999;
       var millisecondsFormatted = formatMilliseconds(ms);
       var secondsFormatted = formatSeconds(ms / 1000);
@@ -42,7 +42,17 @@ describe("Common/utils", () => {
       expect(secondsFormatted).toEqual("0.999s");
     });
 
-    it("returns seconds and milliseconds if the input is less than a minute", () => {
+    it("returns s.SSS if the input is whole seconds and zero milliseconds", () => {
+      const ms = 0;
+      const s = 59000;
+      const millisecondsInput = s + ms;
+      var millisecondsFormatted = formatMilliseconds(millisecondsInput);
+      var secondsFormatted = formatSeconds(millisecondsInput / 1000);
+      expect(millisecondsFormatted).toEqual("59.000s");
+      expect(secondsFormatted).toEqual("59.000s");
+    });
+
+    it("returns s.SSS if the input is just less than a minute", () => {
       const ms = 999;
       const s = 59000;
       const millisecondsInput = s + ms;
@@ -52,7 +62,7 @@ describe("Common/utils", () => {
       expect(secondsFormatted).toEqual("59.999s");
     });
 
-    it("returns minutes and seconds if the input is less than an hour", () => {
+    it("returns m s.SSS if the input is less than an hour", () => {
       const ms = 999;
       const s = 59000;
       const m = 3540000;
@@ -63,19 +73,19 @@ describe("Common/utils", () => {
       expect(secondsFormatted).toEqual("59m 59.999s");
     });
 
-    it("returns hours and minutes if the input is at least an hour", () => {
+    it("returns h m s.SSS if the input is at least an hour", () => {
       const ms = 999;
       const s = 59000;
       const m = 3540000;
-      const h = 212400000;
+      const h = 32400000;
       const millisecondsInput = h + m + s + ms;
       var millisecondsFormatted = formatMilliseconds(millisecondsInput);
       var secondsFormatted = formatSeconds(millisecondsInput / 1000);
-      expect(millisecondsFormatted).toEqual("59h 59m 59.999s");
-      expect(secondsFormatted).toEqual("59h 59m 59.999s");
+      expect(millisecondsFormatted).toEqual("9h 59m 59.999s");
+      expect(secondsFormatted).toEqual("9h 59m 59.999s");
     });
 
-    it("returns hours only if the input is at least an hour and zero minutes", () => {
+    it("returns h m s.SSS if the input is at least an hour and zero minutes", () => {
       const ms = 999;
       const s = 59000;
       const m = 0;
@@ -85,27 +95,6 @@ describe("Common/utils", () => {
       var secondsFormatted = formatSeconds(millisecondsInput / 1000);
       expect(millisecondsFormatted).toEqual("59h 0m 59.999s");
       expect(secondsFormatted).toEqual("59h 0m 59.999s");
-    });
-
-    it("returns minutes only if the input is less than an hour and zero seconds", () => {
-      const ms = 999;
-      const s = 0;
-      const m = 3540000;
-      const millisecondsInput = m + s + ms;
-      var millisecondsFormatted = formatMilliseconds(millisecondsInput);
-      var secondsFormatted = formatSeconds(millisecondsInput / 1000);
-      expect(millisecondsFormatted).toEqual("59m 0.999s");
-      expect(secondsFormatted).toEqual("59m 0.999s");
-    });
-
-    it("returns seconds only if the input is less than a minute and zero milliseconds", () => {
-      const ms = 0;
-      const s = 59000;
-      const millisecondsInput = s + ms;
-      var millisecondsFormatted = formatMilliseconds(millisecondsInput);
-      var secondsFormatted = formatSeconds(millisecondsInput / 1000);
-      expect(millisecondsFormatted).toEqual("59.000s");
-      expect(secondsFormatted).toEqual("59.000s");
     });
   });
 });

--- a/testplan/web_ui/testing/src/Common/utils.js
+++ b/testplan/web_ui/testing/src/Common/utils.js
@@ -137,34 +137,30 @@ function formatSeconds(durationInSeconds) {
 
 /**
  * Formats the input number representing milliseconds into a string
- * with format H:m:s:ms. Each value is display only if it is greater
+ * with format H:m:s.SSS. Each value is displayed only if it is greater
  * than 0 or the previous value has been displayed.
  * @param {number} durationInMilliseconds
  * @returns {string}
  */
 function formatMilliseconds(durationInMilliseconds) {
-  let milliseconds = durationInMilliseconds % 1000;
-  durationInMilliseconds = (durationInMilliseconds - milliseconds) / 1000;
-  let seconds = durationInMilliseconds % 60;
-  durationInMilliseconds = (durationInMilliseconds - seconds) / 60;
-  let minutes = durationInMilliseconds % 60;
-  let hours = (durationInMilliseconds - minutes) / 60;
+  let secondsInMilliseconds = durationInMilliseconds % 60000;
+  let seconds = secondsInMilliseconds / 1000;
+  let minutesInMilliseconds = (durationInMilliseconds - secondsInMilliseconds)
+  / 60000;
+  let minutes = minutesInMilliseconds % 60;
+  let hours = (minutesInMilliseconds - minutes) / 60;
 
   const isDisplayedHours = hours > 0;
-  const isDisplayedMinutes = minutes > 0;
-  const isDisplayedSeconds = seconds > 0 && !isDisplayedHours;
-  const isDisplayedMilliseconds =
-    milliseconds > 0 && !isDisplayedMinutes && !isDisplayedHours;
+  const isDisplayedMinutes = isDisplayedHours || minutes > 0;
 
   let hoursDisplay = isDisplayedHours ? hours + "h" : "";
   let minutesDisplay = isDisplayedMinutes ? minutes + "m" : "";
-  let secondsDisplay = isDisplayedSeconds ? seconds + "s" : "";
-  let millisecondsDisplay = isDisplayedMilliseconds ? milliseconds + "ms" : "";
+  let secondsDisplay = seconds.toFixed(3) + "s";
 
   return (
-    [hoursDisplay, minutesDisplay, secondsDisplay, millisecondsDisplay]
+    [hoursDisplay, minutesDisplay, secondsDisplay]
       .filter(Boolean)
-      .join(" ") || "0ms"
+      .join(" ") || "0s"
   );
 }
 

--- a/testplan/web_ui/testing/src/Report/BatchReport.js
+++ b/testplan/web_ui/testing/src/Report/BatchReport.js
@@ -30,7 +30,7 @@ import {
 } from "../Common/fakeReport";
 import { ErrorBoundary } from "../Common/ErrorBoundary";
 import { useAtomValue } from "jotai";
-import { displayTimeInfoPreference } from "../UserSettings/UserSettings";
+import { displayTimeInfoPreference, timeInfoUTCPreference } from "../UserSettings/UserSettings";
 
 /**
  * BatchReport component:
@@ -41,7 +41,9 @@ import { displayTimeInfoPreference } from "../UserSettings/UserSettings";
 
 const BatchReport = (props) => {
   const displayTimeInfo = useAtomValue(displayTimeInfoPreference);
-  return <BatchReportComponent {...props} displayTime={displayTimeInfo} />;
+  const UTCTimeInfo = useAtomValue(timeInfoUTCPreference);
+  return <BatchReportComponent {...props} displayTime={displayTimeInfo}
+          UTCTime={UTCTimeInfo}/>;
 };
 class BatchReportComponent extends BaseReport {
   constructor(props) {
@@ -253,7 +255,8 @@ class BatchReportComponent extends BaseReport {
       reportFetchMessage,
       this.props.match.params.uid,
       selectedEntries,
-      this.props.displayTime
+      this.props.displayTime,
+      this.props.UTCTime
     );
 
     return (

--- a/testplan/web_ui/testing/src/Report/InteractiveReport.js
+++ b/testplan/web_ui/testing/src/Report/InteractiveReport.js
@@ -700,7 +700,8 @@ class InteractiveReportComponent extends BaseReport {
       reportFetchMessage,
       null,
       selectedEntries,
-      this.props.displayTime
+      this.props.displayTime,
+      this.props.UTCTime
     );
 
     return (

--- a/testplan/web_ui/testing/src/Report/__tests__/BatchReport.test.js
+++ b/testplan/web_ui/testing/src/Report/__tests__/BatchReport.test.js
@@ -20,7 +20,8 @@ describe("BatchReport", () => {
   const renderBatchReport = (
     uid = "123",
     selection = undefined,
-    displayTime = false
+    displayTime = false,
+    UTCTime = false,
   ) => {
     // Mock the match object that would be passed down from react-router.
     // BatchReport uses this object to get the report UID.
@@ -35,6 +36,7 @@ describe("BatchReport", () => {
         match={mockMatch}
         history={routerContext.props().history}
         displayTime={displayTime}
+        UTCTime={UTCTime}
       />,
       {
         ...routerContext.get(),
@@ -274,7 +276,41 @@ describe("BatchReport", () => {
     });
   });
 
-  it("loads a report with selection at Testcase level and Time Information enanbled", (done) => {
+  it("loads a report with selection at Testcase level and UTC Time Information enabled", (done) => {
+    moxios.stubRequest("/api/v1/metadata/fix-spec/tags", {
+      status: 200,
+      response: {},
+    });
+    const batchReport = renderBatchReport(
+      "520a92e4-325e-4077-93e6-55d7091a3f83",
+      "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8/08d4c671-d55d-49d4-96ba-dc654d12be26/f73bd6ea-d378-437b-a5db-00d9e427f36a",
+      true,
+      true
+    );
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      expect(request.url).toBe(
+        "/api/v1/reports/520a92e4-325e-4077-93e6-55d7091a3f83"
+      );
+      request
+        .respondWith({
+          status: 200,
+          response: TESTPLAN_REPORT,
+        })
+        .then(() => {
+          batchReport.update();
+          const props = batchReport.instance().props;
+          expect(props.history.location.pathname).toBe(
+            `/testplan/520a92e4-325e-4077-93e6-55d7091a3f83/8c3c7e6b-48e8-40cd-86db-8c8aed2592c8/08d4c671-d55d-49d4-96ba-dc654d12be26/f73bd6ea-d378-437b-a5db-00d9e427f36a`
+          );
+          handleRedirect(batchReport);
+          expect(batchReport).toMatchSnapshot();
+          done();
+        });
+    });
+  });
+
+  it("loads a report with selection at Testcase level and Time Information enabled", (done) => {
     moxios.stubRequest("/api/v1/metadata/fix-spec/tags", {
       status: 200,
       response: {},

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
@@ -13629,7 +13629,7 @@ exports[`BatchReport loads a report with selection at Testcase level 1`] = `
 </div>
 `;
 
-exports[`BatchReport loads a report with selection at Testcase level and Time Information enanbled 1`] = `
+exports[`BatchReport loads a report with selection at Testcase level and Time Information enabled 1`] = `
 <div
   className="batchReport_7gv3ej"
 >
@@ -13963,8 +13963,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                         "second": 1,
                         "timeInfoArray": Array [
                           0,
-                          "14:30:12.010 UTC",
-                          "(+0ms)",
+                          "15:30:12.010 (UTC+00:00)",
+                          "(+0.000s)",
                         ],
                         "type": "Equal",
                         "utc_time": "2018-10-15T14:30:12.010094+00:00",
@@ -13981,8 +13981,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                         "second": 1,
                         "timeInfoArray": Array [
                           1,
-                          "14:30:14.015 UTC",
-                          "(+2s 5ms)",
+                          "15:30:14.015 (UTC+00:00)",
+                          "(+2.005s)",
                         ],
                         "type": "Equal",
                         "utc_time": "2018-10-15T14:30:14.015698+00:00",
@@ -13999,8 +13999,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                         "second": 1,
                         "timeInfoArray": Array [
                           2,
-                          "14:32:21.123 UTC",
-                          "(+2m 7s)",
+                          "15:32:21.123 (UTC+00:00)",
+                          "(+2m 7.108s)",
                         ],
                         "type": "Equal",
                         "utc_time": "2018-10-15T14:32:21.123494+00:00",
@@ -14017,8 +14017,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                         "second": 1,
                         "timeInfoArray": Array [
                           3,
-                          "14:33:37.015 UTC",
-                          "(+1m 15s)",
+                          "15:33:37.015 (UTC+00:00)",
+                          "(+1m 15.892s)",
                         ],
                         "type": "Equal",
                         "utc_time": "2018-10-15T14:33:37.015678+00:00",
@@ -14472,8 +14472,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                           "second": 1,
                           "timeInfoArray": Array [
                             0,
-                            "14:30:12.010 UTC",
-                            "(+0ms)",
+                            "15:30:12.010 (UTC+00:00)",
+                            "(+0.000s)",
                           ],
                           "type": "Equal",
                           "utc_time": "2018-10-15T14:30:12.010094+00:00",
@@ -14490,8 +14490,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                           "second": 1,
                           "timeInfoArray": Array [
                             1,
-                            "14:30:14.015 UTC",
-                            "(+2s 5ms)",
+                            "15:30:14.015 (UTC+00:00)",
+                            "(+2.005s)",
                           ],
                           "type": "Equal",
                           "utc_time": "2018-10-15T14:30:14.015698+00:00",
@@ -14508,8 +14508,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                           "second": 1,
                           "timeInfoArray": Array [
                             2,
-                            "14:32:21.123 UTC",
-                            "(+2m 7s)",
+                            "15:32:21.123 (UTC+00:00)",
+                            "(+2m 7.108s)",
                           ],
                           "type": "Equal",
                           "utc_time": "2018-10-15T14:32:21.123494+00:00",
@@ -14526,8 +14526,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                           "second": 1,
                           "timeInfoArray": Array [
                             3,
-                            "14:33:37.015 UTC",
-                            "(+1m 15s)",
+                            "15:33:37.015 (UTC+00:00)",
+                            "(+1m 15.892s)",
                           ],
                           "type": "Equal",
                           "utc_time": "2018-10-15T14:33:37.015678+00:00",
@@ -14672,8 +14672,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                       "second": 1,
                       "timeInfoArray": Array [
                         0,
-                        "14:30:12.010 UTC",
-                        "(+0ms)",
+                        "15:30:12.010 (UTC+00:00)",
+                        "(+0.000s)",
                       ],
                       "type": "Equal",
                       "utc_time": "2018-10-15T14:30:12.010094+00:00",
@@ -14690,8 +14690,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                       "second": 1,
                       "timeInfoArray": Array [
                         1,
-                        "14:30:14.015 UTC",
-                        "(+2s 5ms)",
+                        "15:30:14.015 (UTC+00:00)",
+                        "(+2.005s)",
                       ],
                       "type": "Equal",
                       "utc_time": "2018-10-15T14:30:14.015698+00:00",
@@ -14708,8 +14708,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                       "second": 1,
                       "timeInfoArray": Array [
                         2,
-                        "14:32:21.123 UTC",
-                        "(+2m 7s)",
+                        "15:32:21.123 (UTC+00:00)",
+                        "(+2m 7.108s)",
                       ],
                       "type": "Equal",
                       "utc_time": "2018-10-15T14:32:21.123494+00:00",
@@ -14726,8 +14726,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                       "second": 1,
                       "timeInfoArray": Array [
                         3,
-                        "14:33:37.015 UTC",
-                        "(+1m 15s)",
+                        "15:33:37.015 (UTC+00:00)",
+                        "(+1m 15.892s)",
                       ],
                       "type": "Equal",
                       "utc_time": "2018-10-15T14:33:37.015678+00:00",
@@ -14833,8 +14833,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                   "second": 1,
                   "timeInfoArray": Array [
                     0,
-                    "14:30:12.010 UTC",
-                    "(+0ms)",
+                    "15:30:12.010 (UTC+00:00)",
+                    "(+0.000s)",
                   ],
                   "type": "Equal",
                   "utc_time": "2018-10-15T14:30:12.010094+00:00",
@@ -14851,8 +14851,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                   "second": 1,
                   "timeInfoArray": Array [
                     1,
-                    "14:30:14.015 UTC",
-                    "(+2s 5ms)",
+                    "15:30:14.015 (UTC+00:00)",
+                    "(+2.005s)",
                   ],
                   "type": "Equal",
                   "utc_time": "2018-10-15T14:30:14.015698+00:00",
@@ -14869,8 +14869,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                   "second": 1,
                   "timeInfoArray": Array [
                     2,
-                    "14:32:21.123 UTC",
-                    "(+2m 7s)",
+                    "15:32:21.123 (UTC+00:00)",
+                    "(+2m 7.108s)",
                   ],
                   "type": "Equal",
                   "utc_time": "2018-10-15T14:32:21.123494+00:00",
@@ -14887,8 +14887,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                   "second": 1,
                   "timeInfoArray": Array [
                     3,
-                    "14:33:37.015 UTC",
-                    "(+1m 15s)",
+                    "15:33:37.015 (UTC+00:00)",
+                    "(+1m 15.892s)",
                   ],
                   "type": "Equal",
                   "utc_time": "2018-10-15T14:33:37.015678+00:00",
@@ -14964,8 +14964,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
               "second": 1,
               "timeInfoArray": Array [
                 0,
-                "14:30:12.010 UTC",
-                "(+0ms)",
+                "15:30:12.010 (UTC+00:00)",
+                "(+0.000s)",
               ],
               "type": "Equal",
               "utc_time": "2018-10-15T14:30:12.010094+00:00",
@@ -14982,8 +14982,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
               "second": 1,
               "timeInfoArray": Array [
                 1,
-                "14:30:14.015 UTC",
-                "(+2s 5ms)",
+                "15:30:14.015 (UTC+00:00)",
+                "(+2.005s)",
               ],
               "type": "Equal",
               "utc_time": "2018-10-15T14:30:14.015698+00:00",
@@ -15000,8 +15000,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
               "second": 1,
               "timeInfoArray": Array [
                 2,
-                "14:32:21.123 UTC",
-                "(+2m 7s)",
+                "15:32:21.123 (UTC+00:00)",
+                "(+2m 7.108s)",
               ],
               "type": "Equal",
               "utc_time": "2018-10-15T14:32:21.123494+00:00",
@@ -15018,8 +15018,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
               "second": 1,
               "timeInfoArray": Array [
                 3,
-                "14:33:37.015 UTC",
-                "(+1m 15s)",
+                "15:33:37.015 (UTC+00:00)",
+                "(+1m 15.892s)",
               ],
               "type": "Equal",
               "utc_time": "2018-10-15T14:33:37.015678+00:00",
@@ -15396,8 +15396,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                           "second": 1,
                           "timeInfoArray": Array [
                             0,
-                            "14:30:12.010 UTC",
-                            "(+0ms)",
+                            "15:30:12.010 (UTC+00:00)",
+                            "(+0.000s)",
                           ],
                           "type": "Equal",
                           "utc_time": "2018-10-15T14:30:12.010094+00:00",
@@ -15414,8 +15414,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                           "second": 1,
                           "timeInfoArray": Array [
                             1,
-                            "14:30:14.015 UTC",
-                            "(+2s 5ms)",
+                            "15:30:14.015 (UTC+00:00)",
+                            "(+2.005s)",
                           ],
                           "type": "Equal",
                           "utc_time": "2018-10-15T14:30:14.015698+00:00",
@@ -15432,8 +15432,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                           "second": 1,
                           "timeInfoArray": Array [
                             2,
-                            "14:32:21.123 UTC",
-                            "(+2m 7s)",
+                            "15:32:21.123 (UTC+00:00)",
+                            "(+2m 7.108s)",
                           ],
                           "type": "Equal",
                           "utc_time": "2018-10-15T14:32:21.123494+00:00",
@@ -15450,8 +15450,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                           "second": 1,
                           "timeInfoArray": Array [
                             3,
-                            "14:33:37.015 UTC",
-                            "(+1m 15s)",
+                            "15:33:37.015 (UTC+00:00)",
+                            "(+1m 15.892s)",
                           ],
                           "type": "Equal",
                           "utc_time": "2018-10-15T14:33:37.015678+00:00",
@@ -15898,8 +15898,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                             "second": 1,
                             "timeInfoArray": Array [
                               0,
-                              "14:30:12.010 UTC",
-                              "(+0ms)",
+                              "15:30:12.010 (UTC+00:00)",
+                              "(+0.000s)",
                             ],
                             "type": "Equal",
                             "utc_time": "2018-10-15T14:30:12.010094+00:00",
@@ -15916,8 +15916,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                             "second": 1,
                             "timeInfoArray": Array [
                               1,
-                              "14:30:14.015 UTC",
-                              "(+2s 5ms)",
+                              "15:30:14.015 (UTC+00:00)",
+                              "(+2.005s)",
                             ],
                             "type": "Equal",
                             "utc_time": "2018-10-15T14:30:14.015698+00:00",
@@ -15934,8 +15934,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                             "second": 1,
                             "timeInfoArray": Array [
                               2,
-                              "14:32:21.123 UTC",
-                              "(+2m 7s)",
+                              "15:32:21.123 (UTC+00:00)",
+                              "(+2m 7.108s)",
                             ],
                             "type": "Equal",
                             "utc_time": "2018-10-15T14:32:21.123494+00:00",
@@ -15952,8 +15952,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                             "second": 1,
                             "timeInfoArray": Array [
                               3,
-                              "14:33:37.015 UTC",
-                              "(+1m 15s)",
+                              "15:33:37.015 (UTC+00:00)",
+                              "(+1m 15.892s)",
                             ],
                             "type": "Equal",
                             "utc_time": "2018-10-15T14:33:37.015678+00:00",
@@ -16098,8 +16098,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                         "second": 1,
                         "timeInfoArray": Array [
                           0,
-                          "14:30:12.010 UTC",
-                          "(+0ms)",
+                          "15:30:12.010 (UTC+00:00)",
+                          "(+0.000s)",
                         ],
                         "type": "Equal",
                         "utc_time": "2018-10-15T14:30:12.010094+00:00",
@@ -16116,8 +16116,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                         "second": 1,
                         "timeInfoArray": Array [
                           1,
-                          "14:30:14.015 UTC",
-                          "(+2s 5ms)",
+                          "15:30:14.015 (UTC+00:00)",
+                          "(+2.005s)",
                         ],
                         "type": "Equal",
                         "utc_time": "2018-10-15T14:30:14.015698+00:00",
@@ -16134,8 +16134,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                         "second": 1,
                         "timeInfoArray": Array [
                           2,
-                          "14:32:21.123 UTC",
-                          "(+2m 7s)",
+                          "15:32:21.123 (UTC+00:00)",
+                          "(+2m 7.108s)",
                         ],
                         "type": "Equal",
                         "utc_time": "2018-10-15T14:32:21.123494+00:00",
@@ -16152,8 +16152,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                         "second": 1,
                         "timeInfoArray": Array [
                           3,
-                          "14:33:37.015 UTC",
-                          "(+1m 15s)",
+                          "15:33:37.015 (UTC+00:00)",
+                          "(+1m 15.892s)",
                         ],
                         "type": "Equal",
                         "utc_time": "2018-10-15T14:33:37.015678+00:00",
@@ -16259,8 +16259,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                     "second": 1,
                     "timeInfoArray": Array [
                       0,
-                      "14:30:12.010 UTC",
-                      "(+0ms)",
+                      "15:30:12.010 (UTC+00:00)",
+                      "(+0.000s)",
                     ],
                     "type": "Equal",
                     "utc_time": "2018-10-15T14:30:12.010094+00:00",
@@ -16277,8 +16277,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                     "second": 1,
                     "timeInfoArray": Array [
                       1,
-                      "14:30:14.015 UTC",
-                      "(+2s 5ms)",
+                      "15:30:14.015 (UTC+00:00)",
+                      "(+2.005s)",
                     ],
                     "type": "Equal",
                     "utc_time": "2018-10-15T14:30:14.015698+00:00",
@@ -16295,8 +16295,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                     "second": 1,
                     "timeInfoArray": Array [
                       2,
-                      "14:32:21.123 UTC",
-                      "(+2m 7s)",
+                      "15:32:21.123 (UTC+00:00)",
+                      "(+2m 7.108s)",
                     ],
                     "type": "Equal",
                     "utc_time": "2018-10-15T14:32:21.123494+00:00",
@@ -16313,8 +16313,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                     "second": 1,
                     "timeInfoArray": Array [
                       3,
-                      "14:33:37.015 UTC",
-                      "(+1m 15s)",
+                      "15:33:37.015 (UTC+00:00)",
+                      "(+1m 15.892s)",
                     ],
                     "type": "Equal",
                     "utc_time": "2018-10-15T14:33:37.015678+00:00",
@@ -16390,8 +16390,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                 "second": 1,
                 "timeInfoArray": Array [
                   0,
-                  "14:30:12.010 UTC",
-                  "(+0ms)",
+                  "15:30:12.010 (UTC+00:00)",
+                  "(+0.000s)",
                 ],
                 "type": "Equal",
                 "utc_time": "2018-10-15T14:30:12.010094+00:00",
@@ -16408,8 +16408,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                 "second": 1,
                 "timeInfoArray": Array [
                   1,
-                  "14:30:14.015 UTC",
-                  "(+2s 5ms)",
+                  "15:30:14.015 (UTC+00:00)",
+                  "(+2.005s)",
                 ],
                 "type": "Equal",
                 "utc_time": "2018-10-15T14:30:14.015698+00:00",
@@ -16426,8 +16426,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                 "second": 1,
                 "timeInfoArray": Array [
                   2,
-                  "14:32:21.123 UTC",
-                  "(+2m 7s)",
+                  "15:32:21.123 (UTC+00:00)",
+                  "(+2m 7.108s)",
                 ],
                 "type": "Equal",
                 "utc_time": "2018-10-15T14:32:21.123494+00:00",
@@ -16444,8 +16444,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                 "second": 1,
                 "timeInfoArray": Array [
                   3,
-                  "14:33:37.015 UTC",
-                  "(+1m 15s)",
+                  "15:33:37.015 (UTC+00:00)",
+                  "(+1m 15.892s)",
                 ],
                 "type": "Equal",
                 "utc_time": "2018-10-15T14:33:37.015678+00:00",
@@ -16511,8 +16511,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                 "second": 1,
                 "timeInfoArray": Array [
                   0,
-                  "14:30:12.010 UTC",
-                  "(+0ms)",
+                  "15:30:12.010 (UTC+00:00)",
+                  "(+0.000s)",
                 ],
                 "type": "Equal",
                 "utc_time": "2018-10-15T14:30:12.010094+00:00",
@@ -16529,8 +16529,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                 "second": 1,
                 "timeInfoArray": Array [
                   1,
-                  "14:30:14.015 UTC",
-                  "(+2s 5ms)",
+                  "15:30:14.015 (UTC+00:00)",
+                  "(+2.005s)",
                 ],
                 "type": "Equal",
                 "utc_time": "2018-10-15T14:30:14.015698+00:00",
@@ -16547,8 +16547,8 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                 "second": 1,
                 "timeInfoArray": Array [
                   2,
-                  "14:32:21.123 UTC",
-                  "(+2m 7s)",
+                  "15:32:21.123 (UTC+00:00)",
+                  "(+2m 7.108s)",
                 ],
                 "type": "Equal",
                 "utc_time": "2018-10-15T14:32:21.123494+00:00",
@@ -16565,8 +16565,2966 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                 "second": 1,
                 "timeInfoArray": Array [
                   3,
-                  "14:33:37.015 UTC",
-                  "(+1m 15s)",
+                  "15:33:37.015 (UTC+00:00)",
+                  "(+1m 15.892s)",
+                ],
+                "type": "Equal",
+                "utc_time": "2018-10-15T14:33:37.015678+00:00",
+              },
+            ]
+          }
+          descriptionEntries={Array []}
+          filter={null}
+          key="f73bd6ea-d378-437b-a5db-00d9e427f36a"
+          left="22em"
+          logs={Array []}
+          reportUid="520a92e4-325e-4077-93e6-55d7091a3f83"
+          testcaseUid="f73bd6ea-d378-437b-a5db-00d9e427f36a"
+        />
+      </ErrorBoundary>
+    </ContextProvider>
+  </div>
+</div>
+`;
+
+exports[`BatchReport loads a report with selection at Testcase level and UTC Time Information enabled 1`] = `
+<div
+  className="batchReport_7gv3ej"
+>
+  <Toolbar
+    current_pannel="assertion"
+    expandStatus="default"
+    filterBoxWidth="22em"
+    filterText={null}
+    handleNavFilter={[Function]}
+    report={
+      Object {
+        "category": "testplan",
+        "entries": Array [
+          Object {
+            "category": "multitest",
+            "description": null,
+            "entries": Array [
+              Object {
+                "category": "testsuite",
+                "description": null,
+                "entries": Array [
+                  Object {
+                    "category": "testcase",
+                    "description": null,
+                    "entries": Array [
+                      Object {
+                        "category": "DEFAULT",
+                        "description": "passing equality",
+                        "first": 1,
+                        "label": "==",
+                        "line_no": 24,
+                        "machine_time": "2018-10-15T15:30:11.010098+00:00",
+                        "meta_type": "assertion",
+                        "passed": true,
+                        "second": 1,
+                        "type": "Equal",
+                        "utc_time": "2018-10-15T14:30:11.010094+00:00",
+                      },
+                    ],
+                    "logs": Array [],
+                    "name": "test_equality_passing",
+                    "name_type_index": Array [
+                      "test_equality_passing|testcase",
+                      "AlphaSuite|testsuite",
+                      "Primary|multitest",
+                      "Sample Testplan|testplan",
+                    ],
+                    "status": "passed",
+                    "status_override": null,
+                    "tags": Object {
+                      "colour": Array [
+                        "white",
+                      ],
+                      "simple": Array [
+                        "server",
+                      ],
+                    },
+                    "tags_index": Object {
+                      "colour": Array [
+                        "white",
+                      ],
+                      "simple": Array [
+                        "server",
+                      ],
+                    },
+                    "timer": Object {
+                      "run": Object {
+                        "end": "2018-10-15T14:30:11.132214+00:00",
+                        "start": "2018-10-15T14:30:11.010072+00:00",
+                      },
+                    },
+                    "type": "TestCaseReport",
+                    "uid": "736706ef-ba65-475d-96c5-f2855f431028",
+                    "uids": Array [
+                      "520a92e4-325e-4077-93e6-55d7091a3f83",
+                      "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                      "cb144b10-bdb0-44d3-9170-d8016dd19ee7",
+                      "736706ef-ba65-475d-96c5-f2855f431028",
+                    ],
+                  },
+                  Object {
+                    "category": "testcase",
+                    "description": null,
+                    "entries": Array [
+                      Object {
+                        "category": "DEFAULT",
+                        "description": "passing equality",
+                        "first": 1,
+                        "label": "==",
+                        "line_no": 24,
+                        "machine_time": "2018-10-15T15:30:11.510098+00:00",
+                        "meta_type": "assertion",
+                        "passed": true,
+                        "second": 1,
+                        "timeInfoArray": Array [],
+                        "type": "Equal",
+                        "utc_time": "2018-10-15T14:30:11.510094+00:00",
+                      },
+                    ],
+                    "logs": Array [],
+                    "name": "test_equality_passing2",
+                    "name_type_index": Array [
+                      "test_equality_passing2|testcase",
+                      "AlphaSuite|testsuite",
+                      "Primary|multitest",
+                      "Sample Testplan|testplan",
+                    ],
+                    "status": "failed",
+                    "status_override": null,
+                    "tags": Object {
+                      "simple": Array [
+                        "server",
+                      ],
+                    },
+                    "tags_index": Object {
+                      "simple": Array [
+                        "server",
+                      ],
+                    },
+                    "timer": Object {
+                      "run": Object {
+                        "end": "2018-10-15T14:30:11.632214+00:00",
+                        "start": "2018-10-15T14:30:11.510072+00:00",
+                      },
+                    },
+                    "type": "TestCaseReport",
+                    "uid": "78686a4d-7b94-4ae6-ab50-d9960a7fb714",
+                    "uids": Array [
+                      "520a92e4-325e-4077-93e6-55d7091a3f83",
+                      "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                      "cb144b10-bdb0-44d3-9170-d8016dd19ee7",
+                      "78686a4d-7b94-4ae6-ab50-d9960a7fb714",
+                    ],
+                  },
+                ],
+                "logs": Array [],
+                "name": "AlphaSuite",
+                "name_type_index": Array [
+                  "AlphaSuite|testsuite",
+                  "Primary|multitest",
+                  "Sample Testplan|testplan",
+                  "test_equality_passing|testcase",
+                  "test_equality_passing2|testcase",
+                ],
+                "status": "failed",
+                "status_override": null,
+                "tags": Object {
+                  "simple": Array [
+                    "server",
+                  ],
+                },
+                "tags_index": Object {
+                  "colour": Array [
+                    "white",
+                  ],
+                  "simple": Array [
+                    "server",
+                  ],
+                },
+                "timer": Object {
+                  "run": Object {
+                    "end": "2018-10-15T14:30:11.158224+00:00",
+                    "start": "2018-10-15T14:30:11.009872+00:00",
+                  },
+                },
+                "type": "TestGroupReport",
+                "uid": "cb144b10-bdb0-44d3-9170-d8016dd19ee7",
+                "uids": Array [
+                  "520a92e4-325e-4077-93e6-55d7091a3f83",
+                  "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                  "cb144b10-bdb0-44d3-9170-d8016dd19ee7",
+                ],
+              },
+              Object {
+                "category": "testsuite",
+                "description": null,
+                "entries": Array [
+                  Object {
+                    "category": "testcase",
+                    "description": null,
+                    "entries": Array [
+                      Object {
+                        "category": "DEFAULT",
+                        "description": "passing equality",
+                        "first": 1,
+                        "label": "==",
+                        "line_no": 24,
+                        "machine_time": "2018-10-15T15:30:11.010098+00:00",
+                        "meta_type": "assertion",
+                        "passed": true,
+                        "second": 1,
+                        "type": "Equal",
+                        "utc_time": "2018-10-15T14:30:11.010094+00:00",
+                      },
+                    ],
+                    "logs": Array [],
+                    "name": "test_equality_passing",
+                    "name_type_index": Array [
+                      "test_equality_passing|testcase",
+                      "BetaSuite|testsuite",
+                      "Primary|multitest",
+                      "Sample Testplan|testplan",
+                    ],
+                    "status": "passed",
+                    "status_override": null,
+                    "tags": Object {
+                      "simple": Array [
+                        "server",
+                        "client",
+                      ],
+                    },
+                    "tags_index": Object {
+                      "simple": Array [
+                        "server",
+                        "client",
+                      ],
+                    },
+                    "timer": Object {
+                      "run": Object {
+                        "end": "2018-10-15T14:30:11.132214+00:00",
+                        "start": "2018-10-15T14:30:11.010072+00:00",
+                      },
+                    },
+                    "type": "TestCaseReport",
+                    "uid": "8865a23d-1823-4c8d-ab37-58d24fc8ac05",
+                    "uids": Array [
+                      "520a92e4-325e-4077-93e6-55d7091a3f83",
+                      "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                      "6fc5c008-4d1a-454e-80b6-74bdc9bca49e",
+                      "8865a23d-1823-4c8d-ab37-58d24fc8ac05",
+                    ],
+                  },
+                ],
+                "logs": Array [],
+                "name": "BetaSuite",
+                "name_type_index": Array [
+                  "BetaSuite|testsuite",
+                  "Primary|multitest",
+                  "Sample Testplan|testplan",
+                  "test_equality_passing|testcase",
+                ],
+                "status": "passed",
+                "status_override": null,
+                "tags": Object {
+                  "simple": Array [
+                    "server",
+                    "client",
+                  ],
+                },
+                "tags_index": Object {
+                  "simple": Array [
+                    "server",
+                    "client",
+                  ],
+                },
+                "timer": Object {
+                  "run": Object {
+                    "end": "2018-10-15T14:30:11.158224+00:00",
+                    "start": "2018-10-15T14:30:11.009872+00:00",
+                  },
+                },
+                "type": "TestGroupReport",
+                "uid": "6fc5c008-4d1a-454e-80b6-74bdc9bca49e",
+                "uids": Array [
+                  "520a92e4-325e-4077-93e6-55d7091a3f83",
+                  "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                  "6fc5c008-4d1a-454e-80b6-74bdc9bca49e",
+                ],
+              },
+            ],
+            "logs": Array [],
+            "name": "Primary",
+            "name_type_index": Array [
+              "Primary|multitest",
+              "Sample Testplan|testplan",
+              "AlphaSuite|testsuite",
+              "test_equality_passing|testcase",
+              "test_equality_passing2|testcase",
+              "BetaSuite|testsuite",
+            ],
+            "status": "failed",
+            "status_override": null,
+            "tags": Object {
+              "simple": Array [
+                "server",
+              ],
+            },
+            "tags_index": Object {
+              "colour": Array [
+                "white",
+              ],
+              "simple": Array [
+                "server",
+                "client",
+              ],
+            },
+            "timer": Object {
+              "run": Object {
+                "end": "2018-10-15T14:30:11.159661+00:00",
+                "start": "2018-10-15T14:30:11.009705+00:00",
+              },
+            },
+            "type": "TestGroupReport",
+            "uid": "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+            "uids": Array [
+              "520a92e4-325e-4077-93e6-55d7091a3f83",
+              "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+            ],
+          },
+          Object {
+            "category": "multitest",
+            "description": null,
+            "entries": Array [
+              Object {
+                "category": "testsuite",
+                "description": null,
+                "entries": Array [
+                  Object {
+                    "category": "testcase",
+                    "description": null,
+                    "entries": Array [
+                      Object {
+                        "category": "DEFAULT",
+                        "description": "passing equality",
+                        "first": 1,
+                        "label": "==",
+                        "line_no": 24,
+                        "machine_time": "2018-10-15T15:30:12.010098+00:00",
+                        "meta_type": "assertion",
+                        "passed": true,
+                        "second": 1,
+                        "timeInfoArray": Array [
+                          0,
+                          "14:30:12.010 (UTC)",
+                          "(+0.000s)",
+                        ],
+                        "type": "Equal",
+                        "utc_time": "2018-10-15T14:30:12.010094+00:00",
+                      },
+                      Object {
+                        "category": "DEFAULT",
+                        "description": "passing equality",
+                        "first": 1,
+                        "label": "==",
+                        "line_no": 24,
+                        "machine_time": "2018-10-15T15:30:14.015698+00:00",
+                        "meta_type": "assertion",
+                        "passed": true,
+                        "second": 1,
+                        "timeInfoArray": Array [
+                          1,
+                          "14:30:14.015 (UTC)",
+                          "(+2.005s)",
+                        ],
+                        "type": "Equal",
+                        "utc_time": "2018-10-15T14:30:14.015698+00:00",
+                      },
+                      Object {
+                        "category": "DEFAULT",
+                        "description": "passing equality",
+                        "first": 1,
+                        "label": "==",
+                        "line_no": 24,
+                        "machine_time": "2018-10-15T15:32:21.123494+00:00",
+                        "meta_type": "assertion",
+                        "passed": false,
+                        "second": 1,
+                        "timeInfoArray": Array [
+                          2,
+                          "14:32:21.123 (UTC)",
+                          "(+2m 7.108s)",
+                        ],
+                        "type": "Equal",
+                        "utc_time": "2018-10-15T14:32:21.123494+00:00",
+                      },
+                      Object {
+                        "category": "DEFAULT",
+                        "description": "passing equality",
+                        "first": 1,
+                        "label": "==",
+                        "line_no": 24,
+                        "machine_time": "2018-10-15T15:33:37.015678+00:00",
+                        "meta_type": "assertion",
+                        "passed": true,
+                        "second": 1,
+                        "timeInfoArray": Array [
+                          3,
+                          "14:33:37.015 (UTC)",
+                          "(+1m 15.892s)",
+                        ],
+                        "type": "Equal",
+                        "utc_time": "2018-10-15T14:33:37.015678+00:00",
+                      },
+                    ],
+                    "logs": Array [],
+                    "name": "test_equality_passing",
+                    "name_type_index": Array [
+                      "test_equality_passing|testcase",
+                      "GammaSuite|testsuite",
+                      "Secondary|multitest",
+                      "Sample Testplan|testplan",
+                    ],
+                    "status": "passed",
+                    "status_override": null,
+                    "tags": Object {},
+                    "tags_index": Object {},
+                    "timer": Object {
+                      "run": Object {
+                        "end": "2018-10-15T14:30:12.132214+00:00",
+                        "start": "2018-10-15T14:30:12.010072+00:00",
+                      },
+                    },
+                    "type": "TestCaseReport",
+                    "uid": "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+                    "uids": Array [
+                      "520a92e4-325e-4077-93e6-55d7091a3f83",
+                      "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+                      "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                      "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+                    ],
+                  },
+                ],
+                "logs": Array [],
+                "name": "GammaSuite",
+                "name_type_index": Array [
+                  "GammaSuite|testsuite",
+                  "Secondary|multitest",
+                  "Sample Testplan|testplan",
+                  "test_equality_passing|testcase",
+                ],
+                "status": "passed",
+                "status_override": null,
+                "tags": Object {},
+                "tags_index": Object {},
+                "timer": Object {
+                  "run": Object {
+                    "end": "2018-10-15T14:30:12.158224+00:00",
+                    "start": "2018-10-15T14:30:12.009872+00:00",
+                  },
+                },
+                "type": "TestGroupReport",
+                "uid": "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                "uids": Array [
+                  "520a92e4-325e-4077-93e6-55d7091a3f83",
+                  "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+                  "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                ],
+              },
+            ],
+            "logs": Array [],
+            "name": "Secondary",
+            "name_type_index": Array [
+              "Secondary|multitest",
+              "Sample Testplan|testplan",
+              "GammaSuite|testsuite",
+              "test_equality_passing|testcase",
+            ],
+            "status": "passed",
+            "status_override": null,
+            "tags": Object {},
+            "tags_index": Object {},
+            "timer": Object {
+              "run": Object {
+                "end": "2018-10-15T14:30:12.159661+00:00",
+                "start": "2018-10-15T14:30:12.009705+00:00",
+              },
+            },
+            "type": "TestGroupReport",
+            "uid": "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+            "uids": Array [
+              "520a92e4-325e-4077-93e6-55d7091a3f83",
+              "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+            ],
+          },
+        ],
+        "meta": Object {},
+        "name": "Sample Testplan",
+        "name_type_index": Array [
+          "Sample Testplan|testplan",
+          "Primary|multitest",
+          "AlphaSuite|testsuite",
+          "test_equality_passing|testcase",
+          "test_equality_passing2|testcase",
+          "BetaSuite|testsuite",
+          "Secondary|multitest",
+          "GammaSuite|testsuite",
+        ],
+        "status": "failed",
+        "status_override": null,
+        "tags_index": Object {
+          "colour": Array [
+            "white",
+          ],
+          "simple": Array [
+            "server",
+            "client",
+          ],
+        },
+        "timer": Object {
+          "run": Object {
+            "end": "2018-10-15T14:30:11.296158+00:00",
+            "start": "2018-10-15T14:30:10.998071+00:00",
+          },
+        },
+        "uid": "520a92e4-325e-4077-93e6-55d7091a3f83",
+        "uids": Array [
+          "520a92e4-325e-4077-93e6-55d7091a3f83",
+        ],
+      }
+    }
+    status="failed"
+    switchPanelViewFunc={[Function]}
+    updateExpandStatusFunc={[Function]}
+    updateFilterFunc={[Function]}
+    updateTagsDisplayFunc={[Function]}
+  />
+  <NavBreadcrumbs
+    entries={
+      Array [
+        Object {
+          "category": "testplan",
+          "entries": Array [
+            Object {
+              "category": "multitest",
+              "description": null,
+              "entries": Array [
+                Object {
+                  "category": "testsuite",
+                  "description": null,
+                  "entries": Array [
+                    Object {
+                      "category": "testcase",
+                      "description": null,
+                      "entries": Array [
+                        Object {
+                          "category": "DEFAULT",
+                          "description": "passing equality",
+                          "first": 1,
+                          "label": "==",
+                          "line_no": 24,
+                          "machine_time": "2018-10-15T15:30:11.010098+00:00",
+                          "meta_type": "assertion",
+                          "passed": true,
+                          "second": 1,
+                          "type": "Equal",
+                          "utc_time": "2018-10-15T14:30:11.010094+00:00",
+                        },
+                      ],
+                      "logs": Array [],
+                      "name": "test_equality_passing",
+                      "name_type_index": Array [
+                        "test_equality_passing|testcase",
+                        "AlphaSuite|testsuite",
+                        "Primary|multitest",
+                        "Sample Testplan|testplan",
+                      ],
+                      "status": "passed",
+                      "status_override": null,
+                      "tags": Object {
+                        "colour": Array [
+                          "white",
+                        ],
+                        "simple": Array [
+                          "server",
+                        ],
+                      },
+                      "tags_index": Object {
+                        "colour": Array [
+                          "white",
+                        ],
+                        "simple": Array [
+                          "server",
+                        ],
+                      },
+                      "timer": Object {
+                        "run": Object {
+                          "end": "2018-10-15T14:30:11.132214+00:00",
+                          "start": "2018-10-15T14:30:11.010072+00:00",
+                        },
+                      },
+                      "type": "TestCaseReport",
+                      "uid": "736706ef-ba65-475d-96c5-f2855f431028",
+                      "uids": Array [
+                        "520a92e4-325e-4077-93e6-55d7091a3f83",
+                        "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                        "cb144b10-bdb0-44d3-9170-d8016dd19ee7",
+                        "736706ef-ba65-475d-96c5-f2855f431028",
+                      ],
+                    },
+                    Object {
+                      "category": "testcase",
+                      "description": null,
+                      "entries": Array [
+                        Object {
+                          "category": "DEFAULT",
+                          "description": "passing equality",
+                          "first": 1,
+                          "label": "==",
+                          "line_no": 24,
+                          "machine_time": "2018-10-15T15:30:11.510098+00:00",
+                          "meta_type": "assertion",
+                          "passed": true,
+                          "second": 1,
+                          "timeInfoArray": Array [],
+                          "type": "Equal",
+                          "utc_time": "2018-10-15T14:30:11.510094+00:00",
+                        },
+                      ],
+                      "logs": Array [],
+                      "name": "test_equality_passing2",
+                      "name_type_index": Array [
+                        "test_equality_passing2|testcase",
+                        "AlphaSuite|testsuite",
+                        "Primary|multitest",
+                        "Sample Testplan|testplan",
+                      ],
+                      "status": "failed",
+                      "status_override": null,
+                      "tags": Object {
+                        "simple": Array [
+                          "server",
+                        ],
+                      },
+                      "tags_index": Object {
+                        "simple": Array [
+                          "server",
+                        ],
+                      },
+                      "timer": Object {
+                        "run": Object {
+                          "end": "2018-10-15T14:30:11.632214+00:00",
+                          "start": "2018-10-15T14:30:11.510072+00:00",
+                        },
+                      },
+                      "type": "TestCaseReport",
+                      "uid": "78686a4d-7b94-4ae6-ab50-d9960a7fb714",
+                      "uids": Array [
+                        "520a92e4-325e-4077-93e6-55d7091a3f83",
+                        "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                        "cb144b10-bdb0-44d3-9170-d8016dd19ee7",
+                        "78686a4d-7b94-4ae6-ab50-d9960a7fb714",
+                      ],
+                    },
+                  ],
+                  "logs": Array [],
+                  "name": "AlphaSuite",
+                  "name_type_index": Array [
+                    "AlphaSuite|testsuite",
+                    "Primary|multitest",
+                    "Sample Testplan|testplan",
+                    "test_equality_passing|testcase",
+                    "test_equality_passing2|testcase",
+                  ],
+                  "status": "failed",
+                  "status_override": null,
+                  "tags": Object {
+                    "simple": Array [
+                      "server",
+                    ],
+                  },
+                  "tags_index": Object {
+                    "colour": Array [
+                      "white",
+                    ],
+                    "simple": Array [
+                      "server",
+                    ],
+                  },
+                  "timer": Object {
+                    "run": Object {
+                      "end": "2018-10-15T14:30:11.158224+00:00",
+                      "start": "2018-10-15T14:30:11.009872+00:00",
+                    },
+                  },
+                  "type": "TestGroupReport",
+                  "uid": "cb144b10-bdb0-44d3-9170-d8016dd19ee7",
+                  "uids": Array [
+                    "520a92e4-325e-4077-93e6-55d7091a3f83",
+                    "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                    "cb144b10-bdb0-44d3-9170-d8016dd19ee7",
+                  ],
+                },
+                Object {
+                  "category": "testsuite",
+                  "description": null,
+                  "entries": Array [
+                    Object {
+                      "category": "testcase",
+                      "description": null,
+                      "entries": Array [
+                        Object {
+                          "category": "DEFAULT",
+                          "description": "passing equality",
+                          "first": 1,
+                          "label": "==",
+                          "line_no": 24,
+                          "machine_time": "2018-10-15T15:30:11.010098+00:00",
+                          "meta_type": "assertion",
+                          "passed": true,
+                          "second": 1,
+                          "type": "Equal",
+                          "utc_time": "2018-10-15T14:30:11.010094+00:00",
+                        },
+                      ],
+                      "logs": Array [],
+                      "name": "test_equality_passing",
+                      "name_type_index": Array [
+                        "test_equality_passing|testcase",
+                        "BetaSuite|testsuite",
+                        "Primary|multitest",
+                        "Sample Testplan|testplan",
+                      ],
+                      "status": "passed",
+                      "status_override": null,
+                      "tags": Object {
+                        "simple": Array [
+                          "server",
+                          "client",
+                        ],
+                      },
+                      "tags_index": Object {
+                        "simple": Array [
+                          "server",
+                          "client",
+                        ],
+                      },
+                      "timer": Object {
+                        "run": Object {
+                          "end": "2018-10-15T14:30:11.132214+00:00",
+                          "start": "2018-10-15T14:30:11.010072+00:00",
+                        },
+                      },
+                      "type": "TestCaseReport",
+                      "uid": "8865a23d-1823-4c8d-ab37-58d24fc8ac05",
+                      "uids": Array [
+                        "520a92e4-325e-4077-93e6-55d7091a3f83",
+                        "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                        "6fc5c008-4d1a-454e-80b6-74bdc9bca49e",
+                        "8865a23d-1823-4c8d-ab37-58d24fc8ac05",
+                      ],
+                    },
+                  ],
+                  "logs": Array [],
+                  "name": "BetaSuite",
+                  "name_type_index": Array [
+                    "BetaSuite|testsuite",
+                    "Primary|multitest",
+                    "Sample Testplan|testplan",
+                    "test_equality_passing|testcase",
+                  ],
+                  "status": "passed",
+                  "status_override": null,
+                  "tags": Object {
+                    "simple": Array [
+                      "server",
+                      "client",
+                    ],
+                  },
+                  "tags_index": Object {
+                    "simple": Array [
+                      "server",
+                      "client",
+                    ],
+                  },
+                  "timer": Object {
+                    "run": Object {
+                      "end": "2018-10-15T14:30:11.158224+00:00",
+                      "start": "2018-10-15T14:30:11.009872+00:00",
+                    },
+                  },
+                  "type": "TestGroupReport",
+                  "uid": "6fc5c008-4d1a-454e-80b6-74bdc9bca49e",
+                  "uids": Array [
+                    "520a92e4-325e-4077-93e6-55d7091a3f83",
+                    "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                    "6fc5c008-4d1a-454e-80b6-74bdc9bca49e",
+                  ],
+                },
+              ],
+              "logs": Array [],
+              "name": "Primary",
+              "name_type_index": Array [
+                "Primary|multitest",
+                "Sample Testplan|testplan",
+                "AlphaSuite|testsuite",
+                "test_equality_passing|testcase",
+                "test_equality_passing2|testcase",
+                "BetaSuite|testsuite",
+              ],
+              "status": "failed",
+              "status_override": null,
+              "tags": Object {
+                "simple": Array [
+                  "server",
+                ],
+              },
+              "tags_index": Object {
+                "colour": Array [
+                  "white",
+                ],
+                "simple": Array [
+                  "server",
+                  "client",
+                ],
+              },
+              "timer": Object {
+                "run": Object {
+                  "end": "2018-10-15T14:30:11.159661+00:00",
+                  "start": "2018-10-15T14:30:11.009705+00:00",
+                },
+              },
+              "type": "TestGroupReport",
+              "uid": "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+              "uids": Array [
+                "520a92e4-325e-4077-93e6-55d7091a3f83",
+                "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+              ],
+            },
+            Object {
+              "category": "multitest",
+              "description": null,
+              "entries": Array [
+                Object {
+                  "category": "testsuite",
+                  "description": null,
+                  "entries": Array [
+                    Object {
+                      "category": "testcase",
+                      "description": null,
+                      "entries": Array [
+                        Object {
+                          "category": "DEFAULT",
+                          "description": "passing equality",
+                          "first": 1,
+                          "label": "==",
+                          "line_no": 24,
+                          "machine_time": "2018-10-15T15:30:12.010098+00:00",
+                          "meta_type": "assertion",
+                          "passed": true,
+                          "second": 1,
+                          "timeInfoArray": Array [
+                            0,
+                            "14:30:12.010 (UTC)",
+                            "(+0.000s)",
+                          ],
+                          "type": "Equal",
+                          "utc_time": "2018-10-15T14:30:12.010094+00:00",
+                        },
+                        Object {
+                          "category": "DEFAULT",
+                          "description": "passing equality",
+                          "first": 1,
+                          "label": "==",
+                          "line_no": 24,
+                          "machine_time": "2018-10-15T15:30:14.015698+00:00",
+                          "meta_type": "assertion",
+                          "passed": true,
+                          "second": 1,
+                          "timeInfoArray": Array [
+                            1,
+                            "14:30:14.015 (UTC)",
+                            "(+2.005s)",
+                          ],
+                          "type": "Equal",
+                          "utc_time": "2018-10-15T14:30:14.015698+00:00",
+                        },
+                        Object {
+                          "category": "DEFAULT",
+                          "description": "passing equality",
+                          "first": 1,
+                          "label": "==",
+                          "line_no": 24,
+                          "machine_time": "2018-10-15T15:32:21.123494+00:00",
+                          "meta_type": "assertion",
+                          "passed": false,
+                          "second": 1,
+                          "timeInfoArray": Array [
+                            2,
+                            "14:32:21.123 (UTC)",
+                            "(+2m 7.108s)",
+                          ],
+                          "type": "Equal",
+                          "utc_time": "2018-10-15T14:32:21.123494+00:00",
+                        },
+                        Object {
+                          "category": "DEFAULT",
+                          "description": "passing equality",
+                          "first": 1,
+                          "label": "==",
+                          "line_no": 24,
+                          "machine_time": "2018-10-15T15:33:37.015678+00:00",
+                          "meta_type": "assertion",
+                          "passed": true,
+                          "second": 1,
+                          "timeInfoArray": Array [
+                            3,
+                            "14:33:37.015 (UTC)",
+                            "(+1m 15.892s)",
+                          ],
+                          "type": "Equal",
+                          "utc_time": "2018-10-15T14:33:37.015678+00:00",
+                        },
+                      ],
+                      "logs": Array [],
+                      "name": "test_equality_passing",
+                      "name_type_index": Array [
+                        "test_equality_passing|testcase",
+                        "GammaSuite|testsuite",
+                        "Secondary|multitest",
+                        "Sample Testplan|testplan",
+                      ],
+                      "status": "passed",
+                      "status_override": null,
+                      "tags": Object {},
+                      "tags_index": Object {},
+                      "timer": Object {
+                        "run": Object {
+                          "end": "2018-10-15T14:30:12.132214+00:00",
+                          "start": "2018-10-15T14:30:12.010072+00:00",
+                        },
+                      },
+                      "type": "TestCaseReport",
+                      "uid": "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+                      "uids": Array [
+                        "520a92e4-325e-4077-93e6-55d7091a3f83",
+                        "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+                        "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                        "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+                      ],
+                    },
+                  ],
+                  "logs": Array [],
+                  "name": "GammaSuite",
+                  "name_type_index": Array [
+                    "GammaSuite|testsuite",
+                    "Secondary|multitest",
+                    "Sample Testplan|testplan",
+                    "test_equality_passing|testcase",
+                  ],
+                  "status": "passed",
+                  "status_override": null,
+                  "tags": Object {},
+                  "tags_index": Object {},
+                  "timer": Object {
+                    "run": Object {
+                      "end": "2018-10-15T14:30:12.158224+00:00",
+                      "start": "2018-10-15T14:30:12.009872+00:00",
+                    },
+                  },
+                  "type": "TestGroupReport",
+                  "uid": "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                  "uids": Array [
+                    "520a92e4-325e-4077-93e6-55d7091a3f83",
+                    "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+                    "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                  ],
+                },
+              ],
+              "logs": Array [],
+              "name": "Secondary",
+              "name_type_index": Array [
+                "Secondary|multitest",
+                "Sample Testplan|testplan",
+                "GammaSuite|testsuite",
+                "test_equality_passing|testcase",
+              ],
+              "status": "passed",
+              "status_override": null,
+              "tags": Object {},
+              "tags_index": Object {},
+              "timer": Object {
+                "run": Object {
+                  "end": "2018-10-15T14:30:12.159661+00:00",
+                  "start": "2018-10-15T14:30:12.009705+00:00",
+                },
+              },
+              "type": "TestGroupReport",
+              "uid": "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+              "uids": Array [
+                "520a92e4-325e-4077-93e6-55d7091a3f83",
+                "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+              ],
+            },
+          ],
+          "meta": Object {},
+          "name": "Sample Testplan",
+          "name_type_index": Array [
+            "Sample Testplan|testplan",
+            "Primary|multitest",
+            "AlphaSuite|testsuite",
+            "test_equality_passing|testcase",
+            "test_equality_passing2|testcase",
+            "BetaSuite|testsuite",
+            "Secondary|multitest",
+            "GammaSuite|testsuite",
+          ],
+          "status": "failed",
+          "status_override": null,
+          "tags_index": Object {
+            "colour": Array [
+              "white",
+            ],
+            "simple": Array [
+              "server",
+              "client",
+            ],
+          },
+          "timer": Object {
+            "run": Object {
+              "end": "2018-10-15T14:30:11.296158+00:00",
+              "start": "2018-10-15T14:30:10.998071+00:00",
+            },
+          },
+          "uid": "520a92e4-325e-4077-93e6-55d7091a3f83",
+          "uids": Array [
+            "520a92e4-325e-4077-93e6-55d7091a3f83",
+          ],
+        },
+        Object {
+          "category": "multitest",
+          "description": null,
+          "entries": Array [
+            Object {
+              "category": "testsuite",
+              "description": null,
+              "entries": Array [
+                Object {
+                  "category": "testcase",
+                  "description": null,
+                  "entries": Array [
+                    Object {
+                      "category": "DEFAULT",
+                      "description": "passing equality",
+                      "first": 1,
+                      "label": "==",
+                      "line_no": 24,
+                      "machine_time": "2018-10-15T15:30:12.010098+00:00",
+                      "meta_type": "assertion",
+                      "passed": true,
+                      "second": 1,
+                      "timeInfoArray": Array [
+                        0,
+                        "14:30:12.010 (UTC)",
+                        "(+0.000s)",
+                      ],
+                      "type": "Equal",
+                      "utc_time": "2018-10-15T14:30:12.010094+00:00",
+                    },
+                    Object {
+                      "category": "DEFAULT",
+                      "description": "passing equality",
+                      "first": 1,
+                      "label": "==",
+                      "line_no": 24,
+                      "machine_time": "2018-10-15T15:30:14.015698+00:00",
+                      "meta_type": "assertion",
+                      "passed": true,
+                      "second": 1,
+                      "timeInfoArray": Array [
+                        1,
+                        "14:30:14.015 (UTC)",
+                        "(+2.005s)",
+                      ],
+                      "type": "Equal",
+                      "utc_time": "2018-10-15T14:30:14.015698+00:00",
+                    },
+                    Object {
+                      "category": "DEFAULT",
+                      "description": "passing equality",
+                      "first": 1,
+                      "label": "==",
+                      "line_no": 24,
+                      "machine_time": "2018-10-15T15:32:21.123494+00:00",
+                      "meta_type": "assertion",
+                      "passed": false,
+                      "second": 1,
+                      "timeInfoArray": Array [
+                        2,
+                        "14:32:21.123 (UTC)",
+                        "(+2m 7.108s)",
+                      ],
+                      "type": "Equal",
+                      "utc_time": "2018-10-15T14:32:21.123494+00:00",
+                    },
+                    Object {
+                      "category": "DEFAULT",
+                      "description": "passing equality",
+                      "first": 1,
+                      "label": "==",
+                      "line_no": 24,
+                      "machine_time": "2018-10-15T15:33:37.015678+00:00",
+                      "meta_type": "assertion",
+                      "passed": true,
+                      "second": 1,
+                      "timeInfoArray": Array [
+                        3,
+                        "14:33:37.015 (UTC)",
+                        "(+1m 15.892s)",
+                      ],
+                      "type": "Equal",
+                      "utc_time": "2018-10-15T14:33:37.015678+00:00",
+                    },
+                  ],
+                  "logs": Array [],
+                  "name": "test_equality_passing",
+                  "name_type_index": Array [
+                    "test_equality_passing|testcase",
+                    "GammaSuite|testsuite",
+                    "Secondary|multitest",
+                    "Sample Testplan|testplan",
+                  ],
+                  "status": "passed",
+                  "status_override": null,
+                  "tags": Object {},
+                  "tags_index": Object {},
+                  "timer": Object {
+                    "run": Object {
+                      "end": "2018-10-15T14:30:12.132214+00:00",
+                      "start": "2018-10-15T14:30:12.010072+00:00",
+                    },
+                  },
+                  "type": "TestCaseReport",
+                  "uid": "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+                  "uids": Array [
+                    "520a92e4-325e-4077-93e6-55d7091a3f83",
+                    "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+                    "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                    "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+                  ],
+                },
+              ],
+              "logs": Array [],
+              "name": "GammaSuite",
+              "name_type_index": Array [
+                "GammaSuite|testsuite",
+                "Secondary|multitest",
+                "Sample Testplan|testplan",
+                "test_equality_passing|testcase",
+              ],
+              "status": "passed",
+              "status_override": null,
+              "tags": Object {},
+              "tags_index": Object {},
+              "timer": Object {
+                "run": Object {
+                  "end": "2018-10-15T14:30:12.158224+00:00",
+                  "start": "2018-10-15T14:30:12.009872+00:00",
+                },
+              },
+              "type": "TestGroupReport",
+              "uid": "08d4c671-d55d-49d4-96ba-dc654d12be26",
+              "uids": Array [
+                "520a92e4-325e-4077-93e6-55d7091a3f83",
+                "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+                "08d4c671-d55d-49d4-96ba-dc654d12be26",
+              ],
+            },
+          ],
+          "logs": Array [],
+          "name": "Secondary",
+          "name_type_index": Array [
+            "Secondary|multitest",
+            "Sample Testplan|testplan",
+            "GammaSuite|testsuite",
+            "test_equality_passing|testcase",
+          ],
+          "status": "passed",
+          "status_override": null,
+          "tags": Object {},
+          "tags_index": Object {},
+          "timer": Object {
+            "run": Object {
+              "end": "2018-10-15T14:30:12.159661+00:00",
+              "start": "2018-10-15T14:30:12.009705+00:00",
+            },
+          },
+          "type": "TestGroupReport",
+          "uid": "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+          "uids": Array [
+            "520a92e4-325e-4077-93e6-55d7091a3f83",
+            "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+          ],
+        },
+        Object {
+          "category": "testsuite",
+          "description": null,
+          "entries": Array [
+            Object {
+              "category": "testcase",
+              "description": null,
+              "entries": Array [
+                Object {
+                  "category": "DEFAULT",
+                  "description": "passing equality",
+                  "first": 1,
+                  "label": "==",
+                  "line_no": 24,
+                  "machine_time": "2018-10-15T15:30:12.010098+00:00",
+                  "meta_type": "assertion",
+                  "passed": true,
+                  "second": 1,
+                  "timeInfoArray": Array [
+                    0,
+                    "14:30:12.010 (UTC)",
+                    "(+0.000s)",
+                  ],
+                  "type": "Equal",
+                  "utc_time": "2018-10-15T14:30:12.010094+00:00",
+                },
+                Object {
+                  "category": "DEFAULT",
+                  "description": "passing equality",
+                  "first": 1,
+                  "label": "==",
+                  "line_no": 24,
+                  "machine_time": "2018-10-15T15:30:14.015698+00:00",
+                  "meta_type": "assertion",
+                  "passed": true,
+                  "second": 1,
+                  "timeInfoArray": Array [
+                    1,
+                    "14:30:14.015 (UTC)",
+                    "(+2.005s)",
+                  ],
+                  "type": "Equal",
+                  "utc_time": "2018-10-15T14:30:14.015698+00:00",
+                },
+                Object {
+                  "category": "DEFAULT",
+                  "description": "passing equality",
+                  "first": 1,
+                  "label": "==",
+                  "line_no": 24,
+                  "machine_time": "2018-10-15T15:32:21.123494+00:00",
+                  "meta_type": "assertion",
+                  "passed": false,
+                  "second": 1,
+                  "timeInfoArray": Array [
+                    2,
+                    "14:32:21.123 (UTC)",
+                    "(+2m 7.108s)",
+                  ],
+                  "type": "Equal",
+                  "utc_time": "2018-10-15T14:32:21.123494+00:00",
+                },
+                Object {
+                  "category": "DEFAULT",
+                  "description": "passing equality",
+                  "first": 1,
+                  "label": "==",
+                  "line_no": 24,
+                  "machine_time": "2018-10-15T15:33:37.015678+00:00",
+                  "meta_type": "assertion",
+                  "passed": true,
+                  "second": 1,
+                  "timeInfoArray": Array [
+                    3,
+                    "14:33:37.015 (UTC)",
+                    "(+1m 15.892s)",
+                  ],
+                  "type": "Equal",
+                  "utc_time": "2018-10-15T14:33:37.015678+00:00",
+                },
+              ],
+              "logs": Array [],
+              "name": "test_equality_passing",
+              "name_type_index": Array [
+                "test_equality_passing|testcase",
+                "GammaSuite|testsuite",
+                "Secondary|multitest",
+                "Sample Testplan|testplan",
+              ],
+              "status": "passed",
+              "status_override": null,
+              "tags": Object {},
+              "tags_index": Object {},
+              "timer": Object {
+                "run": Object {
+                  "end": "2018-10-15T14:30:12.132214+00:00",
+                  "start": "2018-10-15T14:30:12.010072+00:00",
+                },
+              },
+              "type": "TestCaseReport",
+              "uid": "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+              "uids": Array [
+                "520a92e4-325e-4077-93e6-55d7091a3f83",
+                "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+                "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+              ],
+            },
+          ],
+          "logs": Array [],
+          "name": "GammaSuite",
+          "name_type_index": Array [
+            "GammaSuite|testsuite",
+            "Secondary|multitest",
+            "Sample Testplan|testplan",
+            "test_equality_passing|testcase",
+          ],
+          "status": "passed",
+          "status_override": null,
+          "tags": Object {},
+          "tags_index": Object {},
+          "timer": Object {
+            "run": Object {
+              "end": "2018-10-15T14:30:12.158224+00:00",
+              "start": "2018-10-15T14:30:12.009872+00:00",
+            },
+          },
+          "type": "TestGroupReport",
+          "uid": "08d4c671-d55d-49d4-96ba-dc654d12be26",
+          "uids": Array [
+            "520a92e4-325e-4077-93e6-55d7091a3f83",
+            "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+            "08d4c671-d55d-49d4-96ba-dc654d12be26",
+          ],
+        },
+        Object {
+          "category": "testcase",
+          "description": null,
+          "entries": Array [
+            Object {
+              "category": "DEFAULT",
+              "description": "passing equality",
+              "first": 1,
+              "label": "==",
+              "line_no": 24,
+              "machine_time": "2018-10-15T15:30:12.010098+00:00",
+              "meta_type": "assertion",
+              "passed": true,
+              "second": 1,
+              "timeInfoArray": Array [
+                0,
+                "14:30:12.010 (UTC)",
+                "(+0.000s)",
+              ],
+              "type": "Equal",
+              "utc_time": "2018-10-15T14:30:12.010094+00:00",
+            },
+            Object {
+              "category": "DEFAULT",
+              "description": "passing equality",
+              "first": 1,
+              "label": "==",
+              "line_no": 24,
+              "machine_time": "2018-10-15T15:30:14.015698+00:00",
+              "meta_type": "assertion",
+              "passed": true,
+              "second": 1,
+              "timeInfoArray": Array [
+                1,
+                "14:30:14.015 (UTC)",
+                "(+2.005s)",
+              ],
+              "type": "Equal",
+              "utc_time": "2018-10-15T14:30:14.015698+00:00",
+            },
+            Object {
+              "category": "DEFAULT",
+              "description": "passing equality",
+              "first": 1,
+              "label": "==",
+              "line_no": 24,
+              "machine_time": "2018-10-15T15:32:21.123494+00:00",
+              "meta_type": "assertion",
+              "passed": false,
+              "second": 1,
+              "timeInfoArray": Array [
+                2,
+                "14:32:21.123 (UTC)",
+                "(+2m 7.108s)",
+              ],
+              "type": "Equal",
+              "utc_time": "2018-10-15T14:32:21.123494+00:00",
+            },
+            Object {
+              "category": "DEFAULT",
+              "description": "passing equality",
+              "first": 1,
+              "label": "==",
+              "line_no": 24,
+              "machine_time": "2018-10-15T15:33:37.015678+00:00",
+              "meta_type": "assertion",
+              "passed": true,
+              "second": 1,
+              "timeInfoArray": Array [
+                3,
+                "14:33:37.015 (UTC)",
+                "(+1m 15.892s)",
+              ],
+              "type": "Equal",
+              "utc_time": "2018-10-15T14:33:37.015678+00:00",
+            },
+          ],
+          "logs": Array [],
+          "name": "test_equality_passing",
+          "name_type_index": Array [
+            "test_equality_passing|testcase",
+            "GammaSuite|testsuite",
+            "Secondary|multitest",
+            "Sample Testplan|testplan",
+          ],
+          "status": "passed",
+          "status_override": null,
+          "tags": Object {},
+          "tags_index": Object {},
+          "timer": Object {
+            "run": Object {
+              "end": "2018-10-15T14:30:12.132214+00:00",
+              "start": "2018-10-15T14:30:12.010072+00:00",
+            },
+          },
+          "type": "TestCaseReport",
+          "uid": "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+          "uids": Array [
+            "520a92e4-325e-4077-93e6-55d7091a3f83",
+            "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+            "08d4c671-d55d-49d4-96ba-dc654d12be26",
+            "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+          ],
+        },
+      ]
+    }
+    url="/testplan/:uid/:selection*"
+  />
+  <div
+    style={
+      Object {
+        "display": "flex",
+        "flex": "1",
+        "overflowY": "auto",
+      }
+    }
+  >
+    <Nav
+      displayTags={false}
+      displayTime={true}
+      filter={null}
+      handleColumnResizing={[Function]}
+      interactive={false}
+      navListWidth="22em"
+      report={
+        Object {
+          "category": "testplan",
+          "entries": Array [
+            Object {
+              "category": "multitest",
+              "description": null,
+              "entries": Array [
+                Object {
+                  "category": "testsuite",
+                  "description": null,
+                  "entries": Array [
+                    Object {
+                      "category": "testcase",
+                      "description": null,
+                      "entries": Array [
+                        Object {
+                          "category": "DEFAULT",
+                          "description": "passing equality",
+                          "first": 1,
+                          "label": "==",
+                          "line_no": 24,
+                          "machine_time": "2018-10-15T15:30:11.010098+00:00",
+                          "meta_type": "assertion",
+                          "passed": true,
+                          "second": 1,
+                          "type": "Equal",
+                          "utc_time": "2018-10-15T14:30:11.010094+00:00",
+                        },
+                      ],
+                      "logs": Array [],
+                      "name": "test_equality_passing",
+                      "name_type_index": Array [
+                        "test_equality_passing|testcase",
+                        "AlphaSuite|testsuite",
+                        "Primary|multitest",
+                        "Sample Testplan|testplan",
+                      ],
+                      "status": "passed",
+                      "status_override": null,
+                      "tags": Object {
+                        "colour": Array [
+                          "white",
+                        ],
+                        "simple": Array [
+                          "server",
+                        ],
+                      },
+                      "tags_index": Object {
+                        "colour": Array [
+                          "white",
+                        ],
+                        "simple": Array [
+                          "server",
+                        ],
+                      },
+                      "timer": Object {
+                        "run": Object {
+                          "end": "2018-10-15T14:30:11.132214+00:00",
+                          "start": "2018-10-15T14:30:11.010072+00:00",
+                        },
+                      },
+                      "type": "TestCaseReport",
+                      "uid": "736706ef-ba65-475d-96c5-f2855f431028",
+                      "uids": Array [
+                        "520a92e4-325e-4077-93e6-55d7091a3f83",
+                        "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                        "cb144b10-bdb0-44d3-9170-d8016dd19ee7",
+                        "736706ef-ba65-475d-96c5-f2855f431028",
+                      ],
+                    },
+                    Object {
+                      "category": "testcase",
+                      "description": null,
+                      "entries": Array [
+                        Object {
+                          "category": "DEFAULT",
+                          "description": "passing equality",
+                          "first": 1,
+                          "label": "==",
+                          "line_no": 24,
+                          "machine_time": "2018-10-15T15:30:11.510098+00:00",
+                          "meta_type": "assertion",
+                          "passed": true,
+                          "second": 1,
+                          "timeInfoArray": Array [],
+                          "type": "Equal",
+                          "utc_time": "2018-10-15T14:30:11.510094+00:00",
+                        },
+                      ],
+                      "logs": Array [],
+                      "name": "test_equality_passing2",
+                      "name_type_index": Array [
+                        "test_equality_passing2|testcase",
+                        "AlphaSuite|testsuite",
+                        "Primary|multitest",
+                        "Sample Testplan|testplan",
+                      ],
+                      "status": "failed",
+                      "status_override": null,
+                      "tags": Object {
+                        "simple": Array [
+                          "server",
+                        ],
+                      },
+                      "tags_index": Object {
+                        "simple": Array [
+                          "server",
+                        ],
+                      },
+                      "timer": Object {
+                        "run": Object {
+                          "end": "2018-10-15T14:30:11.632214+00:00",
+                          "start": "2018-10-15T14:30:11.510072+00:00",
+                        },
+                      },
+                      "type": "TestCaseReport",
+                      "uid": "78686a4d-7b94-4ae6-ab50-d9960a7fb714",
+                      "uids": Array [
+                        "520a92e4-325e-4077-93e6-55d7091a3f83",
+                        "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                        "cb144b10-bdb0-44d3-9170-d8016dd19ee7",
+                        "78686a4d-7b94-4ae6-ab50-d9960a7fb714",
+                      ],
+                    },
+                  ],
+                  "logs": Array [],
+                  "name": "AlphaSuite",
+                  "name_type_index": Array [
+                    "AlphaSuite|testsuite",
+                    "Primary|multitest",
+                    "Sample Testplan|testplan",
+                    "test_equality_passing|testcase",
+                    "test_equality_passing2|testcase",
+                  ],
+                  "status": "failed",
+                  "status_override": null,
+                  "tags": Object {
+                    "simple": Array [
+                      "server",
+                    ],
+                  },
+                  "tags_index": Object {
+                    "colour": Array [
+                      "white",
+                    ],
+                    "simple": Array [
+                      "server",
+                    ],
+                  },
+                  "timer": Object {
+                    "run": Object {
+                      "end": "2018-10-15T14:30:11.158224+00:00",
+                      "start": "2018-10-15T14:30:11.009872+00:00",
+                    },
+                  },
+                  "type": "TestGroupReport",
+                  "uid": "cb144b10-bdb0-44d3-9170-d8016dd19ee7",
+                  "uids": Array [
+                    "520a92e4-325e-4077-93e6-55d7091a3f83",
+                    "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                    "cb144b10-bdb0-44d3-9170-d8016dd19ee7",
+                  ],
+                },
+                Object {
+                  "category": "testsuite",
+                  "description": null,
+                  "entries": Array [
+                    Object {
+                      "category": "testcase",
+                      "description": null,
+                      "entries": Array [
+                        Object {
+                          "category": "DEFAULT",
+                          "description": "passing equality",
+                          "first": 1,
+                          "label": "==",
+                          "line_no": 24,
+                          "machine_time": "2018-10-15T15:30:11.010098+00:00",
+                          "meta_type": "assertion",
+                          "passed": true,
+                          "second": 1,
+                          "type": "Equal",
+                          "utc_time": "2018-10-15T14:30:11.010094+00:00",
+                        },
+                      ],
+                      "logs": Array [],
+                      "name": "test_equality_passing",
+                      "name_type_index": Array [
+                        "test_equality_passing|testcase",
+                        "BetaSuite|testsuite",
+                        "Primary|multitest",
+                        "Sample Testplan|testplan",
+                      ],
+                      "status": "passed",
+                      "status_override": null,
+                      "tags": Object {
+                        "simple": Array [
+                          "server",
+                          "client",
+                        ],
+                      },
+                      "tags_index": Object {
+                        "simple": Array [
+                          "server",
+                          "client",
+                        ],
+                      },
+                      "timer": Object {
+                        "run": Object {
+                          "end": "2018-10-15T14:30:11.132214+00:00",
+                          "start": "2018-10-15T14:30:11.010072+00:00",
+                        },
+                      },
+                      "type": "TestCaseReport",
+                      "uid": "8865a23d-1823-4c8d-ab37-58d24fc8ac05",
+                      "uids": Array [
+                        "520a92e4-325e-4077-93e6-55d7091a3f83",
+                        "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                        "6fc5c008-4d1a-454e-80b6-74bdc9bca49e",
+                        "8865a23d-1823-4c8d-ab37-58d24fc8ac05",
+                      ],
+                    },
+                  ],
+                  "logs": Array [],
+                  "name": "BetaSuite",
+                  "name_type_index": Array [
+                    "BetaSuite|testsuite",
+                    "Primary|multitest",
+                    "Sample Testplan|testplan",
+                    "test_equality_passing|testcase",
+                  ],
+                  "status": "passed",
+                  "status_override": null,
+                  "tags": Object {
+                    "simple": Array [
+                      "server",
+                      "client",
+                    ],
+                  },
+                  "tags_index": Object {
+                    "simple": Array [
+                      "server",
+                      "client",
+                    ],
+                  },
+                  "timer": Object {
+                    "run": Object {
+                      "end": "2018-10-15T14:30:11.158224+00:00",
+                      "start": "2018-10-15T14:30:11.009872+00:00",
+                    },
+                  },
+                  "type": "TestGroupReport",
+                  "uid": "6fc5c008-4d1a-454e-80b6-74bdc9bca49e",
+                  "uids": Array [
+                    "520a92e4-325e-4077-93e6-55d7091a3f83",
+                    "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                    "6fc5c008-4d1a-454e-80b6-74bdc9bca49e",
+                  ],
+                },
+              ],
+              "logs": Array [],
+              "name": "Primary",
+              "name_type_index": Array [
+                "Primary|multitest",
+                "Sample Testplan|testplan",
+                "AlphaSuite|testsuite",
+                "test_equality_passing|testcase",
+                "test_equality_passing2|testcase",
+                "BetaSuite|testsuite",
+              ],
+              "status": "failed",
+              "status_override": null,
+              "tags": Object {
+                "simple": Array [
+                  "server",
+                ],
+              },
+              "tags_index": Object {
+                "colour": Array [
+                  "white",
+                ],
+                "simple": Array [
+                  "server",
+                  "client",
+                ],
+              },
+              "timer": Object {
+                "run": Object {
+                  "end": "2018-10-15T14:30:11.159661+00:00",
+                  "start": "2018-10-15T14:30:11.009705+00:00",
+                },
+              },
+              "type": "TestGroupReport",
+              "uid": "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+              "uids": Array [
+                "520a92e4-325e-4077-93e6-55d7091a3f83",
+                "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+              ],
+            },
+            Object {
+              "category": "multitest",
+              "description": null,
+              "entries": Array [
+                Object {
+                  "category": "testsuite",
+                  "description": null,
+                  "entries": Array [
+                    Object {
+                      "category": "testcase",
+                      "description": null,
+                      "entries": Array [
+                        Object {
+                          "category": "DEFAULT",
+                          "description": "passing equality",
+                          "first": 1,
+                          "label": "==",
+                          "line_no": 24,
+                          "machine_time": "2018-10-15T15:30:12.010098+00:00",
+                          "meta_type": "assertion",
+                          "passed": true,
+                          "second": 1,
+                          "timeInfoArray": Array [
+                            0,
+                            "14:30:12.010 (UTC)",
+                            "(+0.000s)",
+                          ],
+                          "type": "Equal",
+                          "utc_time": "2018-10-15T14:30:12.010094+00:00",
+                        },
+                        Object {
+                          "category": "DEFAULT",
+                          "description": "passing equality",
+                          "first": 1,
+                          "label": "==",
+                          "line_no": 24,
+                          "machine_time": "2018-10-15T15:30:14.015698+00:00",
+                          "meta_type": "assertion",
+                          "passed": true,
+                          "second": 1,
+                          "timeInfoArray": Array [
+                            1,
+                            "14:30:14.015 (UTC)",
+                            "(+2.005s)",
+                          ],
+                          "type": "Equal",
+                          "utc_time": "2018-10-15T14:30:14.015698+00:00",
+                        },
+                        Object {
+                          "category": "DEFAULT",
+                          "description": "passing equality",
+                          "first": 1,
+                          "label": "==",
+                          "line_no": 24,
+                          "machine_time": "2018-10-15T15:32:21.123494+00:00",
+                          "meta_type": "assertion",
+                          "passed": false,
+                          "second": 1,
+                          "timeInfoArray": Array [
+                            2,
+                            "14:32:21.123 (UTC)",
+                            "(+2m 7.108s)",
+                          ],
+                          "type": "Equal",
+                          "utc_time": "2018-10-15T14:32:21.123494+00:00",
+                        },
+                        Object {
+                          "category": "DEFAULT",
+                          "description": "passing equality",
+                          "first": 1,
+                          "label": "==",
+                          "line_no": 24,
+                          "machine_time": "2018-10-15T15:33:37.015678+00:00",
+                          "meta_type": "assertion",
+                          "passed": true,
+                          "second": 1,
+                          "timeInfoArray": Array [
+                            3,
+                            "14:33:37.015 (UTC)",
+                            "(+1m 15.892s)",
+                          ],
+                          "type": "Equal",
+                          "utc_time": "2018-10-15T14:33:37.015678+00:00",
+                        },
+                      ],
+                      "logs": Array [],
+                      "name": "test_equality_passing",
+                      "name_type_index": Array [
+                        "test_equality_passing|testcase",
+                        "GammaSuite|testsuite",
+                        "Secondary|multitest",
+                        "Sample Testplan|testplan",
+                      ],
+                      "status": "passed",
+                      "status_override": null,
+                      "tags": Object {},
+                      "tags_index": Object {},
+                      "timer": Object {
+                        "run": Object {
+                          "end": "2018-10-15T14:30:12.132214+00:00",
+                          "start": "2018-10-15T14:30:12.010072+00:00",
+                        },
+                      },
+                      "type": "TestCaseReport",
+                      "uid": "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+                      "uids": Array [
+                        "520a92e4-325e-4077-93e6-55d7091a3f83",
+                        "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+                        "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                        "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+                      ],
+                    },
+                  ],
+                  "logs": Array [],
+                  "name": "GammaSuite",
+                  "name_type_index": Array [
+                    "GammaSuite|testsuite",
+                    "Secondary|multitest",
+                    "Sample Testplan|testplan",
+                    "test_equality_passing|testcase",
+                  ],
+                  "status": "passed",
+                  "status_override": null,
+                  "tags": Object {},
+                  "tags_index": Object {},
+                  "timer": Object {
+                    "run": Object {
+                      "end": "2018-10-15T14:30:12.158224+00:00",
+                      "start": "2018-10-15T14:30:12.009872+00:00",
+                    },
+                  },
+                  "type": "TestGroupReport",
+                  "uid": "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                  "uids": Array [
+                    "520a92e4-325e-4077-93e6-55d7091a3f83",
+                    "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+                    "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                  ],
+                },
+              ],
+              "logs": Array [],
+              "name": "Secondary",
+              "name_type_index": Array [
+                "Secondary|multitest",
+                "Sample Testplan|testplan",
+                "GammaSuite|testsuite",
+                "test_equality_passing|testcase",
+              ],
+              "status": "passed",
+              "status_override": null,
+              "tags": Object {},
+              "tags_index": Object {},
+              "timer": Object {
+                "run": Object {
+                  "end": "2018-10-15T14:30:12.159661+00:00",
+                  "start": "2018-10-15T14:30:12.009705+00:00",
+                },
+              },
+              "type": "TestGroupReport",
+              "uid": "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+              "uids": Array [
+                "520a92e4-325e-4077-93e6-55d7091a3f83",
+                "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+              ],
+            },
+          ],
+          "meta": Object {},
+          "name": "Sample Testplan",
+          "name_type_index": Array [
+            "Sample Testplan|testplan",
+            "Primary|multitest",
+            "AlphaSuite|testsuite",
+            "test_equality_passing|testcase",
+            "test_equality_passing2|testcase",
+            "BetaSuite|testsuite",
+            "Secondary|multitest",
+            "GammaSuite|testsuite",
+          ],
+          "status": "failed",
+          "status_override": null,
+          "tags_index": Object {
+            "colour": Array [
+              "white",
+            ],
+            "simple": Array [
+              "server",
+              "client",
+            ],
+          },
+          "timer": Object {
+            "run": Object {
+              "end": "2018-10-15T14:30:11.296158+00:00",
+              "start": "2018-10-15T14:30:10.998071+00:00",
+            },
+          },
+          "uid": "520a92e4-325e-4077-93e6-55d7091a3f83",
+          "uids": Array [
+            "520a92e4-325e-4077-93e6-55d7091a3f83",
+          ],
+        }
+      }
+      selected={
+        Array [
+          Object {
+            "category": "testplan",
+            "entries": Array [
+              Object {
+                "category": "multitest",
+                "description": null,
+                "entries": Array [
+                  Object {
+                    "category": "testsuite",
+                    "description": null,
+                    "entries": Array [
+                      Object {
+                        "category": "testcase",
+                        "description": null,
+                        "entries": Array [
+                          Object {
+                            "category": "DEFAULT",
+                            "description": "passing equality",
+                            "first": 1,
+                            "label": "==",
+                            "line_no": 24,
+                            "machine_time": "2018-10-15T15:30:11.010098+00:00",
+                            "meta_type": "assertion",
+                            "passed": true,
+                            "second": 1,
+                            "type": "Equal",
+                            "utc_time": "2018-10-15T14:30:11.010094+00:00",
+                          },
+                        ],
+                        "logs": Array [],
+                        "name": "test_equality_passing",
+                        "name_type_index": Array [
+                          "test_equality_passing|testcase",
+                          "AlphaSuite|testsuite",
+                          "Primary|multitest",
+                          "Sample Testplan|testplan",
+                        ],
+                        "status": "passed",
+                        "status_override": null,
+                        "tags": Object {
+                          "colour": Array [
+                            "white",
+                          ],
+                          "simple": Array [
+                            "server",
+                          ],
+                        },
+                        "tags_index": Object {
+                          "colour": Array [
+                            "white",
+                          ],
+                          "simple": Array [
+                            "server",
+                          ],
+                        },
+                        "timer": Object {
+                          "run": Object {
+                            "end": "2018-10-15T14:30:11.132214+00:00",
+                            "start": "2018-10-15T14:30:11.010072+00:00",
+                          },
+                        },
+                        "type": "TestCaseReport",
+                        "uid": "736706ef-ba65-475d-96c5-f2855f431028",
+                        "uids": Array [
+                          "520a92e4-325e-4077-93e6-55d7091a3f83",
+                          "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                          "cb144b10-bdb0-44d3-9170-d8016dd19ee7",
+                          "736706ef-ba65-475d-96c5-f2855f431028",
+                        ],
+                      },
+                      Object {
+                        "category": "testcase",
+                        "description": null,
+                        "entries": Array [
+                          Object {
+                            "category": "DEFAULT",
+                            "description": "passing equality",
+                            "first": 1,
+                            "label": "==",
+                            "line_no": 24,
+                            "machine_time": "2018-10-15T15:30:11.510098+00:00",
+                            "meta_type": "assertion",
+                            "passed": true,
+                            "second": 1,
+                            "timeInfoArray": Array [],
+                            "type": "Equal",
+                            "utc_time": "2018-10-15T14:30:11.510094+00:00",
+                          },
+                        ],
+                        "logs": Array [],
+                        "name": "test_equality_passing2",
+                        "name_type_index": Array [
+                          "test_equality_passing2|testcase",
+                          "AlphaSuite|testsuite",
+                          "Primary|multitest",
+                          "Sample Testplan|testplan",
+                        ],
+                        "status": "failed",
+                        "status_override": null,
+                        "tags": Object {
+                          "simple": Array [
+                            "server",
+                          ],
+                        },
+                        "tags_index": Object {
+                          "simple": Array [
+                            "server",
+                          ],
+                        },
+                        "timer": Object {
+                          "run": Object {
+                            "end": "2018-10-15T14:30:11.632214+00:00",
+                            "start": "2018-10-15T14:30:11.510072+00:00",
+                          },
+                        },
+                        "type": "TestCaseReport",
+                        "uid": "78686a4d-7b94-4ae6-ab50-d9960a7fb714",
+                        "uids": Array [
+                          "520a92e4-325e-4077-93e6-55d7091a3f83",
+                          "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                          "cb144b10-bdb0-44d3-9170-d8016dd19ee7",
+                          "78686a4d-7b94-4ae6-ab50-d9960a7fb714",
+                        ],
+                      },
+                    ],
+                    "logs": Array [],
+                    "name": "AlphaSuite",
+                    "name_type_index": Array [
+                      "AlphaSuite|testsuite",
+                      "Primary|multitest",
+                      "Sample Testplan|testplan",
+                      "test_equality_passing|testcase",
+                      "test_equality_passing2|testcase",
+                    ],
+                    "status": "failed",
+                    "status_override": null,
+                    "tags": Object {
+                      "simple": Array [
+                        "server",
+                      ],
+                    },
+                    "tags_index": Object {
+                      "colour": Array [
+                        "white",
+                      ],
+                      "simple": Array [
+                        "server",
+                      ],
+                    },
+                    "timer": Object {
+                      "run": Object {
+                        "end": "2018-10-15T14:30:11.158224+00:00",
+                        "start": "2018-10-15T14:30:11.009872+00:00",
+                      },
+                    },
+                    "type": "TestGroupReport",
+                    "uid": "cb144b10-bdb0-44d3-9170-d8016dd19ee7",
+                    "uids": Array [
+                      "520a92e4-325e-4077-93e6-55d7091a3f83",
+                      "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                      "cb144b10-bdb0-44d3-9170-d8016dd19ee7",
+                    ],
+                  },
+                  Object {
+                    "category": "testsuite",
+                    "description": null,
+                    "entries": Array [
+                      Object {
+                        "category": "testcase",
+                        "description": null,
+                        "entries": Array [
+                          Object {
+                            "category": "DEFAULT",
+                            "description": "passing equality",
+                            "first": 1,
+                            "label": "==",
+                            "line_no": 24,
+                            "machine_time": "2018-10-15T15:30:11.010098+00:00",
+                            "meta_type": "assertion",
+                            "passed": true,
+                            "second": 1,
+                            "type": "Equal",
+                            "utc_time": "2018-10-15T14:30:11.010094+00:00",
+                          },
+                        ],
+                        "logs": Array [],
+                        "name": "test_equality_passing",
+                        "name_type_index": Array [
+                          "test_equality_passing|testcase",
+                          "BetaSuite|testsuite",
+                          "Primary|multitest",
+                          "Sample Testplan|testplan",
+                        ],
+                        "status": "passed",
+                        "status_override": null,
+                        "tags": Object {
+                          "simple": Array [
+                            "server",
+                            "client",
+                          ],
+                        },
+                        "tags_index": Object {
+                          "simple": Array [
+                            "server",
+                            "client",
+                          ],
+                        },
+                        "timer": Object {
+                          "run": Object {
+                            "end": "2018-10-15T14:30:11.132214+00:00",
+                            "start": "2018-10-15T14:30:11.010072+00:00",
+                          },
+                        },
+                        "type": "TestCaseReport",
+                        "uid": "8865a23d-1823-4c8d-ab37-58d24fc8ac05",
+                        "uids": Array [
+                          "520a92e4-325e-4077-93e6-55d7091a3f83",
+                          "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                          "6fc5c008-4d1a-454e-80b6-74bdc9bca49e",
+                          "8865a23d-1823-4c8d-ab37-58d24fc8ac05",
+                        ],
+                      },
+                    ],
+                    "logs": Array [],
+                    "name": "BetaSuite",
+                    "name_type_index": Array [
+                      "BetaSuite|testsuite",
+                      "Primary|multitest",
+                      "Sample Testplan|testplan",
+                      "test_equality_passing|testcase",
+                    ],
+                    "status": "passed",
+                    "status_override": null,
+                    "tags": Object {
+                      "simple": Array [
+                        "server",
+                        "client",
+                      ],
+                    },
+                    "tags_index": Object {
+                      "simple": Array [
+                        "server",
+                        "client",
+                      ],
+                    },
+                    "timer": Object {
+                      "run": Object {
+                        "end": "2018-10-15T14:30:11.158224+00:00",
+                        "start": "2018-10-15T14:30:11.009872+00:00",
+                      },
+                    },
+                    "type": "TestGroupReport",
+                    "uid": "6fc5c008-4d1a-454e-80b6-74bdc9bca49e",
+                    "uids": Array [
+                      "520a92e4-325e-4077-93e6-55d7091a3f83",
+                      "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                      "6fc5c008-4d1a-454e-80b6-74bdc9bca49e",
+                    ],
+                  },
+                ],
+                "logs": Array [],
+                "name": "Primary",
+                "name_type_index": Array [
+                  "Primary|multitest",
+                  "Sample Testplan|testplan",
+                  "AlphaSuite|testsuite",
+                  "test_equality_passing|testcase",
+                  "test_equality_passing2|testcase",
+                  "BetaSuite|testsuite",
+                ],
+                "status": "failed",
+                "status_override": null,
+                "tags": Object {
+                  "simple": Array [
+                    "server",
+                  ],
+                },
+                "tags_index": Object {
+                  "colour": Array [
+                    "white",
+                  ],
+                  "simple": Array [
+                    "server",
+                    "client",
+                  ],
+                },
+                "timer": Object {
+                  "run": Object {
+                    "end": "2018-10-15T14:30:11.159661+00:00",
+                    "start": "2018-10-15T14:30:11.009705+00:00",
+                  },
+                },
+                "type": "TestGroupReport",
+                "uid": "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                "uids": Array [
+                  "520a92e4-325e-4077-93e6-55d7091a3f83",
+                  "21739167-b30f-4c13-a315-ef6ae52fd1f7",
+                ],
+              },
+              Object {
+                "category": "multitest",
+                "description": null,
+                "entries": Array [
+                  Object {
+                    "category": "testsuite",
+                    "description": null,
+                    "entries": Array [
+                      Object {
+                        "category": "testcase",
+                        "description": null,
+                        "entries": Array [
+                          Object {
+                            "category": "DEFAULT",
+                            "description": "passing equality",
+                            "first": 1,
+                            "label": "==",
+                            "line_no": 24,
+                            "machine_time": "2018-10-15T15:30:12.010098+00:00",
+                            "meta_type": "assertion",
+                            "passed": true,
+                            "second": 1,
+                            "timeInfoArray": Array [
+                              0,
+                              "14:30:12.010 (UTC)",
+                              "(+0.000s)",
+                            ],
+                            "type": "Equal",
+                            "utc_time": "2018-10-15T14:30:12.010094+00:00",
+                          },
+                          Object {
+                            "category": "DEFAULT",
+                            "description": "passing equality",
+                            "first": 1,
+                            "label": "==",
+                            "line_no": 24,
+                            "machine_time": "2018-10-15T15:30:14.015698+00:00",
+                            "meta_type": "assertion",
+                            "passed": true,
+                            "second": 1,
+                            "timeInfoArray": Array [
+                              1,
+                              "14:30:14.015 (UTC)",
+                              "(+2.005s)",
+                            ],
+                            "type": "Equal",
+                            "utc_time": "2018-10-15T14:30:14.015698+00:00",
+                          },
+                          Object {
+                            "category": "DEFAULT",
+                            "description": "passing equality",
+                            "first": 1,
+                            "label": "==",
+                            "line_no": 24,
+                            "machine_time": "2018-10-15T15:32:21.123494+00:00",
+                            "meta_type": "assertion",
+                            "passed": false,
+                            "second": 1,
+                            "timeInfoArray": Array [
+                              2,
+                              "14:32:21.123 (UTC)",
+                              "(+2m 7.108s)",
+                            ],
+                            "type": "Equal",
+                            "utc_time": "2018-10-15T14:32:21.123494+00:00",
+                          },
+                          Object {
+                            "category": "DEFAULT",
+                            "description": "passing equality",
+                            "first": 1,
+                            "label": "==",
+                            "line_no": 24,
+                            "machine_time": "2018-10-15T15:33:37.015678+00:00",
+                            "meta_type": "assertion",
+                            "passed": true,
+                            "second": 1,
+                            "timeInfoArray": Array [
+                              3,
+                              "14:33:37.015 (UTC)",
+                              "(+1m 15.892s)",
+                            ],
+                            "type": "Equal",
+                            "utc_time": "2018-10-15T14:33:37.015678+00:00",
+                          },
+                        ],
+                        "logs": Array [],
+                        "name": "test_equality_passing",
+                        "name_type_index": Array [
+                          "test_equality_passing|testcase",
+                          "GammaSuite|testsuite",
+                          "Secondary|multitest",
+                          "Sample Testplan|testplan",
+                        ],
+                        "status": "passed",
+                        "status_override": null,
+                        "tags": Object {},
+                        "tags_index": Object {},
+                        "timer": Object {
+                          "run": Object {
+                            "end": "2018-10-15T14:30:12.132214+00:00",
+                            "start": "2018-10-15T14:30:12.010072+00:00",
+                          },
+                        },
+                        "type": "TestCaseReport",
+                        "uid": "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+                        "uids": Array [
+                          "520a92e4-325e-4077-93e6-55d7091a3f83",
+                          "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+                          "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                          "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+                        ],
+                      },
+                    ],
+                    "logs": Array [],
+                    "name": "GammaSuite",
+                    "name_type_index": Array [
+                      "GammaSuite|testsuite",
+                      "Secondary|multitest",
+                      "Sample Testplan|testplan",
+                      "test_equality_passing|testcase",
+                    ],
+                    "status": "passed",
+                    "status_override": null,
+                    "tags": Object {},
+                    "tags_index": Object {},
+                    "timer": Object {
+                      "run": Object {
+                        "end": "2018-10-15T14:30:12.158224+00:00",
+                        "start": "2018-10-15T14:30:12.009872+00:00",
+                      },
+                    },
+                    "type": "TestGroupReport",
+                    "uid": "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                    "uids": Array [
+                      "520a92e4-325e-4077-93e6-55d7091a3f83",
+                      "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+                      "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                    ],
+                  },
+                ],
+                "logs": Array [],
+                "name": "Secondary",
+                "name_type_index": Array [
+                  "Secondary|multitest",
+                  "Sample Testplan|testplan",
+                  "GammaSuite|testsuite",
+                  "test_equality_passing|testcase",
+                ],
+                "status": "passed",
+                "status_override": null,
+                "tags": Object {},
+                "tags_index": Object {},
+                "timer": Object {
+                  "run": Object {
+                    "end": "2018-10-15T14:30:12.159661+00:00",
+                    "start": "2018-10-15T14:30:12.009705+00:00",
+                  },
+                },
+                "type": "TestGroupReport",
+                "uid": "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+                "uids": Array [
+                  "520a92e4-325e-4077-93e6-55d7091a3f83",
+                  "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+                ],
+              },
+            ],
+            "meta": Object {},
+            "name": "Sample Testplan",
+            "name_type_index": Array [
+              "Sample Testplan|testplan",
+              "Primary|multitest",
+              "AlphaSuite|testsuite",
+              "test_equality_passing|testcase",
+              "test_equality_passing2|testcase",
+              "BetaSuite|testsuite",
+              "Secondary|multitest",
+              "GammaSuite|testsuite",
+            ],
+            "status": "failed",
+            "status_override": null,
+            "tags_index": Object {
+              "colour": Array [
+                "white",
+              ],
+              "simple": Array [
+                "server",
+                "client",
+              ],
+            },
+            "timer": Object {
+              "run": Object {
+                "end": "2018-10-15T14:30:11.296158+00:00",
+                "start": "2018-10-15T14:30:10.998071+00:00",
+              },
+            },
+            "uid": "520a92e4-325e-4077-93e6-55d7091a3f83",
+            "uids": Array [
+              "520a92e4-325e-4077-93e6-55d7091a3f83",
+            ],
+          },
+          Object {
+            "category": "multitest",
+            "description": null,
+            "entries": Array [
+              Object {
+                "category": "testsuite",
+                "description": null,
+                "entries": Array [
+                  Object {
+                    "category": "testcase",
+                    "description": null,
+                    "entries": Array [
+                      Object {
+                        "category": "DEFAULT",
+                        "description": "passing equality",
+                        "first": 1,
+                        "label": "==",
+                        "line_no": 24,
+                        "machine_time": "2018-10-15T15:30:12.010098+00:00",
+                        "meta_type": "assertion",
+                        "passed": true,
+                        "second": 1,
+                        "timeInfoArray": Array [
+                          0,
+                          "14:30:12.010 (UTC)",
+                          "(+0.000s)",
+                        ],
+                        "type": "Equal",
+                        "utc_time": "2018-10-15T14:30:12.010094+00:00",
+                      },
+                      Object {
+                        "category": "DEFAULT",
+                        "description": "passing equality",
+                        "first": 1,
+                        "label": "==",
+                        "line_no": 24,
+                        "machine_time": "2018-10-15T15:30:14.015698+00:00",
+                        "meta_type": "assertion",
+                        "passed": true,
+                        "second": 1,
+                        "timeInfoArray": Array [
+                          1,
+                          "14:30:14.015 (UTC)",
+                          "(+2.005s)",
+                        ],
+                        "type": "Equal",
+                        "utc_time": "2018-10-15T14:30:14.015698+00:00",
+                      },
+                      Object {
+                        "category": "DEFAULT",
+                        "description": "passing equality",
+                        "first": 1,
+                        "label": "==",
+                        "line_no": 24,
+                        "machine_time": "2018-10-15T15:32:21.123494+00:00",
+                        "meta_type": "assertion",
+                        "passed": false,
+                        "second": 1,
+                        "timeInfoArray": Array [
+                          2,
+                          "14:32:21.123 (UTC)",
+                          "(+2m 7.108s)",
+                        ],
+                        "type": "Equal",
+                        "utc_time": "2018-10-15T14:32:21.123494+00:00",
+                      },
+                      Object {
+                        "category": "DEFAULT",
+                        "description": "passing equality",
+                        "first": 1,
+                        "label": "==",
+                        "line_no": 24,
+                        "machine_time": "2018-10-15T15:33:37.015678+00:00",
+                        "meta_type": "assertion",
+                        "passed": true,
+                        "second": 1,
+                        "timeInfoArray": Array [
+                          3,
+                          "14:33:37.015 (UTC)",
+                          "(+1m 15.892s)",
+                        ],
+                        "type": "Equal",
+                        "utc_time": "2018-10-15T14:33:37.015678+00:00",
+                      },
+                    ],
+                    "logs": Array [],
+                    "name": "test_equality_passing",
+                    "name_type_index": Array [
+                      "test_equality_passing|testcase",
+                      "GammaSuite|testsuite",
+                      "Secondary|multitest",
+                      "Sample Testplan|testplan",
+                    ],
+                    "status": "passed",
+                    "status_override": null,
+                    "tags": Object {},
+                    "tags_index": Object {},
+                    "timer": Object {
+                      "run": Object {
+                        "end": "2018-10-15T14:30:12.132214+00:00",
+                        "start": "2018-10-15T14:30:12.010072+00:00",
+                      },
+                    },
+                    "type": "TestCaseReport",
+                    "uid": "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+                    "uids": Array [
+                      "520a92e4-325e-4077-93e6-55d7091a3f83",
+                      "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+                      "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                      "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+                    ],
+                  },
+                ],
+                "logs": Array [],
+                "name": "GammaSuite",
+                "name_type_index": Array [
+                  "GammaSuite|testsuite",
+                  "Secondary|multitest",
+                  "Sample Testplan|testplan",
+                  "test_equality_passing|testcase",
+                ],
+                "status": "passed",
+                "status_override": null,
+                "tags": Object {},
+                "tags_index": Object {},
+                "timer": Object {
+                  "run": Object {
+                    "end": "2018-10-15T14:30:12.158224+00:00",
+                    "start": "2018-10-15T14:30:12.009872+00:00",
+                  },
+                },
+                "type": "TestGroupReport",
+                "uid": "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                "uids": Array [
+                  "520a92e4-325e-4077-93e6-55d7091a3f83",
+                  "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+                  "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                ],
+              },
+            ],
+            "logs": Array [],
+            "name": "Secondary",
+            "name_type_index": Array [
+              "Secondary|multitest",
+              "Sample Testplan|testplan",
+              "GammaSuite|testsuite",
+              "test_equality_passing|testcase",
+            ],
+            "status": "passed",
+            "status_override": null,
+            "tags": Object {},
+            "tags_index": Object {},
+            "timer": Object {
+              "run": Object {
+                "end": "2018-10-15T14:30:12.159661+00:00",
+                "start": "2018-10-15T14:30:12.009705+00:00",
+              },
+            },
+            "type": "TestGroupReport",
+            "uid": "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+            "uids": Array [
+              "520a92e4-325e-4077-93e6-55d7091a3f83",
+              "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+            ],
+          },
+          Object {
+            "category": "testsuite",
+            "description": null,
+            "entries": Array [
+              Object {
+                "category": "testcase",
+                "description": null,
+                "entries": Array [
+                  Object {
+                    "category": "DEFAULT",
+                    "description": "passing equality",
+                    "first": 1,
+                    "label": "==",
+                    "line_no": 24,
+                    "machine_time": "2018-10-15T15:30:12.010098+00:00",
+                    "meta_type": "assertion",
+                    "passed": true,
+                    "second": 1,
+                    "timeInfoArray": Array [
+                      0,
+                      "14:30:12.010 (UTC)",
+                      "(+0.000s)",
+                    ],
+                    "type": "Equal",
+                    "utc_time": "2018-10-15T14:30:12.010094+00:00",
+                  },
+                  Object {
+                    "category": "DEFAULT",
+                    "description": "passing equality",
+                    "first": 1,
+                    "label": "==",
+                    "line_no": 24,
+                    "machine_time": "2018-10-15T15:30:14.015698+00:00",
+                    "meta_type": "assertion",
+                    "passed": true,
+                    "second": 1,
+                    "timeInfoArray": Array [
+                      1,
+                      "14:30:14.015 (UTC)",
+                      "(+2.005s)",
+                    ],
+                    "type": "Equal",
+                    "utc_time": "2018-10-15T14:30:14.015698+00:00",
+                  },
+                  Object {
+                    "category": "DEFAULT",
+                    "description": "passing equality",
+                    "first": 1,
+                    "label": "==",
+                    "line_no": 24,
+                    "machine_time": "2018-10-15T15:32:21.123494+00:00",
+                    "meta_type": "assertion",
+                    "passed": false,
+                    "second": 1,
+                    "timeInfoArray": Array [
+                      2,
+                      "14:32:21.123 (UTC)",
+                      "(+2m 7.108s)",
+                    ],
+                    "type": "Equal",
+                    "utc_time": "2018-10-15T14:32:21.123494+00:00",
+                  },
+                  Object {
+                    "category": "DEFAULT",
+                    "description": "passing equality",
+                    "first": 1,
+                    "label": "==",
+                    "line_no": 24,
+                    "machine_time": "2018-10-15T15:33:37.015678+00:00",
+                    "meta_type": "assertion",
+                    "passed": true,
+                    "second": 1,
+                    "timeInfoArray": Array [
+                      3,
+                      "14:33:37.015 (UTC)",
+                      "(+1m 15.892s)",
+                    ],
+                    "type": "Equal",
+                    "utc_time": "2018-10-15T14:33:37.015678+00:00",
+                  },
+                ],
+                "logs": Array [],
+                "name": "test_equality_passing",
+                "name_type_index": Array [
+                  "test_equality_passing|testcase",
+                  "GammaSuite|testsuite",
+                  "Secondary|multitest",
+                  "Sample Testplan|testplan",
+                ],
+                "status": "passed",
+                "status_override": null,
+                "tags": Object {},
+                "tags_index": Object {},
+                "timer": Object {
+                  "run": Object {
+                    "end": "2018-10-15T14:30:12.132214+00:00",
+                    "start": "2018-10-15T14:30:12.010072+00:00",
+                  },
+                },
+                "type": "TestCaseReport",
+                "uid": "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+                "uids": Array [
+                  "520a92e4-325e-4077-93e6-55d7091a3f83",
+                  "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+                  "08d4c671-d55d-49d4-96ba-dc654d12be26",
+                  "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+                ],
+              },
+            ],
+            "logs": Array [],
+            "name": "GammaSuite",
+            "name_type_index": Array [
+              "GammaSuite|testsuite",
+              "Secondary|multitest",
+              "Sample Testplan|testplan",
+              "test_equality_passing|testcase",
+            ],
+            "status": "passed",
+            "status_override": null,
+            "tags": Object {},
+            "tags_index": Object {},
+            "timer": Object {
+              "run": Object {
+                "end": "2018-10-15T14:30:12.158224+00:00",
+                "start": "2018-10-15T14:30:12.009872+00:00",
+              },
+            },
+            "type": "TestGroupReport",
+            "uid": "08d4c671-d55d-49d4-96ba-dc654d12be26",
+            "uids": Array [
+              "520a92e4-325e-4077-93e6-55d7091a3f83",
+              "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+              "08d4c671-d55d-49d4-96ba-dc654d12be26",
+            ],
+          },
+          Object {
+            "category": "testcase",
+            "description": null,
+            "entries": Array [
+              Object {
+                "category": "DEFAULT",
+                "description": "passing equality",
+                "first": 1,
+                "label": "==",
+                "line_no": 24,
+                "machine_time": "2018-10-15T15:30:12.010098+00:00",
+                "meta_type": "assertion",
+                "passed": true,
+                "second": 1,
+                "timeInfoArray": Array [
+                  0,
+                  "14:30:12.010 (UTC)",
+                  "(+0.000s)",
+                ],
+                "type": "Equal",
+                "utc_time": "2018-10-15T14:30:12.010094+00:00",
+              },
+              Object {
+                "category": "DEFAULT",
+                "description": "passing equality",
+                "first": 1,
+                "label": "==",
+                "line_no": 24,
+                "machine_time": "2018-10-15T15:30:14.015698+00:00",
+                "meta_type": "assertion",
+                "passed": true,
+                "second": 1,
+                "timeInfoArray": Array [
+                  1,
+                  "14:30:14.015 (UTC)",
+                  "(+2.005s)",
+                ],
+                "type": "Equal",
+                "utc_time": "2018-10-15T14:30:14.015698+00:00",
+              },
+              Object {
+                "category": "DEFAULT",
+                "description": "passing equality",
+                "first": 1,
+                "label": "==",
+                "line_no": 24,
+                "machine_time": "2018-10-15T15:32:21.123494+00:00",
+                "meta_type": "assertion",
+                "passed": false,
+                "second": 1,
+                "timeInfoArray": Array [
+                  2,
+                  "14:32:21.123 (UTC)",
+                  "(+2m 7.108s)",
+                ],
+                "type": "Equal",
+                "utc_time": "2018-10-15T14:32:21.123494+00:00",
+              },
+              Object {
+                "category": "DEFAULT",
+                "description": "passing equality",
+                "first": 1,
+                "label": "==",
+                "line_no": 24,
+                "machine_time": "2018-10-15T15:33:37.015678+00:00",
+                "meta_type": "assertion",
+                "passed": true,
+                "second": 1,
+                "timeInfoArray": Array [
+                  3,
+                  "14:33:37.015 (UTC)",
+                  "(+1m 15.892s)",
+                ],
+                "type": "Equal",
+                "utc_time": "2018-10-15T14:33:37.015678+00:00",
+              },
+            ],
+            "logs": Array [],
+            "name": "test_equality_passing",
+            "name_type_index": Array [
+              "test_equality_passing|testcase",
+              "GammaSuite|testsuite",
+              "Secondary|multitest",
+              "Sample Testplan|testplan",
+            ],
+            "status": "passed",
+            "status_override": null,
+            "tags": Object {},
+            "tags_index": Object {},
+            "timer": Object {
+              "run": Object {
+                "end": "2018-10-15T14:30:12.132214+00:00",
+                "start": "2018-10-15T14:30:12.010072+00:00",
+              },
+            },
+            "type": "TestCaseReport",
+            "uid": "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+            "uids": Array [
+              "520a92e4-325e-4077-93e6-55d7091a3f83",
+              "8c3c7e6b-48e8-40cd-86db-8c8aed2592c8",
+              "08d4c671-d55d-49d4-96ba-dc654d12be26",
+              "f73bd6ea-d378-437b-a5db-00d9e427f36a",
+            ],
+          },
+        ]
+      }
+      url="/testplan/:uid/:selection*"
+    />
+    <ContextProvider
+      value={
+        Object {
+          "assertions": Object {},
+          "globalExpand": Object {
+            "status": "default",
+            "time": 0,
+          },
+          "updateAssertionStatus": [Function],
+          "updateGlobalExpand": [Function],
+        }
+      }
+    >
+      <ErrorBoundary>
+        <AssertionPane
+          assertions={
+            Array [
+              Object {
+                "category": "DEFAULT",
+                "description": "passing equality",
+                "first": 1,
+                "label": "==",
+                "line_no": 24,
+                "machine_time": "2018-10-15T15:30:12.010098+00:00",
+                "meta_type": "assertion",
+                "passed": true,
+                "second": 1,
+                "timeInfoArray": Array [
+                  0,
+                  "14:30:12.010 (UTC)",
+                  "(+0.000s)",
+                ],
+                "type": "Equal",
+                "utc_time": "2018-10-15T14:30:12.010094+00:00",
+              },
+              Object {
+                "category": "DEFAULT",
+                "description": "passing equality",
+                "first": 1,
+                "label": "==",
+                "line_no": 24,
+                "machine_time": "2018-10-15T15:30:14.015698+00:00",
+                "meta_type": "assertion",
+                "passed": true,
+                "second": 1,
+                "timeInfoArray": Array [
+                  1,
+                  "14:30:14.015 (UTC)",
+                  "(+2.005s)",
+                ],
+                "type": "Equal",
+                "utc_time": "2018-10-15T14:30:14.015698+00:00",
+              },
+              Object {
+                "category": "DEFAULT",
+                "description": "passing equality",
+                "first": 1,
+                "label": "==",
+                "line_no": 24,
+                "machine_time": "2018-10-15T15:32:21.123494+00:00",
+                "meta_type": "assertion",
+                "passed": false,
+                "second": 1,
+                "timeInfoArray": Array [
+                  2,
+                  "14:32:21.123 (UTC)",
+                  "(+2m 7.108s)",
+                ],
+                "type": "Equal",
+                "utc_time": "2018-10-15T14:32:21.123494+00:00",
+              },
+              Object {
+                "category": "DEFAULT",
+                "description": "passing equality",
+                "first": 1,
+                "label": "==",
+                "line_no": 24,
+                "machine_time": "2018-10-15T15:33:37.015678+00:00",
+                "meta_type": "assertion",
+                "passed": true,
+                "second": 1,
+                "timeInfoArray": Array [
+                  3,
+                  "14:33:37.015 (UTC)",
+                  "(+1m 15.892s)",
                 ],
                 "type": "Equal",
                 "utc_time": "2018-10-15T14:33:37.015678+00:00",
@@ -22306,6 +25264,9 @@ ZeroDivisionError: integer division or modulo by zero
                                       </button>
                                     </DropdownItem>
                                   </UserPreferenceCheckbox>
+                                  <TimeInfoRadioButtons
+                                    enabled={false}
+                                  />
                                   <UserPreferenceCheckbox
                                     preferenceAtom={
                                       Object {

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
@@ -25218,19 +25218,19 @@ ZeroDivisionError: integer division or modulo by zero
                                     }
                                   >
                                     <DropdownItem
-                                      className="dropdownItem_1bl0z5g"
+                                      className="dropdownItem_1h5fos4"
                                       tag="button"
                                       toggle={false}
                                     >
                                       <button
-                                        className="dropdownItem_1bl0z5g dropdown-item"
+                                        className="dropdownItem_1h5fos4 dropdown-item"
                                         onClick={[Function]}
                                         role="menuitem"
                                         tabIndex="0"
                                       >
                                         <Label
                                           check={true}
-                                          className="filterLabel_17zzvy"
+                                          className="filterLabel_1wpifct"
                                           tag="label"
                                           widths={
                                             Array [
@@ -25243,7 +25243,7 @@ ZeroDivisionError: integer division or modulo by zero
                                           }
                                         >
                                           <label
-                                            className="filterLabel_17zzvy form-check-label"
+                                            className="filterLabel_1wpifct form-check-label"
                                           >
                                             <Input
                                               checked={false}
@@ -25277,19 +25277,19 @@ ZeroDivisionError: integer division or modulo by zero
                                     }
                                   >
                                     <DropdownItem
-                                      className="dropdownItem_1bl0z5g"
+                                      className="dropdownItem_1h5fos4"
                                       tag="button"
                                       toggle={false}
                                     >
                                       <button
-                                        className="dropdownItem_1bl0z5g dropdown-item"
+                                        className="dropdownItem_1h5fos4 dropdown-item"
                                         onClick={[Function]}
                                         role="menuitem"
                                         tabIndex="0"
                                       >
                                         <Label
                                           check={true}
-                                          className="filterLabel_17zzvy"
+                                          className="filterLabel_1wpifct"
                                           tag="label"
                                           widths={
                                             Array [
@@ -25302,7 +25302,7 @@ ZeroDivisionError: integer division or modulo by zero
                                           }
                                         >
                                           <label
-                                            className="filterLabel_17zzvy form-check-label"
+                                            className="filterLabel_1wpifct form-check-label"
                                           >
                                             <Input
                                               checked={false}
@@ -25357,19 +25357,19 @@ ZeroDivisionError: integer division or modulo by zero
                                     }
                                   >
                                     <DropdownItem
-                                      className="dropdownItem_1bl0z5g"
+                                      className="dropdownItem_1h5fos4"
                                       tag="button"
                                       toggle={false}
                                     >
                                       <button
-                                        className="dropdownItem_1bl0z5g dropdown-item"
+                                        className="dropdownItem_1h5fos4 dropdown-item"
                                         onClick={[Function]}
                                         role="menuitem"
                                         tabIndex="0"
                                       >
                                         <Label
                                           check={true}
-                                          className="filterLabel_17zzvy"
+                                          className="filterLabel_1wpifct"
                                           tag="label"
                                           widths={
                                             Array [
@@ -25382,7 +25382,7 @@ ZeroDivisionError: integer division or modulo by zero
                                           }
                                         >
                                           <label
-                                            className="filterLabel_17zzvy form-check-label"
+                                            className="filterLabel_1wpifct form-check-label"
                                           >
                                             <Input
                                               checked={true}
@@ -25413,19 +25413,19 @@ ZeroDivisionError: integer division or modulo by zero
                                     }
                                   >
                                     <DropdownItem
-                                      className="dropdownItem_1bl0z5g"
+                                      className="dropdownItem_1h5fos4"
                                       tag="button"
                                       toggle={false}
                                     >
                                       <button
-                                        className="dropdownItem_1bl0z5g dropdown-item"
+                                        className="dropdownItem_1h5fos4 dropdown-item"
                                         onClick={[Function]}
                                         role="menuitem"
                                         tabIndex="0"
                                       >
                                         <Label
                                           check={true}
-                                          className="filterLabel_17zzvy"
+                                          className="filterLabel_1wpifct"
                                           tag="label"
                                           widths={
                                             Array [
@@ -25438,7 +25438,7 @@ ZeroDivisionError: integer division or modulo by zero
                                           }
                                         >
                                           <label
-                                            className="filterLabel_17zzvy form-check-label"
+                                            className="filterLabel_1wpifct form-check-label"
                                           >
                                             <Input
                                               checked={false}
@@ -25469,19 +25469,19 @@ ZeroDivisionError: integer division or modulo by zero
                                     }
                                   >
                                     <DropdownItem
-                                      className="dropdownItem_1bl0z5g"
+                                      className="dropdownItem_1h5fos4"
                                       tag="button"
                                       toggle={false}
                                     >
                                       <button
-                                        className="dropdownItem_1bl0z5g dropdown-item"
+                                        className="dropdownItem_1h5fos4 dropdown-item"
                                         onClick={[Function]}
                                         role="menuitem"
                                         tabIndex="0"
                                       >
                                         <Label
                                           check={true}
-                                          className="filterLabel_17zzvy"
+                                          className="filterLabel_1wpifct"
                                           tag="label"
                                           widths={
                                             Array [
@@ -25494,7 +25494,7 @@ ZeroDivisionError: integer division or modulo by zero
                                           }
                                         >
                                           <label
-                                            className="filterLabel_17zzvy form-check-label"
+                                            className="filterLabel_1wpifct form-check-label"
                                           >
                                             <Input
                                               checked={false}
@@ -25629,19 +25629,19 @@ ZeroDivisionError: integer division or modulo by zero
                                   tabIndex="-1"
                                 >
                                   <DropdownItem
-                                    className="dropdownItem_1bl0z5g"
+                                    className="dropdownItem_1h5fos4"
                                     tag="button"
                                     toggle={false}
                                   >
                                     <button
-                                      className="dropdownItem_1bl0z5g dropdown-item"
+                                      className="dropdownItem_1h5fos4 dropdown-item"
                                       onClick={[Function]}
                                       role="menuitem"
                                       tabIndex="0"
                                     >
                                       <Label
                                         check={true}
-                                        className="filterLabel_17zzvy"
+                                        className="filterLabel_1wpifct"
                                         tag="label"
                                         widths={
                                           Array [
@@ -25654,7 +25654,7 @@ ZeroDivisionError: integer division or modulo by zero
                                         }
                                       >
                                         <label
-                                          className="filterLabel_17zzvy form-check-label"
+                                          className="filterLabel_1wpifct form-check-label"
                                         >
                                           <Input
                                             checked={true}
@@ -25679,19 +25679,19 @@ ZeroDivisionError: integer division or modulo by zero
                                     </button>
                                   </DropdownItem>
                                   <DropdownItem
-                                    className="dropdownItem_1bl0z5g"
+                                    className="dropdownItem_1h5fos4"
                                     tag="button"
                                     toggle={false}
                                   >
                                     <button
-                                      className="dropdownItem_1bl0z5g dropdown-item"
+                                      className="dropdownItem_1h5fos4 dropdown-item"
                                       onClick={[Function]}
                                       role="menuitem"
                                       tabIndex="0"
                                     >
                                       <Label
                                         check={true}
-                                        className="filterLabel_17zzvy"
+                                        className="filterLabel_1wpifct"
                                         tag="label"
                                         widths={
                                           Array [
@@ -25704,7 +25704,7 @@ ZeroDivisionError: integer division or modulo by zero
                                         }
                                       >
                                         <label
-                                          className="filterLabel_17zzvy form-check-label"
+                                          className="filterLabel_1wpifct form-check-label"
                                         >
                                           <Input
                                             checked={false}
@@ -25729,19 +25729,19 @@ ZeroDivisionError: integer division or modulo by zero
                                     </button>
                                   </DropdownItem>
                                   <DropdownItem
-                                    className="dropdownItem_1bl0z5g"
+                                    className="dropdownItem_1h5fos4"
                                     tag="button"
                                     toggle={false}
                                   >
                                     <button
-                                      className="dropdownItem_1bl0z5g dropdown-item"
+                                      className="dropdownItem_1h5fos4 dropdown-item"
                                       onClick={[Function]}
                                       role="menuitem"
                                       tabIndex="0"
                                     >
                                       <Label
                                         check={true}
-                                        className="filterLabel_17zzvy"
+                                        className="filterLabel_1wpifct"
                                         tag="label"
                                         widths={
                                           Array [
@@ -25754,7 +25754,7 @@ ZeroDivisionError: integer division or modulo by zero
                                         }
                                       >
                                         <label
-                                          className="filterLabel_17zzvy form-check-label"
+                                          className="filterLabel_1wpifct form-check-label"
                                         >
                                           <Input
                                             checked={false}

--- a/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
+++ b/testplan/web_ui/testing/src/Report/__tests__/__snapshots__/BatchReport.test.js.snap
@@ -13963,7 +13963,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                         "second": 1,
                         "timeInfoArray": Array [
                           0,
-                          "15:30:12.010 (UTC+00:00)",
+                          "15:30:12.010+00:00",
                           "(+0.000s)",
                         ],
                         "type": "Equal",
@@ -13981,7 +13981,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                         "second": 1,
                         "timeInfoArray": Array [
                           1,
-                          "15:30:14.015 (UTC+00:00)",
+                          "15:30:14.015+00:00",
                           "(+2.005s)",
                         ],
                         "type": "Equal",
@@ -13999,7 +13999,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                         "second": 1,
                         "timeInfoArray": Array [
                           2,
-                          "15:32:21.123 (UTC+00:00)",
+                          "15:32:21.123+00:00",
                           "(+2m 7.108s)",
                         ],
                         "type": "Equal",
@@ -14017,7 +14017,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                         "second": 1,
                         "timeInfoArray": Array [
                           3,
-                          "15:33:37.015 (UTC+00:00)",
+                          "15:33:37.015+00:00",
                           "(+1m 15.892s)",
                         ],
                         "type": "Equal",
@@ -14472,7 +14472,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                           "second": 1,
                           "timeInfoArray": Array [
                             0,
-                            "15:30:12.010 (UTC+00:00)",
+                            "15:30:12.010+00:00",
                             "(+0.000s)",
                           ],
                           "type": "Equal",
@@ -14490,7 +14490,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                           "second": 1,
                           "timeInfoArray": Array [
                             1,
-                            "15:30:14.015 (UTC+00:00)",
+                            "15:30:14.015+00:00",
                             "(+2.005s)",
                           ],
                           "type": "Equal",
@@ -14508,7 +14508,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                           "second": 1,
                           "timeInfoArray": Array [
                             2,
-                            "15:32:21.123 (UTC+00:00)",
+                            "15:32:21.123+00:00",
                             "(+2m 7.108s)",
                           ],
                           "type": "Equal",
@@ -14526,7 +14526,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                           "second": 1,
                           "timeInfoArray": Array [
                             3,
-                            "15:33:37.015 (UTC+00:00)",
+                            "15:33:37.015+00:00",
                             "(+1m 15.892s)",
                           ],
                           "type": "Equal",
@@ -14672,7 +14672,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                       "second": 1,
                       "timeInfoArray": Array [
                         0,
-                        "15:30:12.010 (UTC+00:00)",
+                        "15:30:12.010+00:00",
                         "(+0.000s)",
                       ],
                       "type": "Equal",
@@ -14690,7 +14690,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                       "second": 1,
                       "timeInfoArray": Array [
                         1,
-                        "15:30:14.015 (UTC+00:00)",
+                        "15:30:14.015+00:00",
                         "(+2.005s)",
                       ],
                       "type": "Equal",
@@ -14708,7 +14708,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                       "second": 1,
                       "timeInfoArray": Array [
                         2,
-                        "15:32:21.123 (UTC+00:00)",
+                        "15:32:21.123+00:00",
                         "(+2m 7.108s)",
                       ],
                       "type": "Equal",
@@ -14726,7 +14726,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                       "second": 1,
                       "timeInfoArray": Array [
                         3,
-                        "15:33:37.015 (UTC+00:00)",
+                        "15:33:37.015+00:00",
                         "(+1m 15.892s)",
                       ],
                       "type": "Equal",
@@ -14833,7 +14833,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                   "second": 1,
                   "timeInfoArray": Array [
                     0,
-                    "15:30:12.010 (UTC+00:00)",
+                    "15:30:12.010+00:00",
                     "(+0.000s)",
                   ],
                   "type": "Equal",
@@ -14851,7 +14851,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                   "second": 1,
                   "timeInfoArray": Array [
                     1,
-                    "15:30:14.015 (UTC+00:00)",
+                    "15:30:14.015+00:00",
                     "(+2.005s)",
                   ],
                   "type": "Equal",
@@ -14869,7 +14869,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                   "second": 1,
                   "timeInfoArray": Array [
                     2,
-                    "15:32:21.123 (UTC+00:00)",
+                    "15:32:21.123+00:00",
                     "(+2m 7.108s)",
                   ],
                   "type": "Equal",
@@ -14887,7 +14887,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                   "second": 1,
                   "timeInfoArray": Array [
                     3,
-                    "15:33:37.015 (UTC+00:00)",
+                    "15:33:37.015+00:00",
                     "(+1m 15.892s)",
                   ],
                   "type": "Equal",
@@ -14964,7 +14964,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
               "second": 1,
               "timeInfoArray": Array [
                 0,
-                "15:30:12.010 (UTC+00:00)",
+                "15:30:12.010+00:00",
                 "(+0.000s)",
               ],
               "type": "Equal",
@@ -14982,7 +14982,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
               "second": 1,
               "timeInfoArray": Array [
                 1,
-                "15:30:14.015 (UTC+00:00)",
+                "15:30:14.015+00:00",
                 "(+2.005s)",
               ],
               "type": "Equal",
@@ -15000,7 +15000,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
               "second": 1,
               "timeInfoArray": Array [
                 2,
-                "15:32:21.123 (UTC+00:00)",
+                "15:32:21.123+00:00",
                 "(+2m 7.108s)",
               ],
               "type": "Equal",
@@ -15018,7 +15018,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
               "second": 1,
               "timeInfoArray": Array [
                 3,
-                "15:33:37.015 (UTC+00:00)",
+                "15:33:37.015+00:00",
                 "(+1m 15.892s)",
               ],
               "type": "Equal",
@@ -15396,7 +15396,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                           "second": 1,
                           "timeInfoArray": Array [
                             0,
-                            "15:30:12.010 (UTC+00:00)",
+                            "15:30:12.010+00:00",
                             "(+0.000s)",
                           ],
                           "type": "Equal",
@@ -15414,7 +15414,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                           "second": 1,
                           "timeInfoArray": Array [
                             1,
-                            "15:30:14.015 (UTC+00:00)",
+                            "15:30:14.015+00:00",
                             "(+2.005s)",
                           ],
                           "type": "Equal",
@@ -15432,7 +15432,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                           "second": 1,
                           "timeInfoArray": Array [
                             2,
-                            "15:32:21.123 (UTC+00:00)",
+                            "15:32:21.123+00:00",
                             "(+2m 7.108s)",
                           ],
                           "type": "Equal",
@@ -15450,7 +15450,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                           "second": 1,
                           "timeInfoArray": Array [
                             3,
-                            "15:33:37.015 (UTC+00:00)",
+                            "15:33:37.015+00:00",
                             "(+1m 15.892s)",
                           ],
                           "type": "Equal",
@@ -15898,7 +15898,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                             "second": 1,
                             "timeInfoArray": Array [
                               0,
-                              "15:30:12.010 (UTC+00:00)",
+                              "15:30:12.010+00:00",
                               "(+0.000s)",
                             ],
                             "type": "Equal",
@@ -15916,7 +15916,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                             "second": 1,
                             "timeInfoArray": Array [
                               1,
-                              "15:30:14.015 (UTC+00:00)",
+                              "15:30:14.015+00:00",
                               "(+2.005s)",
                             ],
                             "type": "Equal",
@@ -15934,7 +15934,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                             "second": 1,
                             "timeInfoArray": Array [
                               2,
-                              "15:32:21.123 (UTC+00:00)",
+                              "15:32:21.123+00:00",
                               "(+2m 7.108s)",
                             ],
                             "type": "Equal",
@@ -15952,7 +15952,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                             "second": 1,
                             "timeInfoArray": Array [
                               3,
-                              "15:33:37.015 (UTC+00:00)",
+                              "15:33:37.015+00:00",
                               "(+1m 15.892s)",
                             ],
                             "type": "Equal",
@@ -16098,7 +16098,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                         "second": 1,
                         "timeInfoArray": Array [
                           0,
-                          "15:30:12.010 (UTC+00:00)",
+                          "15:30:12.010+00:00",
                           "(+0.000s)",
                         ],
                         "type": "Equal",
@@ -16116,7 +16116,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                         "second": 1,
                         "timeInfoArray": Array [
                           1,
-                          "15:30:14.015 (UTC+00:00)",
+                          "15:30:14.015+00:00",
                           "(+2.005s)",
                         ],
                         "type": "Equal",
@@ -16134,7 +16134,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                         "second": 1,
                         "timeInfoArray": Array [
                           2,
-                          "15:32:21.123 (UTC+00:00)",
+                          "15:32:21.123+00:00",
                           "(+2m 7.108s)",
                         ],
                         "type": "Equal",
@@ -16152,7 +16152,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                         "second": 1,
                         "timeInfoArray": Array [
                           3,
-                          "15:33:37.015 (UTC+00:00)",
+                          "15:33:37.015+00:00",
                           "(+1m 15.892s)",
                         ],
                         "type": "Equal",
@@ -16259,7 +16259,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                     "second": 1,
                     "timeInfoArray": Array [
                       0,
-                      "15:30:12.010 (UTC+00:00)",
+                      "15:30:12.010+00:00",
                       "(+0.000s)",
                     ],
                     "type": "Equal",
@@ -16277,7 +16277,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                     "second": 1,
                     "timeInfoArray": Array [
                       1,
-                      "15:30:14.015 (UTC+00:00)",
+                      "15:30:14.015+00:00",
                       "(+2.005s)",
                     ],
                     "type": "Equal",
@@ -16295,7 +16295,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                     "second": 1,
                     "timeInfoArray": Array [
                       2,
-                      "15:32:21.123 (UTC+00:00)",
+                      "15:32:21.123+00:00",
                       "(+2m 7.108s)",
                     ],
                     "type": "Equal",
@@ -16313,7 +16313,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                     "second": 1,
                     "timeInfoArray": Array [
                       3,
-                      "15:33:37.015 (UTC+00:00)",
+                      "15:33:37.015+00:00",
                       "(+1m 15.892s)",
                     ],
                     "type": "Equal",
@@ -16390,7 +16390,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                 "second": 1,
                 "timeInfoArray": Array [
                   0,
-                  "15:30:12.010 (UTC+00:00)",
+                  "15:30:12.010+00:00",
                   "(+0.000s)",
                 ],
                 "type": "Equal",
@@ -16408,7 +16408,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                 "second": 1,
                 "timeInfoArray": Array [
                   1,
-                  "15:30:14.015 (UTC+00:00)",
+                  "15:30:14.015+00:00",
                   "(+2.005s)",
                 ],
                 "type": "Equal",
@@ -16426,7 +16426,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                 "second": 1,
                 "timeInfoArray": Array [
                   2,
-                  "15:32:21.123 (UTC+00:00)",
+                  "15:32:21.123+00:00",
                   "(+2m 7.108s)",
                 ],
                 "type": "Equal",
@@ -16444,7 +16444,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                 "second": 1,
                 "timeInfoArray": Array [
                   3,
-                  "15:33:37.015 (UTC+00:00)",
+                  "15:33:37.015+00:00",
                   "(+1m 15.892s)",
                 ],
                 "type": "Equal",
@@ -16511,7 +16511,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                 "second": 1,
                 "timeInfoArray": Array [
                   0,
-                  "15:30:12.010 (UTC+00:00)",
+                  "15:30:12.010+00:00",
                   "(+0.000s)",
                 ],
                 "type": "Equal",
@@ -16529,7 +16529,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                 "second": 1,
                 "timeInfoArray": Array [
                   1,
-                  "15:30:14.015 (UTC+00:00)",
+                  "15:30:14.015+00:00",
                   "(+2.005s)",
                 ],
                 "type": "Equal",
@@ -16547,7 +16547,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                 "second": 1,
                 "timeInfoArray": Array [
                   2,
-                  "15:32:21.123 (UTC+00:00)",
+                  "15:32:21.123+00:00",
                   "(+2m 7.108s)",
                 ],
                 "type": "Equal",
@@ -16565,7 +16565,7 @@ exports[`BatchReport loads a report with selection at Testcase level and Time In
                 "second": 1,
                 "timeInfoArray": Array [
                   3,
-                  "15:33:37.015 (UTC+00:00)",
+                  "15:33:37.015+00:00",
                   "(+1m 15.892s)",
                 ],
                 "type": "Equal",
@@ -16921,7 +16921,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                         "second": 1,
                         "timeInfoArray": Array [
                           0,
-                          "14:30:12.010 (UTC)",
+                          "14:30:12.010Z",
                           "(+0.000s)",
                         ],
                         "type": "Equal",
@@ -16939,7 +16939,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                         "second": 1,
                         "timeInfoArray": Array [
                           1,
-                          "14:30:14.015 (UTC)",
+                          "14:30:14.015Z",
                           "(+2.005s)",
                         ],
                         "type": "Equal",
@@ -16957,7 +16957,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                         "second": 1,
                         "timeInfoArray": Array [
                           2,
-                          "14:32:21.123 (UTC)",
+                          "14:32:21.123Z",
                           "(+2m 7.108s)",
                         ],
                         "type": "Equal",
@@ -16975,7 +16975,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                         "second": 1,
                         "timeInfoArray": Array [
                           3,
-                          "14:33:37.015 (UTC)",
+                          "14:33:37.015Z",
                           "(+1m 15.892s)",
                         ],
                         "type": "Equal",
@@ -17430,7 +17430,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                           "second": 1,
                           "timeInfoArray": Array [
                             0,
-                            "14:30:12.010 (UTC)",
+                            "14:30:12.010Z",
                             "(+0.000s)",
                           ],
                           "type": "Equal",
@@ -17448,7 +17448,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                           "second": 1,
                           "timeInfoArray": Array [
                             1,
-                            "14:30:14.015 (UTC)",
+                            "14:30:14.015Z",
                             "(+2.005s)",
                           ],
                           "type": "Equal",
@@ -17466,7 +17466,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                           "second": 1,
                           "timeInfoArray": Array [
                             2,
-                            "14:32:21.123 (UTC)",
+                            "14:32:21.123Z",
                             "(+2m 7.108s)",
                           ],
                           "type": "Equal",
@@ -17484,7 +17484,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                           "second": 1,
                           "timeInfoArray": Array [
                             3,
-                            "14:33:37.015 (UTC)",
+                            "14:33:37.015Z",
                             "(+1m 15.892s)",
                           ],
                           "type": "Equal",
@@ -17630,7 +17630,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                       "second": 1,
                       "timeInfoArray": Array [
                         0,
-                        "14:30:12.010 (UTC)",
+                        "14:30:12.010Z",
                         "(+0.000s)",
                       ],
                       "type": "Equal",
@@ -17648,7 +17648,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                       "second": 1,
                       "timeInfoArray": Array [
                         1,
-                        "14:30:14.015 (UTC)",
+                        "14:30:14.015Z",
                         "(+2.005s)",
                       ],
                       "type": "Equal",
@@ -17666,7 +17666,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                       "second": 1,
                       "timeInfoArray": Array [
                         2,
-                        "14:32:21.123 (UTC)",
+                        "14:32:21.123Z",
                         "(+2m 7.108s)",
                       ],
                       "type": "Equal",
@@ -17684,7 +17684,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                       "second": 1,
                       "timeInfoArray": Array [
                         3,
-                        "14:33:37.015 (UTC)",
+                        "14:33:37.015Z",
                         "(+1m 15.892s)",
                       ],
                       "type": "Equal",
@@ -17791,7 +17791,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                   "second": 1,
                   "timeInfoArray": Array [
                     0,
-                    "14:30:12.010 (UTC)",
+                    "14:30:12.010Z",
                     "(+0.000s)",
                   ],
                   "type": "Equal",
@@ -17809,7 +17809,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                   "second": 1,
                   "timeInfoArray": Array [
                     1,
-                    "14:30:14.015 (UTC)",
+                    "14:30:14.015Z",
                     "(+2.005s)",
                   ],
                   "type": "Equal",
@@ -17827,7 +17827,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                   "second": 1,
                   "timeInfoArray": Array [
                     2,
-                    "14:32:21.123 (UTC)",
+                    "14:32:21.123Z",
                     "(+2m 7.108s)",
                   ],
                   "type": "Equal",
@@ -17845,7 +17845,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                   "second": 1,
                   "timeInfoArray": Array [
                     3,
-                    "14:33:37.015 (UTC)",
+                    "14:33:37.015Z",
                     "(+1m 15.892s)",
                   ],
                   "type": "Equal",
@@ -17922,7 +17922,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
               "second": 1,
               "timeInfoArray": Array [
                 0,
-                "14:30:12.010 (UTC)",
+                "14:30:12.010Z",
                 "(+0.000s)",
               ],
               "type": "Equal",
@@ -17940,7 +17940,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
               "second": 1,
               "timeInfoArray": Array [
                 1,
-                "14:30:14.015 (UTC)",
+                "14:30:14.015Z",
                 "(+2.005s)",
               ],
               "type": "Equal",
@@ -17958,7 +17958,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
               "second": 1,
               "timeInfoArray": Array [
                 2,
-                "14:32:21.123 (UTC)",
+                "14:32:21.123Z",
                 "(+2m 7.108s)",
               ],
               "type": "Equal",
@@ -17976,7 +17976,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
               "second": 1,
               "timeInfoArray": Array [
                 3,
-                "14:33:37.015 (UTC)",
+                "14:33:37.015Z",
                 "(+1m 15.892s)",
               ],
               "type": "Equal",
@@ -18354,7 +18354,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                           "second": 1,
                           "timeInfoArray": Array [
                             0,
-                            "14:30:12.010 (UTC)",
+                            "14:30:12.010Z",
                             "(+0.000s)",
                           ],
                           "type": "Equal",
@@ -18372,7 +18372,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                           "second": 1,
                           "timeInfoArray": Array [
                             1,
-                            "14:30:14.015 (UTC)",
+                            "14:30:14.015Z",
                             "(+2.005s)",
                           ],
                           "type": "Equal",
@@ -18390,7 +18390,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                           "second": 1,
                           "timeInfoArray": Array [
                             2,
-                            "14:32:21.123 (UTC)",
+                            "14:32:21.123Z",
                             "(+2m 7.108s)",
                           ],
                           "type": "Equal",
@@ -18408,7 +18408,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                           "second": 1,
                           "timeInfoArray": Array [
                             3,
-                            "14:33:37.015 (UTC)",
+                            "14:33:37.015Z",
                             "(+1m 15.892s)",
                           ],
                           "type": "Equal",
@@ -18856,7 +18856,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                             "second": 1,
                             "timeInfoArray": Array [
                               0,
-                              "14:30:12.010 (UTC)",
+                              "14:30:12.010Z",
                               "(+0.000s)",
                             ],
                             "type": "Equal",
@@ -18874,7 +18874,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                             "second": 1,
                             "timeInfoArray": Array [
                               1,
-                              "14:30:14.015 (UTC)",
+                              "14:30:14.015Z",
                               "(+2.005s)",
                             ],
                             "type": "Equal",
@@ -18892,7 +18892,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                             "second": 1,
                             "timeInfoArray": Array [
                               2,
-                              "14:32:21.123 (UTC)",
+                              "14:32:21.123Z",
                               "(+2m 7.108s)",
                             ],
                             "type": "Equal",
@@ -18910,7 +18910,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                             "second": 1,
                             "timeInfoArray": Array [
                               3,
-                              "14:33:37.015 (UTC)",
+                              "14:33:37.015Z",
                               "(+1m 15.892s)",
                             ],
                             "type": "Equal",
@@ -19056,7 +19056,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                         "second": 1,
                         "timeInfoArray": Array [
                           0,
-                          "14:30:12.010 (UTC)",
+                          "14:30:12.010Z",
                           "(+0.000s)",
                         ],
                         "type": "Equal",
@@ -19074,7 +19074,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                         "second": 1,
                         "timeInfoArray": Array [
                           1,
-                          "14:30:14.015 (UTC)",
+                          "14:30:14.015Z",
                           "(+2.005s)",
                         ],
                         "type": "Equal",
@@ -19092,7 +19092,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                         "second": 1,
                         "timeInfoArray": Array [
                           2,
-                          "14:32:21.123 (UTC)",
+                          "14:32:21.123Z",
                           "(+2m 7.108s)",
                         ],
                         "type": "Equal",
@@ -19110,7 +19110,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                         "second": 1,
                         "timeInfoArray": Array [
                           3,
-                          "14:33:37.015 (UTC)",
+                          "14:33:37.015Z",
                           "(+1m 15.892s)",
                         ],
                         "type": "Equal",
@@ -19217,7 +19217,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                     "second": 1,
                     "timeInfoArray": Array [
                       0,
-                      "14:30:12.010 (UTC)",
+                      "14:30:12.010Z",
                       "(+0.000s)",
                     ],
                     "type": "Equal",
@@ -19235,7 +19235,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                     "second": 1,
                     "timeInfoArray": Array [
                       1,
-                      "14:30:14.015 (UTC)",
+                      "14:30:14.015Z",
                       "(+2.005s)",
                     ],
                     "type": "Equal",
@@ -19253,7 +19253,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                     "second": 1,
                     "timeInfoArray": Array [
                       2,
-                      "14:32:21.123 (UTC)",
+                      "14:32:21.123Z",
                       "(+2m 7.108s)",
                     ],
                     "type": "Equal",
@@ -19271,7 +19271,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                     "second": 1,
                     "timeInfoArray": Array [
                       3,
-                      "14:33:37.015 (UTC)",
+                      "14:33:37.015Z",
                       "(+1m 15.892s)",
                     ],
                     "type": "Equal",
@@ -19348,7 +19348,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                 "second": 1,
                 "timeInfoArray": Array [
                   0,
-                  "14:30:12.010 (UTC)",
+                  "14:30:12.010Z",
                   "(+0.000s)",
                 ],
                 "type": "Equal",
@@ -19366,7 +19366,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                 "second": 1,
                 "timeInfoArray": Array [
                   1,
-                  "14:30:14.015 (UTC)",
+                  "14:30:14.015Z",
                   "(+2.005s)",
                 ],
                 "type": "Equal",
@@ -19384,7 +19384,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                 "second": 1,
                 "timeInfoArray": Array [
                   2,
-                  "14:32:21.123 (UTC)",
+                  "14:32:21.123Z",
                   "(+2m 7.108s)",
                 ],
                 "type": "Equal",
@@ -19402,7 +19402,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                 "second": 1,
                 "timeInfoArray": Array [
                   3,
-                  "14:33:37.015 (UTC)",
+                  "14:33:37.015Z",
                   "(+1m 15.892s)",
                 ],
                 "type": "Equal",
@@ -19469,7 +19469,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                 "second": 1,
                 "timeInfoArray": Array [
                   0,
-                  "14:30:12.010 (UTC)",
+                  "14:30:12.010Z",
                   "(+0.000s)",
                 ],
                 "type": "Equal",
@@ -19487,7 +19487,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                 "second": 1,
                 "timeInfoArray": Array [
                   1,
-                  "14:30:14.015 (UTC)",
+                  "14:30:14.015Z",
                   "(+2.005s)",
                 ],
                 "type": "Equal",
@@ -19505,7 +19505,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                 "second": 1,
                 "timeInfoArray": Array [
                   2,
-                  "14:32:21.123 (UTC)",
+                  "14:32:21.123Z",
                   "(+2m 7.108s)",
                 ],
                 "type": "Equal",
@@ -19523,7 +19523,7 @@ exports[`BatchReport loads a report with selection at Testcase level and UTC Tim
                 "second": 1,
                 "timeInfoArray": Array [
                   3,
-                  "14:33:37.015 (UTC)",
+                  "14:33:37.015Z",
                   "(+1m 15.892s)",
                 ],
                 "type": "Equal",

--- a/testplan/web_ui/testing/src/Report/reportUtils.js
+++ b/testplan/web_ui/testing/src/Report/reportUtils.js
@@ -200,7 +200,8 @@ const GetCenterPane = (
   reportFetchMessage,
   reportUid,
   selectedEntries,
-  displayTime
+  displayTime,
+  UTCTime
 ) => {
   const selectedEntry = _.last(selectedEntries);
   const logs = selectedEntry?.logs || [];
@@ -235,7 +236,7 @@ const GetCenterPane = (
     );
   }
 
-  const assertions = getAssertions(selectedEntries, displayTime);
+  const assertions = getAssertions(selectedEntries, displayTime, UTCTime);
   if (
     assertions.length > 0 ||
     logs.length > 0 ||
@@ -263,7 +264,7 @@ const GetCenterPane = (
 };
 
 /** TODO */
-const getAssertions = (selectedEntries, displayTime) => {
+const getAssertions = (selectedEntries, displayTime, UTCTime) => {
   // get all assertions from groups and list them sequentially in an array
   const getAssertionsRecursively = (links, entries) => {
     for (let i = 0; i < entries.length; ++i) {
@@ -287,6 +288,7 @@ const getAssertions = (selectedEntries, displayTime) => {
         links[i].timeInfoArray = [i]; // [index, start_time, duration]
         const idx = links[i].utc_time.lastIndexOf("+");
         links[i].timeInfoArray.push(
+          UTCTime ?
           links[i].utc_time
             ? format(
                 new Date(
@@ -295,7 +297,17 @@ const getAssertions = (selectedEntries, displayTime) => {
                     : links[i].utc_time.substring(0, idx)
                 ),
                 "HH:mm:ss.SSS"
-              ) + " UTC"
+              ) + " (UTC)"
+            : ""
+          : links[i].machine_time
+            ? format(
+                new Date(
+                  idx === -1
+                    ? links[i].machine_time
+                    : links[i].machine_time.substring(0, idx)
+                ),
+                "HH:mm:ss.SSS"
+              ) + " (UTC" + links[i].machine_time.substring(idx) + ")"
             : ""
         );
       }

--- a/testplan/web_ui/testing/src/Report/reportUtils.js
+++ b/testplan/web_ui/testing/src/Report/reportUtils.js
@@ -277,20 +277,13 @@ const getAssertions = (selectedEntries, displayTime, UTCTime) => {
   };
 
   const createTimeInfoString = (entry, UTCTime) => {
-    let Z;
-    let timestamp;
-    if (UTCTime) {
-      timestamp = entry.utc_time;
-      Z = "Z";
-    } else {
-      timestamp = entry.machine_time;
-    }
+    let timestamp = UTCTime ? entry.utc_time : entry.machine_time;
     if (!timestamp) {
       return "";
     }
     timestamp = timestamp.split("+");
-    return format(new Date(timestamp[0]), "HH:mm:ss.SSS")
-    .concat(Z || "+" + timestamp[1]);
+    let label = UTCTime ? "Z" : timestamp.length == 2 ? "+" + timestamp[1] : "";
+    return format(new Date(timestamp[0]), "HH:mm:ss.SSS") + label;
   };
 
   const selectedEntry = selectedEntries[selectedEntries.length - 1];

--- a/testplan/web_ui/testing/src/Report/reportUtils.js
+++ b/testplan/web_ui/testing/src/Report/reportUtils.js
@@ -297,7 +297,7 @@ const getAssertions = (selectedEntries, displayTime, UTCTime) => {
                     : links[i].utc_time.substring(0, idx)
                 ),
                 "HH:mm:ss.SSS"
-              ) + " (UTC)"
+              ) + "Z"
             : ""
           : links[i].machine_time
             ? format(
@@ -307,7 +307,7 @@ const getAssertions = (selectedEntries, displayTime, UTCTime) => {
                     : links[i].machine_time.substring(0, idx)
                 ),
                 "HH:mm:ss.SSS"
-              ) + " (UTC" + links[i].machine_time.substring(idx) + ")"
+              ) + links[i].machine_time.substring(idx)
             : ""
         );
       }

--- a/testplan/web_ui/testing/src/Report/reportUtils.js
+++ b/testplan/web_ui/testing/src/Report/reportUtils.js
@@ -276,6 +276,23 @@ const getAssertions = (selectedEntries, displayTime, UTCTime) => {
     }
   };
 
+  const createTimeInfoString = (entry, UTCTime) => {
+    let Z;
+    let timestamp;
+    if (UTCTime) {
+      timestamp = entry.utc_time;
+      Z = "Z";
+    } else {
+      timestamp = entry.machine_time;
+    }
+    if (!timestamp) {
+      return "";
+    }
+    timestamp = timestamp.split("+");
+    return format(new Date(timestamp[0]), "HH:mm:ss.SSS")
+    .concat(Z || "+" + timestamp[1]);
+  };
+
   const selectedEntry = selectedEntries[selectedEntries.length - 1];
   if (selectedEntry && isReportLeaf(selectedEntry)) {
     let links = [];
@@ -285,31 +302,8 @@ const getAssertions = (selectedEntries, displayTime, UTCTime) => {
     if (displayTime) {
       // add time information to the array in a human readable format
       for (let i = 0; i < links.length; ++i) {
-        links[i].timeInfoArray = [i]; // [index, start_time, duration]
-        const idx = links[i].utc_time.lastIndexOf("+");
-        links[i].timeInfoArray.push(
-          UTCTime ?
-          links[i].utc_time
-            ? format(
-                new Date(
-                  idx === -1
-                    ? links[i].utc_time
-                    : links[i].utc_time.substring(0, idx)
-                ),
-                "HH:mm:ss.SSS"
-              ) + "Z"
-            : ""
-          : links[i].machine_time
-            ? format(
-                new Date(
-                  idx === -1
-                    ? links[i].machine_time
-                    : links[i].machine_time.substring(0, idx)
-                ),
-                "HH:mm:ss.SSS"
-              ) + links[i].machine_time.substring(idx)
-            : ""
-        );
+        // links[i].timeInfoArray = [index, start_time, duration]
+        links[i].timeInfoArray = [i, createTimeInfoString(links[i], UTCTime)];
       }
       // calculate the time elapsed between assertions
       for (let i = links.length - 1; i > 0; --i) {

--- a/testplan/web_ui/testing/src/Toolbar/Toolbar.js
+++ b/testplan/web_ui/testing/src/Toolbar/Toolbar.js
@@ -211,7 +211,7 @@ const TimeInfoRadioButtons = ({ enabled }) => {
       preferenceAtom={timeInfoUTCPreference}
       name="timezone"
       value={false}>
-      Machine time
+      Server time
     </UserPreferenceRadio>
   </>
   : "";

--- a/testplan/web_ui/testing/src/Toolbar/Toolbar.js
+++ b/testplan/web_ui/testing/src/Toolbar/Toolbar.js
@@ -184,7 +184,8 @@ const UserPreferenceRadio = ({ children, preferenceAtom, name, value }) => {
   const [preference, setPreference] = useAtom(preferenceAtom);
   return (
     <DropdownItem toggle={false} className={css(styles.dropdownItem)}>
-      <Label check className={css(styles.filterLabel_indent1)}>
+      <Label check className={css(
+        styles.filterLabel, styles.filterLabel_indent1)}>
         <Input
           type="radio"
           name={name}

--- a/testplan/web_ui/testing/src/Toolbar/Toolbar.js
+++ b/testplan/web_ui/testing/src/Toolbar/Toolbar.js
@@ -52,11 +52,12 @@ import styles from "./navStyles";
 import {
   displayPathPreference,
   displayTimeInfoPreference,
+  timeInfoUTCPreference,
   hideEmptyTestcasesPreference,
   hideSkippedTestcasesPreference,
   useTreeViewPreference,
 } from "../UserSettings/UserSettings";
-import { useAtom } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import _ from "lodash";
 
 library.add(
@@ -179,6 +180,44 @@ const UserPreferenceCheckbox = ({ children, preferenceAtom }) => {
   );
 };
 
+const UserPreferenceRadio = ({ children, preferenceAtom, name, value }) => {
+  const [preference, setPreference] = useAtom(preferenceAtom);
+  return (
+    <DropdownItem toggle={false} className={css(styles.dropdownItem)}>
+      <Label check className={css(styles.filterLabel_indent1)}>
+        <Input
+          type="radio"
+          name={name}
+          value={value}
+          checked={value === preference}
+          onChange={() => setPreference(value)}
+        />{" "}
+        {children}
+      </Label>
+    </DropdownItem>
+  );
+};
+
+const TimeInfoRadioButtons = ({ enabled }) => {
+  let component = enabled ? 
+  <>
+    <UserPreferenceRadio
+      preferenceAtom={timeInfoUTCPreference}
+      name="timezone"
+      value={true}>
+      UTC time
+    </UserPreferenceRadio>
+    <UserPreferenceRadio
+      preferenceAtom={timeInfoUTCPreference}
+      name="timezone"
+      value={false}>
+      Machine time
+    </UserPreferenceRadio>
+  </>
+  : "";
+  return component;
+};
+
 const ToolbarPreferencesButton = ({ toolbarStyle }) => {
   return (
     <UncontrolledDropdown nav inNavbar>
@@ -197,6 +236,8 @@ const ToolbarPreferencesButton = ({ toolbarStyle }) => {
         <UserPreferenceCheckbox preferenceAtom={displayTimeInfoPreference}>
           Display time information
         </UserPreferenceCheckbox>
+        <TimeInfoRadioButtons
+          enabled={useAtomValue(displayTimeInfoPreference)}/>
         <UserPreferenceCheckbox preferenceAtom={displayPathPreference}>
           Display file path of assertions
         </UserPreferenceCheckbox>

--- a/testplan/web_ui/testing/src/Toolbar/navStyles.js
+++ b/testplan/web_ui/testing/src/Toolbar/navStyles.js
@@ -35,6 +35,13 @@ const styles = StyleSheet.create({
     padding: "0.2em",
     "margin-left": "2em",
   },
+  filterLabel_indent1: {
+    width: "100%",
+    display: "inlinde-block",
+    cursor: "pointer",
+    padding: "0.2em",
+    "margin-left": "3em",
+  },
   dropdownItem: {
     padding: "0",
     ":focus": {

--- a/testplan/web_ui/testing/src/Toolbar/navStyles.js
+++ b/testplan/web_ui/testing/src/Toolbar/navStyles.js
@@ -33,16 +33,14 @@ const styles = StyleSheet.create({
     display: "inlinde-block",
     cursor: "pointer",
     padding: "0.2em",
+    "padding-right": "1em",
     "margin-left": "2em",
   },
   filterLabel_indent1: {
-    width: "100%",
-    display: "inlinde-block",
-    cursor: "pointer",
-    padding: "0.2em",
     "margin-left": "3em",
   },
   dropdownItem: {
+    overflow: "hidden",
     padding: "0",
     ":focus": {
       outline: "0",

--- a/testplan/web_ui/testing/src/UserSettings/UserSettings.js
+++ b/testplan/web_ui/testing/src/UserSettings/UserSettings.js
@@ -6,6 +6,7 @@ export const displayTimeInfoPreference = atomWithStorage(
   false
 );
 export const displayPathPreference = atomWithStorage("displayPath", false);
+export const timeInfoUTCPreference = atomWithStorage("UTCTime", false);
 export const hideEmptyTestcasesPreference = atomWithStorage(
   "hideEmptyTestcases",
   false


### PR DESCRIPTION
## Bug / Requirement Description
Users prefer to have timestamps shown in local timezone instead of UTC and shown on the left hand side before.

## Solution description
Change layout AssertionHeader layout and add a switch to switch between UTC and server time.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
