### PR TITLE
Refactor/app stopping

### DIFF
--- a/doc/newsfragments/3041_changed.app_stop.rst
+++ b/doc/newsfragments/3041_changed.app_stop.rst
@@ -1,0 +1,1 @@
+Refactor the stop logic of :py:class:`App <~testplan.testing.multitest.driver.app.App>` driver for faster environment shutdown. Rename parameter ``sigint_timeout`` to ``stop_timeout``. Add a new parameter ``stop_signal`` for custom stop signals, its default value ``None`` invokes ``terminate`` method on subprocess during stop.

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -306,7 +306,17 @@ class Environment:
 
         # Wait resources status to be STOPPED.
         for resource in resources_to_wait_for:
-            resource.wait(resource.STATUS.STOPPED)
+            try:
+                resource.wait(resource.STATUS.STOPPED)
+            except Exception:
+                self._record_resource_exception(
+                    message="While waiting for resource {resource} to stop:"
+                    "\n{traceback_exc}\n{fetch_msg}",
+                    resource=resource,
+                    msg_store=self.stop_exceptions,
+                )
+                # Resource status should be STOPPED even it failed to stop
+                resource.force_stopped()
             resource.logger.info("%s stopped", resource)
 
     def stop_in_pool(self, pool, is_reversed=False):

--- a/testplan/common/entity/base.py
+++ b/testplan/common/entity/base.py
@@ -3,7 +3,6 @@ Module containing base classes that represent object entities that can accept
 configuration, start/stop/run/abort, create results and have some state.
 """
 
-from enum import Enum
 import os
 import signal
 import sys

--- a/testplan/common/serialization/fields.py
+++ b/testplan/common/serialization/fields.py
@@ -283,7 +283,7 @@ class GenericNested(fields.Field):
         self.schema_context = schema_context
         self.type_field = type_field
         self.many = kwargs.get("many", False)
-        super(GenericNested, self).__init__(default=default, **kwargs)
+        super(GenericNested, self).__init__(default=default, metadata=kwargs)
 
     def _get_schema_obj(self, schema_value):
         parent_ctx = getattr(self.parent, "context", {})

--- a/testplan/testing/environment/base.py
+++ b/testplan/testing/environment/base.py
@@ -152,6 +152,10 @@ class TestEnvironment(Environment):
                     res = None
                     if watch.should_check():
                         res = driver.started_check()
+                    if res:
+                        driver._after_started()
+                        driver.logger.info("%s started", driver)
+                        self._rt_dependency.mark_processed(driver)
                 except Exception:
                     self._record_resource_exception(
                         message="While waiting for driver {resource} to start:\n"
@@ -163,11 +167,6 @@ class TestEnvironment(Environment):
                     # continue here as we tend to have fully started drivers
                     self._rt_dependency.purge_drivers_to_process()
                     self._rt_dependency.mark_failed_to_process(driver)
-                else:
-                    if res:
-                        driver._after_started()
-                        driver.logger.info("%s started", driver)
-                        self._rt_dependency.mark_processed(driver)
 
             time.sleep(MINIMUM_CHECK_INTERVAL)
 
@@ -230,6 +229,10 @@ class TestEnvironment(Environment):
                     res = None
                     if watch.should_check():
                         res = driver.stopped_check()
+                    if res:
+                        driver._after_stopped()
+                        driver.logger.info("%s stopped", driver)
+                        self._rt_dependency.mark_processed(driver)
                 except Exception:
                     self._record_resource_exception(
                         message="While waiting for driver {resource} to stop:\n"
@@ -241,10 +244,5 @@ class TestEnvironment(Environment):
                     driver.force_stopped()
                     driver.logger.info("%s stopped", driver)
                     self._rt_dependency.mark_processed(driver)
-                else:
-                    if res:
-                        driver._after_stopped()
-                        driver.logger.info("%s stopped", driver)
-                        self._rt_dependency.mark_processed(driver)
 
             time.sleep(MINIMUM_CHECK_INTERVAL)

--- a/testplan/testing/environment/base.py
+++ b/testplan/testing/environment/base.py
@@ -112,11 +112,11 @@ class TestEnvironment(Environment):
             if isinstance(v.started_check_interval, tuple):
                 curr_interval, interval_cap = v.started_check_interval
                 self._pocketwatches[k] = DriverPocketwatch(
-                    v.cfg.timeout, curr_interval, interval_cap
+                    v.start_timeout, curr_interval, interval_cap
                 )
             else:
                 self._pocketwatches[k] = DriverPocketwatch(
-                    v.cfg.timeout, v.started_check_interval
+                    v.start_timeout, v.started_check_interval
                 )
 
         while not self._rt_dependency.all_drivers_processed():
@@ -179,7 +179,7 @@ class TestEnvironment(Environment):
             return super().stop(is_reversed=is_reversed)
 
         # schedule driver stopping in "reverse" order
-        self._rt_dependency = self._orig_dependency.transpose()
+        self._rt_dependency: DriverDepGraph = self._orig_dependency.transpose()
 
         # filter drivers based on status
         for driver in self._resources.values():
@@ -188,14 +188,14 @@ class TestEnvironment(Environment):
 
         # distribute pocketwatches
         for k, v in self._rt_dependency.vertices.items():
-            if isinstance(v.started_check_interval, tuple):
-                curr_interval, interval_cap = v.started_check_interval
+            if isinstance(v.stopped_check_interval, tuple):
+                curr_interval, interval_cap = v.stopped_check_interval
                 self._pocketwatches[k] = DriverPocketwatch(
-                    v.cfg.timeout, curr_interval, interval_cap
+                    v.stop_timeout, curr_interval, interval_cap
                 )
             else:
                 self._pocketwatches[k] = DriverPocketwatch(
-                    v.cfg.timeout, v.started_check_interval
+                    v.stop_timeout, v.stopped_check_interval
                 )
 
         while not self._rt_dependency.all_drivers_processed():

--- a/testplan/testing/multitest/driver/zookeeper.py
+++ b/testplan/testing/multitest/driver/zookeeper.py
@@ -198,3 +198,4 @@ class ZookeeperStandalone(Driver):
             )
         finally:
             self.std.close()
+        super().stopping()

--- a/tests/functional/testplan/testing/multitest/test_bad_app.py
+++ b/tests/functional/testplan/testing/multitest/test_bad_app.py
@@ -1,6 +1,8 @@
 import os
 import re
 import sys
+from datetime import datetime
+from itertools import count
 
 import psutil
 import pytest
@@ -28,50 +30,56 @@ class BadSuite:
         result.false(True)
 
 
-def make_mt(app_args, driver_args):
-    def _():
-        return App(
-            name="App",
-            binary=sys.executable,
-            args=[
-                "-u",
-                os.path.join(MYAPP_DIR, "multi_proc_app.py"),
-                *app_args,
-            ],
-            stdout_regexps=[
-                re.compile(r"^curr pid (?P<pid>[0-9]+)$"),
-                re.compile(r"^child 1 pid (?P<pid1>[0-9]+)$"),
-                re.compile(r"^child 2 pid (?P<pid2>[0-9]+)$"),
-            ],
-            **driver_args,
-        )
-
-    yield mt.MultiTest("mt1", [GoodSuite()], environment=[_()])
-    yield mt.MultiTest("mt2", [BadSuite()], environment=[_()])
+def make_app(app_args, driver_args, name="app"):
+    return App(
+        name=name,
+        binary=sys.executable,
+        args=[
+            "-u",
+            os.path.join(MYAPP_DIR, "multi_proc_app.py"),
+            *app_args,
+        ],
+        stdout_regexps=[
+            re.compile(r"^parent pid (?P<pid>[0-9]+)$"),
+            re.compile(r"^child 1 pid (?P<pid1>[0-9]+)$"),
+            re.compile(r"^child 2 pid (?P<pid2>[0-9]+)$"),
+        ],
+        **driver_args,
+    )
 
 
 @pytest.mark.parametrize(
-    "app_args, driver_args, has_exception",
+    "app_args, driver_args, suite_cls, has_exception",
     (
-        (["--mask-sigterm", "parent", "--sleep-time", "1"], {}, False),
+        ([], {}, GoodSuite, False),
+        ([], {}, BadSuite, False),
+        (["--mask-sigterm", "parent", "--term-child"], {}, GoodSuite, False),
         (
-            ["--mask-sigterm", "parent", "--sleep-time", "5"],
+            ["--mask-sigterm", "parent", "--term-child", "--sleep-time", "5"],
             {"sigint_timeout": 1},
+            GoodSuite,
             True,
         ),
         (
-            ["--mask-sigterm", "parent", "--sleep-time", "5"],
+            ["--mask-sigterm", "parent", "--term-child", "--sleep-time", "5"],
             {"sigterm_timeout": 1},
+            GoodSuite,
             True,
         ),
     ),
+    ids=count(0),
 )
-def test_bad_app(app_args, driver_args, has_exception):
+def test_basic(app_args, driver_args, suite_cls, has_exception):
     mockplan = Mockplan(
         name="bad_app_mock_test",
     )
-    for mt in make_mt(app_args, driver_args):
-        mockplan.add(mt)
+    mockplan.add(
+        mt.MultiTest(
+            "dummy_mt",
+            suite_cls(),
+            environment=[make_app(app_args, driver_args)],
+        )
+    )
     report = mockplan.run().report
 
     curr_proc = psutil.Process()
@@ -79,6 +87,68 @@ def test_bad_app(app_args, driver_args, has_exception):
     assert len(child_procs) == 0
 
     if has_exception:
-        for e in map(lambda x: x.entries[2].entries[0], report.entries):
-            assert e.logs
-            assert "TimeoutException" in e.logs[0]["message"]
+        assert report.status == report.status.ERROR
+        stopping_case = report.entries[0].entries[2].entries[0]
+        assert "TimeoutException" in stopping_case.logs[0]["message"]
+    else:
+        assert report.status != report.status.ERROR
+
+
+@pytest.mark.parametrize(
+    "app_args, driver_args, dependencies, stopped_order",
+    (
+        (
+            ["--mask-sigterm", "parent", "--term-child", "--sleep-time", "1"],
+            {},
+            {"app2": "app"},
+            ["app3", "app", "app2"],
+        ),
+        (
+            ["--mask-sigterm", "all"],
+            {"sigterm_timeout": 1},
+            {"app2": "app"},
+            ["app3", "app2"],
+        ),
+    ),
+    ids=count(0),
+)
+def test_complex(app_args, driver_args, dependencies, stopped_order):
+    mockplan = Mockplan(
+        name="bad_app_mock_test",
+        driver_info=True,
+    )
+    app = make_app(app_args, driver_args)
+    app2 = make_app([], {}, name="app2")
+    app3 = make_app([], {}, name="app3")
+    dmap = {app.name: app, app2.name: app2}
+    dep = (
+        None
+        if dependencies is None
+        else {dmap[k]: dmap[v] for k, v in dependencies.items()}
+    )
+    mockplan.add(
+        mt.MultiTest(
+            "dummy_mt",
+            GoodSuite(),
+            environment=[app, app2, app3],
+            dependencies=dep,
+        )
+    )
+    report = mockplan.run().report
+
+    # here we use data in TableLog entry to check the order of stopping
+    stopping_table = (
+        report.entries[0].entries[2].entries[0].entries[0]["table"]
+    )
+    assert (
+        list(
+            map(
+                lambda r: r[1],
+                sorted(
+                    filter(lambda x: x[3], stopping_table),
+                    key=lambda x: datetime.strptime(x[3], "%H:%M:%S.%f"),
+                ),
+            )
+        )
+        == stopped_order
+    )

--- a/tests/functional/testplan/testing/multitest/test_bad_app.py
+++ b/tests/functional/testplan/testing/multitest/test_bad_app.py
@@ -1,0 +1,84 @@
+import os
+import re
+import sys
+
+import psutil
+import pytest
+
+import testplan.testing.multitest as mt
+from testplan.base import TestplanMock as Mockplan
+from testplan.testing.multitest.driver.app import App
+from tests.unit.testplan.testing.multitest.driver.myapp.test_app import (
+    MYAPP_DIR,
+)
+
+
+@mt.testsuite
+class GoodSuite:
+    @mt.testcase
+    def passed(self, env, result):
+        result.true(True)
+
+
+@mt.testsuite
+class BadSuite:
+    @mt.testcase
+    def illegal(self, env, result):
+        env.app.proc.terminate()
+        result.false(True)
+
+
+def make_mt(app_args, driver_args):
+    def _():
+        return App(
+            name="App",
+            binary=sys.executable,
+            args=[
+                "-u",
+                os.path.join(MYAPP_DIR, "multi_proc_app.py"),
+                *app_args,
+            ],
+            stdout_regexps=[
+                re.compile(r"^curr pid (?P<pid>[0-9]+)$"),
+                re.compile(r"^child 1 pid (?P<pid1>[0-9]+)$"),
+                re.compile(r"^child 2 pid (?P<pid2>[0-9]+)$"),
+            ],
+            **driver_args,
+        )
+
+    yield mt.MultiTest("mt1", [GoodSuite()], environment=[_()])
+    yield mt.MultiTest("mt2", [BadSuite()], environment=[_()])
+
+
+@pytest.mark.parametrize(
+    "app_args, driver_args, has_exception",
+    (
+        (["--mask-sigterm", "parent", "--sleep-time", "1"], {}, False),
+        (
+            ["--mask-sigterm", "parent", "--sleep-time", "5"],
+            {"sigint_timeout": 1},
+            True,
+        ),
+        (
+            ["--mask-sigterm", "parent", "--sleep-time", "5"],
+            {"sigterm_timeout": 1},
+            True,
+        ),
+    ),
+)
+def test_bad_app(app_args, driver_args, has_exception):
+    mockplan = Mockplan(
+        name="bad_app_mock_test",
+    )
+    for mt in make_mt(app_args, driver_args):
+        mockplan.add(mt)
+    report = mockplan.run().report
+
+    curr_proc = psutil.Process()
+    child_procs = curr_proc.children(recursive=True)
+    assert len(child_procs) == 0
+
+    if has_exception:
+        for e in map(lambda x: x.entries[2].entries[0], report.entries):
+            assert e.logs
+            assert "TimeoutException" in e.logs[0]["message"]

--- a/tests/functional/testplan/testing/multitest/test_bad_app.py
+++ b/tests/functional/testplan/testing/multitest/test_bad_app.py
@@ -1,3 +1,8 @@
+from pytest_test_filters import skip_module_on_windows
+
+skip_module_on_windows(reason="SIGTERM is not really used on windows.")
+
+
 import os
 import re
 import sys

--- a/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
+++ b/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
@@ -289,8 +289,8 @@ def test_multitest_driver_start_timeout():
         timeout=1,
         stdout_regexps=[re.compile(r"Expression that won't match")],
     )
-    assert driver1.cfg.status_wait_timeout == 1
     assert driver1.cfg.timeout == 1
+    assert driver1.stop_timeout == 1
 
     try:
         with driver1:

--- a/tests/unit/testplan/testing/multitest/driver/myapp/multi_proc_app.py
+++ b/tests/unit/testplan/testing/multitest/driver/myapp/multi_proc_app.py
@@ -34,7 +34,7 @@ def dummy_loop(mask_sigterm):
 
 
 def main(mask_sigterm, sleep_time, term_child):
-    print(f"curr pid {os.getpid()}")
+    print(f"parent pid {os.getpid()}")
     child_mask = True if mask_sigterm == "all" else False
     p1 = mp.Process(target=dummy_loop, args=(child_mask,))
     p2 = mp.Process(target=dummy_loop, args=(child_mask,))

--- a/tests/unit/testplan/testing/multitest/driver/myapp/multi_proc_app.py
+++ b/tests/unit/testplan/testing/multitest/driver/myapp/multi_proc_app.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+import multiprocessing as mp
+import os
+import signal
+import sys
+import time
+from argparse import ArgumentParser
+
+
+def handler(p1: mp.Process, p2: mp.Process, mask_sigterm, term_child):
+    def _(signum, frame):
+        print(f"{signum} received", file=sys.stderr)
+        if term_child:
+            p1.terminate()
+            p2.terminate()
+            print("p1 terminated", file=sys.stderr)
+            print("p2 terminated", file=sys.stderr)
+        if not mask_sigterm:
+            signal.signal(signal.SIGTERM, signal.SIG_DFL)
+            os.kill(os.getpid(), signal.SIGTERM)
+
+    return _
+
+
+def child_handler(signum, frame):
+    print(f"{signum} received", file=sys.stderr)
+
+
+def dummy_loop(mask_sigterm):
+    if mask_sigterm:
+        signal.signal(signal.SIGTERM, child_handler)
+    while True:
+        time.sleep(1)
+
+
+def main(mask_sigterm, sleep_time, term_child):
+    print(f"curr pid {os.getpid()}")
+    child_mask = True if mask_sigterm == "all" else False
+    p1 = mp.Process(target=dummy_loop, args=(child_mask,))
+    p2 = mp.Process(target=dummy_loop, args=(child_mask,))
+    p1.start()
+    print(f"child 1 pid {p1.pid}")
+    p2.start()
+    print(f"child 2 pid {p2.pid}")
+    parent_mask = True if mask_sigterm != "none" else False
+    print(f"child sigterm mask {child_mask}")
+    print(f"parent sigterm mask {parent_mask}")
+    signal.signal(signal.SIGTERM, handler(p1, p2, parent_mask, term_child))
+    p1.join()
+    p2.join()
+    if 0 < sleep_time < float("inf"):
+        time.sleep(sleep_time)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser("multi_proc_app")
+    parser.add_argument(
+        "--mask-sigterm", choices=["all", "parent", "none"], default="none"
+    )
+    parser.add_argument("--sleep-time", type=float, default=0)
+    parser.add_argument("--term-child", default=False, action="store_true")
+    args = parser.parse_args()
+    print(args)
+    main(args.mask_sigterm, args.sleep_time, args.term_child)

--- a/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
+++ b/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
@@ -396,7 +396,7 @@ def test_multiproc_app_stop(runpath, app_args, force_stop, num_leftover):
         binary=sys.executable,
         args=["-u", os.path.join(MYAPP_DIR, "multi_proc_app.py"), *app_args],
         stdout_regexps=[
-            re.compile(r"^curr pid (?P<pid>[0-9]+)$"),
+            re.compile(r"^parent pid (?P<pid>[0-9]+)$"),
             re.compile(r"^child 1 pid (?P<pid1>[0-9]+)$"),
             re.compile(r"^child 2 pid (?P<pid2>[0-9]+)$"),
         ],
@@ -411,7 +411,7 @@ def test_multiproc_app_stop(runpath, app_args, force_stop, num_leftover):
         if force_stop:
             app.force_stopped()
         else:
-            assert "Timeout when stopping App[App]" in str(e)
+            assert "Timeout when stopping App" in str(e)
             assert psutil.pid_exists(int(app.extracts["pid"]))
 
     curr_proc = psutil.Process()

--- a/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
+++ b/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
@@ -15,6 +15,9 @@ import pytest
 from testplan.common.entity import ActionResult
 from testplan.testing.multitest.driver.app import App
 
+from pytest_test_filters import skip_on_windows
+
+
 MYAPP_DIR = os.path.dirname(__file__)
 
 
@@ -364,6 +367,7 @@ def run_app(cwd, runpath):
     return app
 
 
+@skip_on_windows(reason="SIGTERM is not really used on windows.")
 @pytest.mark.parametrize(
     "app_args, force_stop, num_leftover",
     (


### PR DESCRIPTION
## Bug / Requirement Description
lift proc poll at app stopping to parent level (make use of stopped check)

## Solution description
have new timeout attributes & overridden wait methods for drivers

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
