### PR TITLE
fix flaky test where logmatcher timeout before read to EOF

### DIFF
--- a/tests/functional/testplan/runners/fixtures/assertions_passing/report.py
+++ b/tests/functional/testplan/runners/fixtures/assertions_passing/report.py
@@ -990,7 +990,7 @@ expected_report = TestReport(
                                     "type": "LogfileMatch",
                                     "description": None,
                                     "passed": True,
-                                    "timeout": 0.1,
+                                    "timeout": 1,
                                     "results": [
                                         {
                                             "matched": "lime juice",
@@ -1007,7 +1007,7 @@ expected_report = TestReport(
                                     "type": "LogfileMatch",
                                     "description": None,
                                     "passed": True,
-                                    "timeout": 0.1,
+                                    "timeout": 1,
                                     "results": [
                                         {
                                             "matched": "ginger beer",

--- a/tests/functional/testplan/runners/fixtures/assertions_passing/suites.py
+++ b/tests/functional/testplan/runners/fixtures/assertions_passing/suites.py
@@ -532,9 +532,9 @@ class MySuite:
             f.write("vodka\n")
             f.write("lime juice\n")
             f.flush()
-            result.logfile.match(lm, r"lime juice", timeout=0.1)
+            result.logfile.match(lm, r"lime juice", timeout=1)
             result.logfile.seek_eof(lm)
-            with result.logfile.expect(lm, r"ginger beer", timeout=0.1):
+            with result.logfile.expect(lm, r"ginger beer", timeout=1):
                 f.write("ginger beer\n")
                 f.flush()
         finally:


### PR DESCRIPTION
## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
