### PR TITLE
Improve remote driver log matching performance

### DIFF
--- a/testplan/common/utils/match.py
+++ b/testplan/common/utils/match.py
@@ -196,6 +196,15 @@ class LogMatcher(logger.Loggable):
 
         if isinstance(regexp, (str, bytes)):
             regexp = re.compile(regexp)
+        else:
+            try:
+                import rpyc
+
+                if isinstance(regexp, rpyc.core.netref.BaseNetref):
+                    regexp = re.compile(regexp.pattern, regexp.flags)
+            except ImportError:
+                pass
+
         try:
             if self.binary and isinstance(regexp.pattern, str):
                 raise TypeError(


### PR DESCRIPTION
## Bug / Requirement Description
When we call match() on a remote driver's log_matcher, and pass a regex object, it match would happen in localhost, which is extremely slow.

## Solution description
We are going to re-construct the regex object on remote side to make sure the log matching happens on remote host.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
