### PR TITLE
Testplan result importer to best effort fix attachment path

### DIFF
--- a/testplan/importers/testplan.py
+++ b/testplan/importers/testplan.py
@@ -1,9 +1,12 @@
 """
 Implements one-phase importer for Testplan JSON format.
 """
+import os
+import pathlib
 from typing import List
 
 from testplan.common.utils.json import json_loads
+from testplan.defaults import ATTACHMENTS
 from testplan.importers import ImportedResult, ResultImporter
 from testplan.report import ReportCategories, TestGroupReport, TestReport
 from testplan.report.testing.schemas import TestReportSchema
@@ -42,6 +45,47 @@ class TestplanResultImporter(ResultImporter):
         """ """
         with open(self.path) as fp:
             result_json = json_loads(fp.read())
+            self.fix_attachments_path(result_json)
             result = self.schema.load(result_json)
 
             return TestplanImportedResult(result)
+
+    def fix_attachments_path(
+        self,
+        report: dict,
+        attachment_dir: pathlib.Path = None,
+    ):
+        """
+        Best effort fix attachment path in case report.json and _attachments are copied around
+        """
+        attachment_dir = (
+            str(attachment_dir)
+            if attachment_dir
+            else os.path.join(os.path.dirname(self.path), ATTACHMENTS)
+        )
+        if report.get("attachments"):
+            for dst, src in report["attachments"].items():
+                if os.path.isfile(src):
+                    # attachment path is correct
+                    break
+                else:
+                    # attempt to fix attachment path
+                    alt_src = os.path.join(attachment_dir, dst)
+                    if os.path.isfile(alt_src):
+                        report["attachments"][dst] = alt_src
+
+        # recursively fix entries
+        def _fix_attachments_path(report):
+            if report.get("entries"):
+                for entry in report["entries"]:
+                    _fix_attachments_path(entry)
+            elif report.get("source_path") and report.get("dst_path"):
+                if os.path.isfile(report["source_path"]):
+                    # attachment path is correct
+                    return
+                alt_src = os.path.join(attachment_dir, report["dst_path"])
+                if os.path.isfile(alt_src):
+                    report["source_path"] = alt_src
+
+        _fix_attachments_path(report)
+        return report


### PR DESCRIPTION
## Bug / Requirement Description
When we copy report.json and _attachment around, we are not able to locate the attachments after import json.

## Solution description
Best effort fix attachment path by checking local _attachment dir.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
