### PR TITLE
Fix/make driver's installed files writable

### DIFF
--- a/testplan/common/utils/path.py
+++ b/testplan/common/utils/path.py
@@ -204,7 +204,7 @@ def instantiate(template, values, destination):
             try:
                 target.write(render(source.read(), values))
             except UnicodeDecodeError:
-                shutil.copy(template, destination)
+                shutil.copyfile(template, destination)
             except Exception as exc:
                 raise Exception(
                     "On reading/writing template: {} - of file {}".format(

--- a/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
+++ b/tests/unit/testplan/testing/multitest/driver/myapp/test_app.py
@@ -256,6 +256,7 @@ def test_install_files(runpath):
     bfile = os.path.join(
         os.path.abspath(os.path.dirname(__file__)), "binary_file"
     )
+    os.chmod(bfile, 0o444)  # only 644 or 755 supported by git
     stdout_regexps = [
         re.compile(r".*binary=(?P<binary>.*)"),
         re.compile(r".*command=(?P<command>.*)"),
@@ -280,12 +281,13 @@ def test_install_files(runpath):
         assert os.path.exists(app.extracts["binary"])
         assert bool(json.loads(app.extracts["command"]))
         assert os.path.exists(app.extracts["app_path"])
-        assert os.path.exists(os.path.join(app.app_path, "etc", "binary_file"))
-        assert os.path.exists(os.path.join(app.app_path, "etc", "config.yaml"))
-        assert os.path.exists(os.path.join(dst, "config.yaml"))
-        assert os.path.exists(
-            os.path.join(app.app_path, "etc", "rel_path", "config.yaml")
-        )
+        for p in [
+            os.path.join(app.app_path, "etc", "binary_file"),
+            os.path.join(app.app_path, "etc", "config.yaml"),
+            os.path.join(dst, "config.yaml"),
+            os.path.join(app.app_path, "etc", "rel_path", "config.yaml"),
+        ]:
+            assert os.access(p, os.F_OK | os.R_OK | os.W_OK)
 
 
 def test_echo_hello(runpath):


### PR DESCRIPTION
## Bug / Requirement Description
make sure installed files of drivers writable under runpath

## Solution description
copyfile should only copy contents, regardless of read-only being set at src

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
