### PR TITLE
Fix timezone error when drivers fail to startup in driver-info

### DIFF
--- a/doc/newsfragments/3040_changed.fix_tz_issue_in_driver_info.rst
+++ b/doc/newsfragments/3040_changed.fix_tz_issue_in_driver_info.rst
@@ -1,0 +1,1 @@
+Fix bug where timezone error is raised if drivers raise exception in ``started_check`` with ``--driver-info`` flag enabled.

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -815,11 +815,11 @@ class Test(Runnable):
             {
                 "Driver Class": driver.__class__.__name__,
                 "Driver Name": driver.name,
-                "Start Time (UTC)": driver.timer[setup_or_teardown][-1].start,
-                "Stop Time (UTC)": driver.timer[setup_or_teardown][-1].end,
-                "Duration(seconds)": driver.timer[setup_or_teardown][
-                    -1
-                ].elapsed,
+                "Start Time (UTC)": driver.timer.last(setup_or_teardown).start,
+                "Stop Time (UTC)": driver.timer.last(setup_or_teardown).end,
+                "Duration(seconds)": driver.timer.last(
+                    setup_or_teardown
+                ).elapsed,
             }
             for driver in self.resources
             if setup_or_teardown in driver.timer.keys()
@@ -833,9 +833,10 @@ class Test(Runnable):
             "Driver Name": [],
         }
         for driver in table:
-            px_input["Driver Name"].append(driver["Driver Name"])
-            px_input["Start Time (UTC)"].append(driver["Start Time (UTC)"])
-            px_input["Stop Time (UTC)"].append(driver["Stop Time (UTC)"])
+            if driver["Stop Time (UTC)"]:
+                px_input["Driver Name"].append(driver["Driver Name"])
+                px_input["Start Time (UTC)"].append(driver["Start Time (UTC)"])
+                px_input["Stop Time (UTC)"].append(driver["Stop Time (UTC)"])
 
             # format tablelog entries to be human readable
             if driver["Start Time (UTC)"]:
@@ -855,6 +856,9 @@ class Test(Runnable):
         padding = 150
         row_size = 25
         height = padding + row_size * len(px_input["Driver Name"])
+        if height == padding:
+            # min height
+            height = padding + row_size
         fig = px.timeline(
             px_input,
             x_start="Start Time (UTC)",

--- a/tests/functional/testplan/testing/fixtures/base/failing/report.py
+++ b/tests/functional/testplan/testing/fixtures/base/failing/report.py
@@ -5,6 +5,7 @@ from testplan.report import (
     TestGroupReport,
     TestCaseReport,
     RuntimeStatus,
+    Status,
 )
 
 testcase_report = TestCaseReport(
@@ -36,5 +37,123 @@ expected_report = TestReport(
                 )
             ],
         )
+    ],
+)
+
+
+expected_report_with_failing_driver_and_driver_info_flag = TestReport(
+    name="plan",
+    entries=[
+        TestGroupReport(
+            name="MyTest",
+            category="multitest",
+            entries=[
+                TestGroupReport(
+                    name="Environment Start",
+                    category="synthesized",
+                    entries=[
+                        TestCaseReport(
+                            name="Starting",
+                            uid="Starting",
+                            description="",
+                            status_override=Status.ERROR,
+                            entries=[
+                                {
+                                    "type": "TableLog",
+                                    "indices": [0],
+                                    "display_index": False,
+                                    "columns": [
+                                        "Driver Class",
+                                        "Driver Name",
+                                        "Start Time (UTC)",
+                                        "Stop Time (UTC)",
+                                        "Duration(seconds)",
+                                    ],
+                                    "category": "DEFAULT",
+                                    "table": [
+                                        [
+                                            "FailingDriver",
+                                            "driver",
+                                            re.compile(
+                                                r"\d{2}:\d{2}:\d{2}.\d{6}"
+                                            ),
+                                            None,
+                                            None,
+                                        ]
+                                    ],
+                                    "description": "Driver Setup Info",
+                                    "meta_type": "entry",
+                                },
+                                {
+                                    "style": None,
+                                    "type": "Plotly",
+                                    "filesize": lambda x: isinstance(x, int),
+                                    "dst_path": re.compile(r".*\.json"),
+                                    "category": "DEFAULT",
+                                    "source_path": re.compile(r".*\.json"),
+                                    "orig_filename": re.compile(r".*\.json"),
+                                    "description": "Driver Setup Timeline",
+                                    "meta_type": "entry",
+                                },
+                            ],
+                        )
+                    ],
+                    tags=None,
+                ),
+                TestGroupReport(
+                    name="Environment Stop",
+                    category="synthesized",
+                    entries=[
+                        TestCaseReport(
+                            name="Stopping",
+                            uid="Stopping",
+                            description="",
+                            entries=[
+                                {
+                                    "type": "TableLog",
+                                    "indices": [0],
+                                    "display_index": False,
+                                    "columns": [
+                                        "Driver Class",
+                                        "Driver Name",
+                                        "Start Time (UTC)",
+                                        "Stop Time (UTC)",
+                                        "Duration(seconds)",
+                                    ],
+                                    "category": "DEFAULT",
+                                    "table": [
+                                        [
+                                            "FailingDriver",
+                                            "driver",
+                                            re.compile(
+                                                r"\d{2}:\d{2}:\d{2}.\d{6}"
+                                            ),
+                                            re.compile(
+                                                r"\d{2}:\d{2}:\d{2}.\d{6}"
+                                            ),
+                                            lambda x: isinstance(x, float),
+                                        ]
+                                    ],
+                                    "description": "Driver Teardown Info",
+                                    "meta_type": "entry",
+                                },
+                                {
+                                    "style": None,
+                                    "type": "Plotly",
+                                    "filesize": lambda x: isinstance(x, int),
+                                    "dst_path": re.compile(r".*\.json"),
+                                    "category": "DEFAULT",
+                                    "source_path": re.compile(r".*\.json"),
+                                    "orig_filename": re.compile(r".*\.json"),
+                                    "description": "Driver Teardown Timeline",
+                                    "meta_type": "entry",
+                                },
+                            ],
+                        )
+                    ],
+                    tags=None,
+                ),
+            ],
+        ),
     ],
 )

--- a/tests/functional/testplan/testing/fixtures/base/passing/report.py
+++ b/tests/functional/testplan/testing/fixtures/base/passing/report.py
@@ -89,7 +89,7 @@ expected_report_with_driver_and_driver_info_flag = TestReport(
     entries=[
         TestGroupReport(
             name="MyTest",
-            category="dummytest",
+            category="multitest",
             entries=[
                 TestGroupReport(
                     name="Environment Start",
@@ -114,8 +114,8 @@ expected_report_with_driver_and_driver_info_flag = TestReport(
                                     "category": "DEFAULT",
                                     "table": [
                                         [
-                                            "MyDriver",
-                                            "My executable",
+                                            "Driver",
+                                            "driver",
                                             re.compile(
                                                 r"\d{2}:\d{2}:\d{2}.\d{6}"
                                             ),
@@ -145,11 +145,6 @@ expected_report_with_driver_and_driver_info_flag = TestReport(
                     tags=None,
                 ),
                 TestGroupReport(
-                    name="ProcessChecks",
-                    category="testsuite",
-                    entries=[testcase_report],
-                ),
-                TestGroupReport(
                     name="Environment Stop",
                     category="synthesized",
                     entries=[
@@ -172,8 +167,8 @@ expected_report_with_driver_and_driver_info_flag = TestReport(
                                     "category": "DEFAULT",
                                     "table": [
                                         [
-                                            "MyDriver",
-                                            "My executable",
+                                            "Driver",
+                                            "driver",
                                             re.compile(
                                                 r"\d{2}:\d{2}:\d{2}.\d{6}"
                                             ),

--- a/tests/functional/testplan/testing/multitest/test_driver_info.py
+++ b/tests/functional/testplan/testing/multitest/test_driver_info.py
@@ -1,0 +1,45 @@
+import pytest
+
+from testplan.testing.multitest import MultiTest
+from testplan.testing.multitest.driver.base import Driver
+
+from testplan.common.utils.testing import check_report
+
+from ..fixtures import base
+
+
+class FailingDriver(Driver):
+    def started_check(self):
+        raise Exception
+
+
+def test_driver_info_flag(mockplan):
+    expected_report = (
+        base.passing.report.expected_report_with_driver_and_driver_info_flag
+    )
+    multitest = MultiTest(
+        name="MyTest",
+        environment=[Driver("driver")],
+        suites=[],
+    )
+    multitest.cfg.set_local("driver_info", True)
+    mockplan.add(multitest)
+    assert mockplan.run().run is True
+
+    check_report(expected=expected_report, actual=mockplan.report)
+
+
+def test_failing_driver_with_driver_info_flag(mockplan):
+    expected_report = (
+        base.failing.report.expected_report_with_failing_driver_and_driver_info_flag
+    )
+    multitest = MultiTest(
+        name="MyTest",
+        environment=[FailingDriver("driver")],
+        suites=[],
+    )
+    multitest.cfg.set_local("driver_info", True)
+    mockplan.add(multitest)
+    assert mockplan.run().run is True
+
+    check_report(expected=expected_report, actual=mockplan.report)

--- a/tests/functional/testplan/testing/test_base.py
+++ b/tests/functional/testplan/testing/test_base.py
@@ -91,26 +91,3 @@ def test_process_runner(mockplan, binary_path, expected_report, test_kwargs):
     assert mockplan.run().run is True
 
     check_report(expected=expected_report, actual=mockplan.report)
-
-
-@skip_on_windows(reason="Bash files skipped on Windows.")
-def test_process_runner_with_driver_info_flag(mockplan):
-    binary_path = os.path.join(fixture_root, "passing", "test_env.sh")
-    expected_report = (
-        base.passing.report.expected_report_with_driver_and_driver_info_flag
-    )
-    process_test = DummyTest(
-        name="MyTest",
-        binary=binary_path,
-        proc_env={
-            "proc_env1": "abc",
-            "proc_env2": "123",
-            "test_name": "{{name}}",
-        },
-        environment=[MyDriver(name="My executable", my_val="hello")],
-    )
-    process_test.cfg.set_local("driver_info", True)
-    mockplan.add(process_test)
-    assert mockplan.run().run is True
-
-    check_report(expected=expected_report, actual=mockplan.report)


### PR DESCRIPTION
## Bug / Requirement Description
Fix timezone error when drivers fail to startup in driver-info

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
