### PR TITLE
FixLog missing sort buttons

### DIFF
--- a/doc/newsfragments/2945_fix.fixlog_sort_button.rst
+++ b/doc/newsfragments/2945_fix.fixlog_sort_button.rst
@@ -1,0 +1,1 @@
+Fixed FixLog assertion not showing sort buttons on the web UI.

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/FixLogAssertion.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/FixLogAssertion.js
@@ -59,7 +59,7 @@ export default function FixLogAssertion(props) {
 
   return (
     <DictBaseAssertion
-      buttonGroup={buttonGroup}
+      buttons={buttonGroup}
       columns={columns}
       rows={prepareDictRowData(rowData, props.assertion.line_no)}
     />

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/__tests__/__snapshots__/FixLogAssertion.test.js.snap
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/__tests__/__snapshots__/FixLogAssertion.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`FixLogAssertion shallow renders the correct HTML structure 1`] = `
 <DictBaseAssertion
-  buttonGroup={
+  buttons={
     <DictButtonGroup
       defaultSortType={Symbol(NONE)}
       flattenedDict={


### PR DESCRIPTION
## Bug / Requirement Description
FixLog not showing sort buttons on the webUI.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
