### PR TITLE
Task error fix

### DIFF
--- a/doc/newsfragments/2929_changed.fix_worker_stop_on_error.rst
+++ b/doc/newsfragments/2929_changed.fix_worker_stop_on_error.rst
@@ -1,0 +1,1 @@
+Fixed an issue which make the worker stop in case of Task errors.


### PR DESCRIPTION
## Bug / Requirement Description
Worker can stop on task execution error and not sending back result

## Solution description
Task not always have result, as if it fails it is None. Helper function added to handle the error case.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
