### PR TITLE
Fix issue where timer field on remote drivers cannot be dumped to json

### DIFF
--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -1312,12 +1312,9 @@ class ResourceStatus(EntityStatus):
         return transitions
 
 
-class ResourceTimings(str, Enum):
+class ResourceTimings:
     RESOURCE_SETUP = "setup"
     RESOURCE_TEARDOWN = "teardown"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 class Resource(Entity):

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -814,7 +814,7 @@ class Test(Runnable):
                 "Start Time (UTC)": driver.timer[setup_or_teardown][-1].start,
                 "Stop Time (UTC)": driver.timer[setup_or_teardown][-1].end,
                 "Duration(seconds)": driver.timer[setup_or_teardown][
-                    0
+                    -1
                 ].elapsed,
             }
             for driver in self.resources


### PR DESCRIPTION
## Bug / Requirement Description
Fix issue where the timer field on remote drivers cannot be dumped to json.
Also fixed issue where driver duration for `--driver-info` in interactive mode does not update between runs

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
