### PR TITLE
Fix timestamp switch in interactive UI

### DIFF
--- a/doc/newsfragments/2988_changed.time_information_interactive_fix.rst
+++ b/doc/newsfragments/2988_changed.time_information_interactive_fix.rst
@@ -1,0 +1,1 @@
+Fixed UTC and Server time switch on interactive UI.

--- a/testplan/web_ui/testing/src/Report/BatchReport.js
+++ b/testplan/web_ui/testing/src/Report/BatchReport.js
@@ -42,8 +42,13 @@ import { displayTimeInfoPreference, timeInfoUTCPreference } from "../UserSetting
 const BatchReport = (props) => {
   const displayTimeInfo = useAtomValue(displayTimeInfoPreference);
   const UTCTimeInfo = useAtomValue(timeInfoUTCPreference);
-  return <BatchReportComponent {...props} displayTime={displayTimeInfo}
-          UTCTime={UTCTimeInfo}/>;
+  return (
+    <BatchReportComponent
+      {...props}
+      displayTime={displayTimeInfo}
+      UTCTime={UTCTimeInfo}
+      />
+  );
 };
 class BatchReportComponent extends BaseReport {
   constructor(props) {

--- a/testplan/web_ui/testing/src/Report/BatchReport.js
+++ b/testplan/web_ui/testing/src/Report/BatchReport.js
@@ -47,7 +47,7 @@ const BatchReport = (props) => {
       {...props}
       displayTime={displayTimeInfo}
       UTCTime={UTCTimeInfo}
-      />
+    />
   );
 };
 class BatchReportComponent extends BaseReport {

--- a/testplan/web_ui/testing/src/Report/InteractiveReport.js
+++ b/testplan/web_ui/testing/src/Report/InteractiveReport.js
@@ -42,7 +42,7 @@ import { encodeURIComponent2, parseToJson } from "../Common/utils";
 import { POLL_MS, CATEGORIES } from "../Common/defaults";
 import { AssertionContext, defaultAssertionStatus } from "../Common/context";
 import { ErrorBoundary } from "../Common/ErrorBoundary";
-import { displayTimeInfoPreference } from "../UserSettings/UserSettings";
+import { displayTimeInfoPreference, timeInfoUTCPreference } from "../UserSettings/UserSettings";
 
 const api_prefix = "/api/v1/interactive";
 const pendingEnvRequestAtom = atom("");
@@ -56,11 +56,13 @@ const pendingEnvRequestAtom = atom("");
 const InteractiveReport = (props) => {
   const displayTimeInfo = useAtomValue(displayTimeInfoPreference);
   const pendingEnvRequest = useAtomValue(pendingEnvRequestAtom);
+  const UTCTimeInfo = useAtomValue(timeInfoUTCPreference);
   return (
     <InteractiveReportComponent
       {...props}
       displayTime={displayTimeInfo}
       pendingEnvRequest={pendingEnvRequest}
+      UTCTime={UTCTimeInfo}
     />
   );
 };


### PR DESCRIPTION
## Bug / Requirement Description
UTC and Server timestamp switch is not working in interactive mode

## Solution description
Forgot to add the related atomvalue to the Interactive component's props

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
