### PR TITLE
refine auto-parts logic

### DIFF
--- a/doc/newsfragments/2991_changed.auto_parts_refine.rst
+++ b/doc/newsfragments/2991_changed.auto_parts_refine.rst
@@ -1,0 +1,2 @@
+Refine Auto-Part feature to handle corner cases when zero/negative/overly large number of parts are calculated.
+


### PR DESCRIPTION
## Bug / Requirement Description
Make Auto-Part corner case handling more robust.

## Solution description
try-except divide by zero
0/negative number of parts --> 1
cap number of parts

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
