### PR TITLE
Fix/update orjson opt to seralize numpy objs

### DIFF
--- a/doc/newsfragments/3178_changed.orjson_opt.rst
+++ b/doc/newsfragments/3178_changed.orjson_opt.rst
@@ -1,0 +1,1 @@
+Update ``orjson`` dumping option to allow serializing ``numpy`` objects.

--- a/testplan/common/utils/json.py
+++ b/testplan/common/utils/json.py
@@ -24,7 +24,8 @@ def json_dumps(data, indent_2=False, default=None) -> str:
         return orjson.dumps(
             data,
             default=default,
-            option=orjson.OPT_INDENT_2 if indent_2 else 0,
+            option=(orjson.OPT_INDENT_2 if indent_2 else 0)
+            | orjson.OPT_SERIALIZE_NUMPY,
         ).decode()
     else:
         if default:


### PR DESCRIPTION
## Bug / Requirement Description
currently `json_dumps` not able to serialize numpy objs when using orjson

## Solution description
update `orjson.dumps` opt

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
