### PR TITLE
refine the exception msg when driver doesn't start

### DIFF
--- a/doc/newsfragments/2938_changed.driver_start_exception.rst
+++ b/doc/newsfragments/2938_changed.driver_start_exception.rst
@@ -1,0 +1,2 @@
+When a driver fails to start, it now prints more explicit error message about what regexps are not matched.
+

--- a/testplan/common/utils/timing.py
+++ b/testplan/common/utils/timing.py
@@ -61,7 +61,7 @@ class TimeoutExceptionInfo:
             "%Y-%m-%d %H:%M:%S"
         )
         duration = ended - self.started
-        return "Info[started at {}, raised at {} after {}s]".format(
+        return "Started at {}, raised at {} after {}s.".format(
             started_wait, raised_date, round(duration, 2)
         )
 

--- a/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
+++ b/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
@@ -287,10 +287,19 @@ def test_multitest_driver_start_timeout():
     assert driver1.cfg.status_wait_timeout == 1
     assert driver1.cfg.timeout == 1
 
-    with pytest.raises(TimeoutException, match=r".*Timeout.*after 1.0s*"):
+    try:
         with driver1:
             # we will not reach here
             assert False
+    except TimeoutException as exc:
+        assert (
+            r"Timeout when starting BaseDriver[timeout_driver]. Started at"
+            in str(exc)
+        )
+        assert (
+            r"""Unmatched stdout_regexps: [re.compile("Expression that won't match")]"""
+            in str(exc)
+        )
 
     driver2 = GoodDriver(
         name="good_driver",


### PR DESCRIPTION
## Bug / Requirement Description
Be explicit about what log/stdout_regexps are missing when driver fails to start

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
