### PR TITLE
Fixed entry status icon - status category mapping on webUI

### DIFF
--- a/doc/newsfragments/3170_changed.status_icon_xfail.rst
+++ b/doc/newsfragments/3170_changed.status_icon_xfail.rst
@@ -1,0 +1,1 @@
+Fixed an issue where enabling Status icons crashed the report when a test was marked as XFAIL.

--- a/testplan/web_ui/testing/src/Nav/navUtils.js
+++ b/testplan/web_ui/testing/src/Nav/navUtils.js
@@ -12,6 +12,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import TagList from "./TagList";
 import Column from "./Column";
 import CommonStyles, { statusStyles } from "../Common/Styles.js";
+import { STATUS_CATEGORY } from "../Common/defaults.js";
 import { navStyles } from "../Common/Styles";
 import {
   generateURLWithParameters,
@@ -304,7 +305,7 @@ const GetStatusIcon = (status) => (
     <FontAwesomeIcon
       title={status}
       size="sm"
-      icon={statusStyles[status].icon}
+      icon={statusStyles[STATUS_CATEGORY[status]].icon}
       className={css(navStyles.icon)}
     />
   </span>


### PR DESCRIPTION
## Bug / Requirement Description
Enabling status icons crashes the whole report when there is an xfail entry.

## Solution description
Fixed by mapping statusStyles to STATUS_CATEGORY

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
