### PR TITLE
Fix/save exception raised by resource hooks to step_results

### DIFF
--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -224,9 +224,6 @@ class MultiTestConfig(testing_base.TestConfig):
                     and tup[1] > 1,
                 ),
             ),
-            config.ConfigOption("multi_part_uid", default=None): Or(
-                None, lambda x: callable(x)
-            ),
             config.ConfigOption("fix_spec_path", default=None): Or(
                 None, And(str, os.path.exists)
             ),
@@ -261,9 +258,6 @@ class MultiTest(testing_base.Test):
     :param part: Execute only a part of the total testcases. MultiTest needs to
         know which part of the total it is. Only works with Multitest.
     :type part: ``tuple`` of (``int``, ``int``)
-    :param multi_part_uid: Custom function to overwrite the uid of test entity
-        if `part` attribute is defined, otherwise use default implementation.
-    :type multi_part_uid: ``callable``
     :type result: :py:class:`~testplan.testing.multitest.result.result.Result`
     :param fix_spec_path: Path of fix specification file.
     :type fix_spec_path: ``NoneType`` or ``str``.
@@ -296,7 +290,6 @@ class MultiTest(testing_base.Test):
         thread_pool_size=0,
         max_thread_pool_size=10,
         part=None,
-        multi_part_uid=None,
         before_start=None,
         after_start=None,
         before_stop=None,
@@ -345,12 +338,8 @@ class MultiTest(testing_base.Test):
         A Multitest part instance should not have the same uid as its name.
         """
         if self.cfg.part:
-            return (
-                self.cfg.multi_part_uid(self.cfg.name, self.cfg.part)
-                if self.cfg.multi_part_uid
-                else TEST_PART_PATTERN_FORMAT_STRING.format(
-                    self.cfg.name, self.cfg.part[0], self.cfg.part[1]
-                )
+            return TEST_PART_PATTERN_FORMAT_STRING.format(
+                self.cfg.name, self.cfg.part[0], self.cfg.part[1]
             )
         else:
             return self.cfg.name
@@ -529,7 +518,7 @@ class MultiTest(testing_base.Test):
         self,
         testsuite_pattern: str = "*",
         testcase_pattern: str = "*",
-        shallow_report: Dict = None,
+        shallow_report: Optional[Dict] = None,
     ) -> Generator:
         """
         Run all testcases and yield testcase reports.

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -303,6 +303,14 @@ class MultiTest(testing_base.Test):
     ):
         self._tags_index = None
 
+        if "multi_part_uid" in options:
+            # might be replaced by multi_part_name_func
+            warnings.warn(
+                "MultiTest uid can no longer be customised, please remove ``multi_part_uid`` argument.",
+                DeprecationWarning,
+            )
+            del options["multi_part_uid"]
+
         options.update(self.filter_locals(locals()))
         super(MultiTest, self).__init__(**options)
 

--- a/testplan/testing/py_test.py
+++ b/testplan/testing/py_test.py
@@ -27,7 +27,7 @@ from testplan.testing.multitest.entries.schemas.base import (
 from testplan.testing.multitest.entries.stdout.base import (
     registry as stdout_registry,
 )
-from testplan.testing.result import Result as MultiTestResult
+from testplan.testing.result import Result
 
 # Regex for parsing suite and case name and case parameters
 _CASE_REGEX = re.compile(
@@ -49,9 +49,9 @@ class PyTestConfig(testing.TestConfig):
             "target": Or(str, [str]),
             ConfigOption("select", default=""): str,
             ConfigOption("extra_args", default=None): Or([str], None),
-            ConfigOption(
-                "result", default=MultiTestResult
-            ): validation.is_subclass(MultiTestResult),
+            ConfigOption("result", default=Result): validation.is_subclass(
+                Result
+            ),
         }
 
 
@@ -85,7 +85,7 @@ class PyTest(testing.Test):
         description=None,
         select="",
         extra_args=None,
-        result=MultiTestResult,
+        result=Result,
         **options
     ):
         options.update(self.filter_locals(locals()))

--- a/tests/functional/testplan/testing/multitest/test_error_handler_hook.py
+++ b/tests/functional/testplan/testing/multitest/test_error_handler_hook.py
@@ -157,6 +157,7 @@ def test_multitest_hook_failure(mockplan):
             TestGroupReport(
                 name="MyMultitest",
                 category=ReportCategories.MULTITEST,
+                status_override=Status.ERROR,
                 entries=[
                     TestGroupReport(
                         name="Environment Start",

--- a/tests/functional/testplan/testing/multitest/test_multitest_parts.py
+++ b/tests/functional/testplan/testing/multitest/test_multitest_parts.py
@@ -1,3 +1,4 @@
+import re
 from itertools import chain, cycle, repeat
 from operator import eq
 
@@ -159,7 +160,7 @@ def test_multi_parts_incorrect_schedule():
     )
 
 
-def test_multi_parts_duplicate_part():
+def test_multi_parts_duplicate_part(mocker):
     """
     Execute MultiTest parts with a part of MultiTest has been
     scheduled twice and automatically be filtered out.
@@ -167,6 +168,7 @@ def test_multi_parts_duplicate_part():
     since multi_part_uid has no functional effect now, original test is invalid
     preserved for simple backward compatibility test, i.e. no exception raised
     """
+    mock_warn = mocker.patch("warnings.warn")
     plan = TestplanMock(name="plan", merge_scheduled_parts=True)
     pool = ThreadPool(name="MyThreadPool", size=2)
     plan.add_resource(pool)
@@ -179,6 +181,8 @@ def test_multi_parts_duplicate_part():
         task = Task(target=get_mtest_with_custom_uid(part_tuple=(1, 3)))
         plan.schedule(task, resource="MyThreadPool")
 
+    assert mock_warn.call_count == 4
+    assert re.search(r"remove.*multi_part_uid", mock_warn.call_args[0][0])
     assert len(plan._tests) == 3
     assert plan.run().run is True
 

--- a/tests/functional/testplan/testing/multitest/test_pre_post_steps.py
+++ b/tests/functional/testplan/testing/multitest/test_pre_post_steps.py
@@ -200,3 +200,20 @@ def test_no_pre_post_steps(mockplan):
     )
 
     check_report(expected_report, mockplan.report)
+
+
+def test_before_start_error_skip_remaining(mockplan):
+    multitest = MultiTest(
+        name="MyMultiTest",
+        suites=[MySuite()],
+        before_start=lambda env: 1 / 0,
+    )
+    mockplan.add(multitest)
+    mockplan.run()
+
+    mt_rpt = mockplan.report.entries[0]
+    # only before start report exists
+    assert len(mt_rpt.entries) == 1
+    assert mt_rpt.entries[0].entries[0].status == Status.ERROR
+    assert len(mt_rpt.entries[0].entries[0].logs) == 1
+    assert mt_rpt.entries[0].entries[0].logs[0]["levelname"] == "ERROR"


### PR DESCRIPTION
## Bug / Requirement Description
step_results wasn't correctly set in a previous refactor, resulting in unexpected steps being executed

## Solution description
see code

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
