### PR TITLE
Fix issue where driver_info flag does not work in decorator

### DIFF
--- a/doc/newsfragments/2998_changed.fix_driver_info_in_decorator.rst
+++ b/doc/newsfragments/2998_changed.fix_driver_info_in_decorator.rst
@@ -1,0 +1,1 @@
+Fix a bug where ``driver_info`` flag does not work in decorator.

--- a/testplan/base.py
+++ b/testplan/base.py
@@ -144,6 +144,7 @@ class Testplan(entity.RunnableManager):
         paths of these modules.
     :param label: Label the test report with the given name, useful to
         categorize or classify similar reports .
+    :param driver_info: Display driver setup and teardown time in the report.
     """
 
     CONFIG = TestplanConfig
@@ -191,6 +192,7 @@ class Testplan(entity.RunnableManager):
         interactive_handler: Type[TestRunnerIHandler] = TestRunnerIHandler,
         extra_deps: Optional[List[Union[str, ModuleType]]] = None,
         label: Optional[str] = None,
+        driver_info: bool = False,
         auto_part_runtime_limit: int = defaults.AUTO_PART_RUNTIME_LIMIT,
         plan_runtime_target: int = defaults.PLAN_RUNTIME_TARGET,
         **options,
@@ -252,6 +254,7 @@ class Testplan(entity.RunnableManager):
             interactive_handler=interactive_handler,
             extra_deps=extra_deps,
             label=label,
+            driver_info=driver_info,
             auto_part_runtime_limit=auto_part_runtime_limit,
             plan_runtime_target=plan_runtime_target,
             **options,
@@ -396,6 +399,7 @@ class Testplan(entity.RunnableManager):
         interactive_handler=TestRunnerIHandler,
         extra_deps=None,
         label=None,
+        driver_info=False,
         auto_part_runtime_limit=defaults.AUTO_PART_RUNTIME_LIMIT,
         plan_runtime_target=defaults.PLAN_RUNTIME_TARGET,
         **options,
@@ -456,6 +460,7 @@ class Testplan(entity.RunnableManager):
                     interactive_handler=interactive_handler,
                     extra_deps=extra_deps,
                     label=label,
+                    driver_info=driver_info,
                     auto_part_runtime_limit=auto_part_runtime_limit,
                     plan_runtime_target=plan_runtime_target,
                     **options,

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -494,7 +494,7 @@ that match ALL of the given tags.
         report_group.add_argument(
             "--driver-info",
             action="store_true",
-            default=False,
+            default=self._default_options["driver_info"],
             help="Display drivers startup and shutdown info.",
         )
 

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -847,13 +847,18 @@ class Test(Runnable):
             table, description=f"Driver {setup_or_teardown.capitalize()} Info"
         )
 
+        # values are arbitary
+        padding = 150
+        row_size = 25
+        height = padding + row_size * len(px_input["Driver Name"])
         fig = px.timeline(
             px_input,
             x_start="Start Time (UTC)",
             x_end="Stop Time (UTC)",
             y="Driver Name",
+            height=height,
         )
-        fig.update_yaxes(autorange="reversed")
+        fig.update_yaxes(autorange="reversed", automargin=True)
         case_result.plotly(
             fig,
             description=f"Driver {setup_or_teardown.capitalize()} Timeline",


### PR DESCRIPTION
## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Fix bug where driver_info does not work in test_plan decorator.
Fix the driver-info plot to show all labels without hiding any by default.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
