### PR TITLE
Fix parser to allow for teardown time in runtime_json

### DIFF
--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -200,6 +200,7 @@ A typical input JSON looks like below:
     "<Multitest>": {
         "execution_time": 199.99,
         "setup_time": 39.99,
+        "teardown_time": 39.99, // optional
     },
     ......
 }""",
@@ -594,6 +595,7 @@ runtime_schema = schema.Schema(
         str: {
             "execution_time": schema.Or(int, float),
             "setup_time": schema.Or(int, float),
+            schema.Optional("teardown_time"): schema.Or(int, float),
         }
     }
 )


### PR DESCRIPTION
## Bug / Requirement Description
Fix a bug where a missing teardown_time in runtime_json throws error

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
