### PR TITLE
Added proper uid to imported testcases, so the ui navigation can work with them properly.

### DIFF
--- a/doc/newsfragments/2966_changed.imported_reports_uids.rst
+++ b/doc/newsfragments/2966_changed.imported_reports_uids.rst
@@ -1,0 +1,1 @@
+Imported unittest reports (gtest, cppunit, junit) are now properly rendering the error output in the report viewer.

--- a/testplan/importers/cppunit.py
+++ b/testplan/importers/cppunit.py
@@ -9,6 +9,7 @@ from lxml import objectify, etree
 from lxml.builder import E
 from lxml.objectify import Element
 
+from testplan.common.utils.strings import uuid4
 from testplan.importers.base import ThreePhaseFileImporter, T
 from testplan.importers.suitesresults import SuitesResult
 from testplan.report import (
@@ -133,6 +134,7 @@ class CPPUnitResultImporter(ThreePhaseFileImporter[Element]):
             suite_report = TestGroupReport(
                 name=suite_name,
                 category=ReportCategories.TESTSUITE,
+                uid=uuid4(),
             )
 
             for testcase in suite.getchildren():
@@ -144,6 +146,7 @@ class CPPUnitResultImporter(ThreePhaseFileImporter[Element]):
                 testcase_prefix = testcase_classname.split(".")[-1]
                 testcase_report = TestCaseReport(
                     name="{}::{}".format(testcase_prefix, testcase_name),
+                    uid=uuid4(),
                 )
 
                 if not testcase.getchildren():

--- a/testplan/importers/gtest.py
+++ b/testplan/importers/gtest.py
@@ -6,6 +6,7 @@ from typing import List
 from lxml import objectify
 from lxml.objectify import Element
 
+from testplan.common.utils.strings import uuid4
 from testplan.importers.base import T, ThreePhaseFileImporter
 from testplan.importers.suitesresults import SuitesResult
 from testplan.report import (
@@ -51,13 +52,16 @@ class GTestResultImporter(ThreePhaseFileImporter[Element]):
             suite_report = TestGroupReport(
                 name=suite_name,
                 category=ReportCategories.TESTSUITE,
+                uid=uuid4(),
             )
             suite_has_run = False
 
             for testcase in suite.getchildren():
 
                 testcase_name = testcase.attrib["name"]
-                testcase_report = TestCaseReport(name=testcase_name)
+                testcase_report = TestCaseReport(
+                    name=testcase_name, uid=uuid4()
+                )
 
                 if not testcase.getchildren():
                     assertion_obj = RawAssertion(

--- a/testplan/importers/junit.py
+++ b/testplan/importers/junit.py
@@ -16,6 +16,7 @@ from testplan.report import (
 )
 from testplan.testing.multitest.entries.assertions import RawAssertion
 from testplan.testing.multitest.entries.schemas.base import registry
+from ..common.utils.strings import uuid4
 
 
 class JUnitImportedResult(SuitesResult):
@@ -53,6 +54,7 @@ class JUnitResultImporter(ThreePhaseFileImporter):
             suite_report = TestGroupReport(
                 name=suite_name,
                 category=ReportCategories.TESTSUITE,
+                uid=uuid4(),
             )
 
             for element in suite.getchildren():
@@ -76,7 +78,9 @@ class JUnitResultImporter(ThreePhaseFileImporter):
                 else:
                     case_report_name = f"{case_class}::{case_name}"
 
-                case_report = TestCaseReport(name=case_report_name)
+                case_report = TestCaseReport(
+                    name=case_report_name, uid=uuid4()
+                )
 
                 if not element.getchildren():
                     assertion = RawAssertion(

--- a/testplan/importers/suitesresults.py
+++ b/testplan/importers/suitesresults.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from testplan.common.utils.strings import uuid4
 from testplan.importers import ImportedResult
 from testplan.report import TestGroupReport, TestReport, ReportCategories
 
@@ -30,11 +31,14 @@ class SuitesResult(ImportedResult):
 
         :return: a plan report contains a single test having all the returned suite results
         """
-        report = TestReport(name=self.name, description=self.description)
+        report = TestReport(
+            name=self.name, description=self.description, uid=uuid4()
+        )
         test_report = TestGroupReport(
             name=self.name,
             category=self.REPORT_CATEGORY,
             description=self.description,
+            uid=uuid4(),
         )
 
         for suite_report in self.results():


### PR DESCRIPTION
## Bug / Requirement Description
The importer used the testcase/suite/... names as uids. This is not working well with the batch report viewer, and the navigation do not found the right entity.


## Solution description
Now proper uids getting generated, and the navigation just works, showing the errors properly.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
