### PR TITLE
Misc/capture logs when running examples

### DIFF
--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -47,11 +47,6 @@ from .connection import (
 IS_WIN = platform.system() == "Windows"
 
 
-def _unblock_sigs():
-    # unblocking not blocked is not blocked
-    signal.pthread_sigmask(signal.SIG_UNBLOCK, range(1, signal.NSIG))
-
-
 class AppConfig(DriverConfig):
     """
     Configuration object for
@@ -362,7 +357,6 @@ class App(Driver):
                 stdin=subprocess.PIPE,
                 stdout=self.std.out,
                 stderr=self.std.err,
-                preexec_fn=_unblock_sigs if not IS_WIN else None,
                 cwd=cwd,
                 env=self.env,
             )
@@ -493,31 +487,24 @@ class App(Driver):
             all persistence is deleted, else a normal restart.
 
         """
-        try:
-            self.stop()
-            if self.async_start:
-                self.wait(self.status.STOPPED)
+        self.stop()
+        if self.async_start:
+            self.wait(self.status.STOPPED)
 
-            if clean:
-                self._move_app_path()
-            else:
-                self._move_std_and_logs()
+        if clean:
+            self._move_app_path()
+        else:
+            self._move_std_and_logs()
 
-            # we don't want to cleanup runpath during restart
-            path_cleanup = self.cfg.path_cleanup
-            self.cfg._options["path_cleanup"] = False
+        # we don't want to cleanup runpath during restart
+        path_cleanup = self.cfg.path_cleanup
+        self.cfg._options["path_cleanup"] = False
 
-            self.start()
-            if self.async_start:
-                self.wait(self.status.STARTED)
+        self.start()
+        if self.async_start:
+            self.wait(self.status.STARTED)
 
-            self.cfg._options["path_cleanup"] = path_cleanup
-        except Exception as e:
-            self.logger.error(
-                "Error during restart %s: %s, force stopping...", self, e
-            )
-            self.force_stopped()
-            raise
+        self.cfg._options["path_cleanup"] = path_cleanup
 
     def _move_app_path(self) -> None:
         """

--- a/testplan/testing/py_test.py
+++ b/testplan/testing/py_test.py
@@ -516,7 +516,6 @@ class _ReportPlugin:
         elif self._current_case_report is not None:
             # Log assertion errors or exceptions in testcase report
             trace = call.excinfo.traceback[-1]
-            # XXX: use report.longreprtext instead?
             message = (
                 getattr(call.excinfo.value, "message", None)
                 or getattr(call.excinfo.value, "msg", None)

--- a/testplan/testing/py_test.py
+++ b/testplan/testing/py_test.py
@@ -482,6 +482,9 @@ class _ReportPlugin:
 
             if report.failed:
                 self._current_case_report.status_override = Status.FAILED
+            # XXX: report.skipped set to True when xfail, how to distinguish?
+            # elif report.skipped:
+            #     self._current_case_report.status_override = Status.SKIPPED
             else:
                 self._current_case_report.pass_if_empty()
             self._current_case_report.runtime_status = RuntimeStatus.FINISHED
@@ -513,6 +516,7 @@ class _ReportPlugin:
         elif self._current_case_report is not None:
             # Log assertion errors or exceptions in testcase report
             trace = call.excinfo.traceback[-1]
+            # XXX: use report.longreprtext instead?
             message = (
                 getattr(call.excinfo.value, "message", None)
                 or getattr(call.excinfo.value, "msg", None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import sys
 import tempfile
-from logging import Logger
+from logging import Logger, INFO
 from logging.handlers import RotatingFileHandler
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
@@ -125,3 +125,13 @@ def rotating_logger(runpath):
     yield logger
 
     logger.handler.close()
+
+
+@pytest.fixture
+def captplog(caplog):
+    from testplan.common.utils.logger import TESTPLAN_LOGGER
+
+    caplog.set_level(INFO)
+    TESTPLAN_LOGGER.addHandler(caplog.handler)
+    yield caplog
+    TESTPLAN_LOGGER.removeHandler(caplog.handler)

--- a/tests/functional/examples/test_examples.py
+++ b/tests/functional/examples/test_examples.py
@@ -90,7 +90,7 @@ def _param_formatter(param):
     ],
     ids=_param_formatter,
 )
-def test_example(root, filename, runpath):
+def test_example(root, filename, runpath, captplog):
     file_path = os.path.join(root, filename)
 
     if ON_WINDOWS and any(
@@ -106,5 +106,9 @@ def test_example(root, filename, runpath):
         pytest.skip()
 
     run_example_in_process(
-        filename, root, KNOWN_EXCEPTIONS, ["--runpath", runpath]
+        filename,
+        root,
+        KNOWN_EXCEPTIONS,
+        ["--runpath", runpath],
+        captplog,
     )

--- a/tests/helpers/example_runner.py
+++ b/tests/helpers/example_runner.py
@@ -18,8 +18,15 @@ SUCCES_EXIT_CODES = (
 
 
 def run_example_in_process(
-    filename, root, known_exceptions, cmdline_args=None
+    filename,
+    root,
+    known_exceptions,
+    cmdline_args=None,
+    caplog=None,
 ):
+    if caplog is not None:
+        caplog.clear()
+
     sys_path = copy.copy(sys.path)
     sys_argv = copy.copy(sys.argv)
 
@@ -43,9 +50,12 @@ def run_example_in_process(
     except SystemExit as e:
         if e.code not in SUCCES_EXIT_CODES:
             assert (
-                "# This plan contains tests that demonstrate failures as well."
-            ) == second_line, (
-                'Expected "{}" example to pass, it failed'.format(file_path)
+                second_line
+                == "# This plan contains tests that demonstrate failures as well."
+            ), 'Expected "{}" example to pass, it failed'.format(file_path) + (
+                "\nCaptured logs:\n{}".format(caplog.text)
+                if caplog is not None
+                else ""
             )
     except Exception as e:
         for exception in known_exceptions:


### PR DESCRIPTION
## Bug / Requirement Description
certain python package will block signals, which will be inherited by subprocess in App driver, which will later cause SIGTERM failed to be received by subprocess

## Solution description
unblock all signals in subprocess.Popen's preexec_fn

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
