### PR TITLE
Fix/suppress certain exceptions during app stop

### DIFF
--- a/doc/newsfragments/3041_changed.relax_app_stop_error_condition.rst
+++ b/doc/newsfragments/3041_changed.relax_app_stop_error_condition.rst
@@ -1,0 +1,1 @@
+If :py:class:`App <~testplan.testing.multitest.driver.app.App>` driver times out during shutdown or leaves orphaned processes after shutdown, Testplan will now emit a warning and perform a forced cleanup instead of failing the tests.

--- a/testplan/common/utils/process.py
+++ b/testplan/common/utils/process.py
@@ -206,6 +206,17 @@ def cleanup_child_procs(
             log(exc)
 
 
+def any_alive_child_procs(procs: List[psutil.Process]) -> bool:
+    for p in procs:
+        try:
+            # orphaned zombie process should be reaped by pid 1
+            if p.is_running() and p.status() != psutil.STATUS_ZOMBIE:
+                return True
+        except psutil.NoSuchProcess:
+            pass
+    return False
+
+
 DEFAULT_CLOSE_FDS = platform.system() != "Windows"
 
 

--- a/testplan/testing/base.py
+++ b/testplan/testing/base.py
@@ -463,6 +463,10 @@ class Test(Runnable):
             )
             self._record_driver_connection(case_report)
         case_report.pass_if_empty()
+
+        if self.resources.start_warnings:
+            for msg in self.resources.start_warnings.values():
+                case_report.logger.warning(msg)
         if self.resources.start_exceptions:
             for msg in self.resources.start_exceptions.values():
                 case_report.logger.error(msg)
@@ -485,6 +489,10 @@ class Test(Runnable):
                 ResourceTimings.RESOURCE_TEARDOWN, case_report
             )
         case_report.pass_if_empty()
+
+        if self.resources.stop_warnings:
+            for msg in self.resources.stop_warnings.values():
+                case_report.logger.warning(msg)
         if self.resources.stop_exceptions:
             for msg in self.resources.stop_exceptions.values():
                 case_report.logger.error(msg)

--- a/testplan/testing/environment/base.py
+++ b/testplan/testing/environment/base.py
@@ -212,7 +212,7 @@ class TestEnvironment(Environment):
                     if do_suppress:
                         self._record_resource_warning(
                             message="While stopping driver {resource}"
-                            " (mitigated by forcefully stopping resource)"
+                            " (mitigated by forcefully stopping driver)"
                             ":\n{traceback_exc}\n{fetch_msg}",
                             resource=driver,
                             msg_store=self.stop_warnings,
@@ -259,7 +259,7 @@ class TestEnvironment(Environment):
                     if do_suppress:
                         self._record_resource_warning(
                             message="While waiting for driver {resource} to stop"
-                            " (mitigated by forcefully stopping resource)"
+                            " (mitigated by forcefully stopping driver)"
                             ":\n{traceback_exc}\n{fetch_msg}",
                             resource=driver,
                             msg_store=self.stop_warnings,

--- a/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
+++ b/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
@@ -409,6 +409,7 @@ def test_multiproc_app_stop(runpath, app_args, force_stop, num_leftover):
         async_start=False,
         expected_retcode=0,
     )
+    # TODO: make start, stop behave consistent regardlessly async_start
     app.start()
     try:
         app.stop()


### PR DESCRIPTION
## Bug / Requirement Description
it might be to strict to ensure app terminated normally, after all a killed app during env shutdown does no harm. here we loose the constraint

## Solution description
add extra class var for suppressible exceptions (by type ofc)

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
