### PR TITLE
use python 3.10 for pylint

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -45,7 +45,7 @@ jobs:
     if: needs.is_source_changed.outputs.is_source_changed == 'true'
     env:
       BLACK_VERSION: "22.10.0"
-      LINT_PYTHON_VERSION: "3.7"
+      LINT_PYTHON_VERSION: "3.10"
     steps:
       - name: Checkout repository
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6

--- a/testplan/common/serialization/fields.py
+++ b/testplan/common/serialization/fields.py
@@ -11,7 +11,7 @@ from lxml import etree
 
 from marshmallow import fields
 from marshmallow import class_registry
-from marshmallow.base import SchemaABC
+from marshmallow.schema import Schema
 from marshmallow.utils import missing as missing_
 
 from testplan.common.utils import comparison
@@ -291,12 +291,12 @@ class GenericNested(fields.Field):
         if callable(schema_value) and not isinstance(schema_value, type):
             schema_value = schema_value()
 
-        if isinstance(schema_value, SchemaABC):
+        if isinstance(schema_value, Schema):
             schema_value.context.update(parent_ctx)
             return schema_value
 
         elif isinstance(schema_value, type) and issubclass(
-            schema_value, SchemaABC
+            schema_value, Schema
         ):
             return schema_value(many=self.many, context=parent_ctx)
 

--- a/testplan/exporters/testing/__init__.py
+++ b/testplan/exporters/testing/__init__.py
@@ -50,3 +50,4 @@ def __getattr__(name):
         from .xml import XMLExporter
 
         return XMLExporter
+    raise AttributeError(f"module {__name__} has no attribute {name}")


### PR DESCRIPTION
## Bug / Requirement Description
use python 3.10 for pylint
fix for marshmallow latest release
fix __ getattr __ lazy import

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
