### PR TITLE
remove redundant _prepare_regexp

### DIFF
--- a/testplan/common/utils/comparison.py
+++ b/testplan/common/utils/comparison.py
@@ -14,7 +14,9 @@ def is_regex(obj):
     """
     Cannot do type check against SRE_Pattern, so we use duck typing.
     """
-    return hasattr(obj, "match") and hasattr(obj, "pattern")
+    import re
+
+    return isinstance(obj, re.Pattern)
 
 
 def basic_compare(first, second, strict=False):

--- a/testplan/common/utils/match.py
+++ b/testplan/common/utils/match.py
@@ -196,6 +196,8 @@ class LogMatcher(logger.Loggable):
 
         if isinstance(regexp, (str, bytes)):
             regexp = re.compile(regexp)
+        elif isinstance(regexp, re.Pattern):
+            pass
         else:
             try:
                 import rpyc
@@ -278,7 +280,6 @@ class LogMatcher(logger.Loggable):
         match = None
         start_time = time.time()
         end_time = start_time + timeout
-        regex = self._prepare_regexp(regex)
 
         with closing(self.log_stream) as log:
             log.seek(self.position)
@@ -301,11 +302,10 @@ class LogMatcher(logger.Loggable):
                     if match:
                         break
                 elif timeout > 0:
+                    if time.time() > end_time:
+                        break
                     time.sleep(LOG_MATCHER_INTERVAL)
                 else:
-                    break
-
-                if timeout > 0 and time.time() > end_time:
                     break
 
             self.position = self.log_stream.position

--- a/tests/functional/testplan/runners/fixtures/assertions_passing/report.py
+++ b/tests/functional/testplan/runners/fixtures/assertions_passing/report.py
@@ -990,7 +990,7 @@ expected_report = TestReport(
                                     "type": "LogfileMatch",
                                     "description": None,
                                     "passed": True,
-                                    "timeout": 1,
+                                    "timeout": 0.1,
                                     "results": [
                                         {
                                             "matched": "lime juice",
@@ -1007,7 +1007,7 @@ expected_report = TestReport(
                                     "type": "LogfileMatch",
                                     "description": None,
                                     "passed": True,
-                                    "timeout": 1,
+                                    "timeout": 0.1,
                                     "results": [
                                         {
                                             "matched": "ginger beer",

--- a/tests/functional/testplan/runners/fixtures/assertions_passing/suites.py
+++ b/tests/functional/testplan/runners/fixtures/assertions_passing/suites.py
@@ -532,9 +532,9 @@ class MySuite:
             f.write("vodka\n")
             f.write("lime juice\n")
             f.flush()
-            result.logfile.match(lm, r"lime juice", timeout=1)
+            result.logfile.match(lm, r"lime juice", timeout=0.1)
             result.logfile.seek_eof(lm)
-            with result.logfile.expect(lm, r"ginger beer", timeout=1):
+            with result.logfile.expect(lm, r"ginger beer", timeout=0.1):
                 f.write("ginger beer\n")
                 f.flush()
         finally:


### PR DESCRIPTION
change is_regex implementation
logmatcher.match to read til EOF if there are more immediate lines regardless of timeout

## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
