### PR TITLE
Change minimum Python version to 3.10

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.7"
+    python: "3.10"
   jobs:
     post_checkout:
       - git fetch --unshallow || true

--- a/doc/en/conf.py
+++ b/doc/en/conf.py
@@ -39,6 +39,11 @@ def generate_news():
 
 
 def setup(app):
-    app.add_stylesheet("icon.css")
-    app.add_stylesheet("news.css")
+    try:
+        app.add_css_file("icon.css")
+        app.add_css_file("news.css")
+    except AttributeError:
+        app.add_stylesheet("icon.css")
+        app.add_stylesheet("news.css")
+
     generate_news()

--- a/doc/en/getting_started.rst
+++ b/doc/en/getting_started.rst
@@ -9,7 +9,7 @@ in your local environment!
 Supported Python Versions
 =========================
 
-Testplan is tested to work with Python 3.7 and 3.8, 3.10 and 3.11 so we recommend choosing one of those.
+Testplan is tested to work with Python 3.10 and 3.11 so we recommend choosing one of those.
 
 .. _install_testplan:
 
@@ -22,7 +22,7 @@ Install from archive:
   
     .. code-block:: bash
 
-      python3.7 -m pip install https://github.com/morganstanley/testplan/releases/download/latest/testplan-21.9.29-py3-none-any.whl
+      python3.10 -m pip install https://github.com/morganstanley/testplan/releases/download/24.9.2/testplan-24.9.2-py3-none-any.whl
       
 
 Run testplan
@@ -76,8 +76,8 @@ Also find all our downloadable examples :ref:`here <download>`.
 
 Working with the source
 -----------------------
-
-You will need a working python 3.7+ interrpreter preferably a venv, and for the interactive ui you need node installed. 
+ 
+You will need a working python 3.10+ interpreter preferably a venv, and for the interactive ui you need node installed. 
 We are using `doit <https://pydoit.org/contents.html>`_ as the taskrunner ``doit list`` can show all the commands.
 
   .. code-block:: text

--- a/doc/en/unittests.rst
+++ b/doc/en/unittests.rst
@@ -42,7 +42,7 @@ Python - unittest
 =================
 
 ``unittest`` is the unit-testing framework built into the Python standard library,
-see https://docs.python.org/3.7/library/unittest.html for more information.
+see https://docs.python.org/3/library/unittest.html for more information.
 ``unittest`` testcases may be integrated with Testplan via the :py:class:`~testplan.testing.pyunit.PyUnit`
 test runner. Example can be found :ref:`here <example_pyunit>`.
 

--- a/examples/PyUnit/test_plan.py
+++ b/examples/PyUnit/test_plan.py
@@ -29,7 +29,7 @@ class TestAlpha(unittest.TestCase):
     """
     Minimal PyUnit testcase with a single trivial test method. For more
     information about the unittest library, see the [documentation](
-    http://docs.python.org/2/library/unittest.html).
+    http://docs.python.org/3/library/unittest.html).
     """
 
     def test_example(self):
@@ -42,7 +42,7 @@ class TestBeta(unittest.TestCase):
     """
     Minimal PyUnit testcase with a single trivial test method. For more
     information about the unittest library, see the [documentation](
-    http://docs.python.org/2/library/unittest.html).
+    http://docs.python.org/3/library/unittest.html).
     """
 
     def test_fails(self):

--- a/testplan/testing/filtering.py
+++ b/testplan/testing/filtering.py
@@ -268,7 +268,7 @@ class Pattern(Filter):
     """
     Base class for name based, glob style filtering.
 
-    https://docs.python.org/3.4/library/fnmatch.html
+    https://docs.python.org/3/library/fnmatch.html
 
     Examples:
 

--- a/tests/unit/testplan/testing/test_pyunit.py
+++ b/tests/unit/testplan/testing/test_pyunit.py
@@ -23,7 +23,7 @@ class Passing(unittest.TestCase):
     """
     Minimal PyUnit testcase with a single trivial test method. For more
     information about the unittest library, see the [documentation](
-    http://docs.python.org/2/library/unittest.html).
+    http://docs.python.org/3/library/unittest.html).
     """
 
     def test_asserts(self):


### PR DESCRIPTION
## Bug / Requirement Description
Drop support for py 3.7 and 3.8, minimum version is 3.10+.

## Solution description
Changed documentation and config files.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
