### PR TITLE
Fix/some rework on remote service & remote resource

### DIFF
--- a/doc/newsfragments/3193_changed.adjust_remote_service.rst
+++ b/doc/newsfragments/3193_changed.adjust_remote_service.rst
@@ -1,0 +1,1 @@
+Improve error logging for :py:class:`~testplan.common.remote.remote_service.RemoteService`; fix incorrect imitated workspace on remote due to leftover symlink from previous run.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,8 @@
         "gherkin-official==4.1.3",
         "parse",
         "orjson; python_version>='3.8'",
-        "flask-orjson; python_version>='3.8'"
+        "flask-orjson; python_version>='3.8'",
+        "exceptiongroup"
     ]
     requires-python = ">=3.7"
 

--- a/testplan/common/remote/remote_driver.py
+++ b/testplan/common/remote/remote_driver.py
@@ -12,20 +12,38 @@ class RemoteDriver:
 
     def __init__(self, remote_service, driver_cls, **options):
 
-        self.__dict__["rpyc_connection"] = remote_service.rpyc_connection
-        self.__dict__["_driver_cls"] = getattr(
-            self.rpyc_connection.modules[driver_cls.__module__],
-            driver_cls.__name__,
-        )
+        self.__dict__["_remote_service"] = remote_service
+        self.__dict__["_driver_cls"] = driver_cls
+        self.__dict__["_options"] = options
+        self.__dict__["_handle"] = None
 
-        options["runpath"] = "/".join(
-            [remote_service._remote_resource_runpath, options["name"]]
+    def _init_handle(self):
+        rmt_driver_cls = getattr(
+            self._remote_service.rpyc_connection.modules[
+                self._driver_cls.__module__
+            ],
+            self._driver_cls.__name__,
         )
+        self._options["runpath"] = "/".join(
+            [
+                self._remote_service._remote_resource_runpath,
+                self._options["name"],
+            ]
+        )
+        self.__dict__["_handle"] = rmt_driver_cls(**self._options)
 
-        self.__dict__["_handle"] = self._driver_cls(**options)
+    def uid(self) -> str:
+        # driver uid needed in env constructing check
+        # whether remote or local, uid should be the same since it's cfg based
+        # XXX: would it be a bad idea to have it inited locally?
+        return self._driver_cls(**self._options).uid()
 
     def __getattr__(self, name):
+        if self._handle is None:
+            self._init_handle()
         return getattr(self._handle, name)
 
     def __setattr__(self, name, value):
+        if self._handle is None:
+            self._init_handle()
         setattr(self._handle, name, value)

--- a/testplan/common/remote/remote_resource.py
+++ b/testplan/common/remote/remote_resource.py
@@ -167,10 +167,10 @@ class RemoteResource(Entity):
             "host": self.cfg.remote_host,
             "port": self.cfg.ssh_port,
         }
-        if 0 != self._execute_cmd_remote("uname"):
-            raise NotImplementedError(
-                "RemoteResource not supported on Windows remote hosts."
-            )
+        # if 0 != self._execute_cmd_remote("uname"):
+        #     raise NotImplementedError(
+        #         "RemoteResource not supported on Windows remote hosts."
+        #     )
 
         self._remote_plan_runpath = None
         self._remote_resource_runpath = None

--- a/testplan/common/remote/remote_resource.py
+++ b/testplan/common/remote/remote_resource.py
@@ -439,25 +439,29 @@ class RemoteResource(Entity):
                 self,
                 self.ssh_cfg["host"],
             )
-            r, w = os.pipe()
             rmt_non_existing = None
-            if 0 == self._execute_cmd_remote(
-                cmd="/bin/bash -c "
-                + shlex.quote(
-                    'e=""; for i in '
-                    + " ".join(
-                        map(
-                            shlex.quote,
-                            self._workspace_paths.local.split(os.sep)[1:],
-                        )
-                    )
-                    + '; do e+="/${i}"; if [ ! -e "$e" ]; then echo "$e"; break; fi; done'
-                ),
-                label="imitate local workspace path on remote - detect non-existing",
-                stdout=os.fdopen(w),
-                check=False,  # XXX: bash might not be there
-            ):
-                rmt_non_existing = os.fdopen(r).read().strip() or None
+            # TODO: uncomment later
+            # TODO: there is another issue related to created dir cleanup
+            # TODO: if push given, pushed files under created dir and delete_pushed
+            # TODO: set to False, what to do?
+            # r, w = os.pipe()
+            # if 0 == self._execute_cmd_remote(
+            #     cmd="/bin/bash -c "
+            #     + shlex.quote(
+            #         'e=""; for i in '
+            #         + " ".join(
+            #             map(
+            #                 shlex.quote,
+            #                 self._workspace_paths.local.split(os.sep)[1:],
+            #             )
+            #         )
+            #         + '; do e+="/${i}"; if [ ! -e "$e" ]; then echo "$e"; break; fi; done'
+            #     ),
+            #     label="imitate local workspace path on remote - detect non-existing",
+            #     stdout=os.fdopen(w),
+            #     check=False,  # XXX: bash might not be there
+            # ):
+            #     rmt_non_existing = os.fdopen(r).read().strip() or None
             if 0 == self._execute_cmd_remote(
                 cmd=mkdir_cmd(os.path.dirname(self._workspace_paths.local)),
                 label="imitate local workspace path on remote - mkdir",
@@ -662,11 +666,10 @@ class RemoteResource(Entity):
             )
 
             if self._dangling_remote_fs_obj:
-                # TODO: uncomment later
-                # self._execute_cmd_remote(
-                #     cmd=rm_cmd(self._dangling_remote_fs_obj),
-                #     label=f"Remove imitated workspace outside runpath",
-                # )
+                self._execute_cmd_remote(
+                    cmd=rm_cmd(self._dangling_remote_fs_obj),
+                    label=f"Remove imitated workspace outside runpath",
+                )
                 self._dangling_remote_fs_obj = None
 
         if self.cfg.delete_pushed:

--- a/testplan/common/remote/remote_resource.py
+++ b/testplan/common/remote/remote_resource.py
@@ -471,6 +471,14 @@ class RemoteResource(Entity):
                 check=False,  # just best effort
             ):
                 self._dangling_remote_fs_obj = rmt_non_existing
+                if rmt_non_existing:
+                    self.logger.info(
+                        "%s: on %s, %s and its possible descendants are "
+                        "created to imitate local workspace path",
+                        self,
+                        self.ssh_cfg["host"],
+                        rmt_non_existing,
+                    )
 
     def _push_files(self) -> None:
         """Push files and directories to remote host."""

--- a/testplan/common/remote/remote_resource.py
+++ b/testplan/common/remote/remote_resource.py
@@ -169,7 +169,7 @@ class RemoteResource(Entity):
         }
         if 0 != self._execute_cmd_remote("uname"):
             raise NotImplementedError(
-                "RemoteResource not supported on Windows hosts."
+                "RemoteResource not supported on Windows remote hosts."
             )
 
         self._remote_plan_runpath = None
@@ -470,15 +470,17 @@ class RemoteResource(Entity):
                 label="imitate local workspace path on remote - ln",
                 check=False,  # just best effort
             ):
-                self._dangling_remote_fs_obj = rmt_non_existing
-                if rmt_non_existing:
-                    self.logger.info(
-                        "%s: on %s, %s and its possible descendants are "
-                        "created to imitate local workspace path",
-                        self,
-                        self.ssh_cfg["host"],
-                        rmt_non_existing,
-                    )
+                # NOTE: we shall always remove created symlink
+                self._dangling_remote_fs_obj = (
+                    rmt_non_existing or self._workspace_paths.local
+                )
+                self.logger.info(
+                    "%s: on %s, %s and its possible descendants are "
+                    "created to imitate local workspace path",
+                    self,
+                    self.ssh_cfg["host"],
+                    self._dangling_remote_fs_obj,
+                )
 
     def _push_files(self) -> None:
         """Push files and directories to remote host."""
@@ -660,10 +662,11 @@ class RemoteResource(Entity):
             )
 
             if self._dangling_remote_fs_obj:
-                self._execute_cmd_remote(
-                    cmd=rm_cmd(self._dangling_remote_fs_obj),
-                    label=f"Remove imitated workspace outside runpath",
-                )
+                # TODO: uncomment later
+                # self._execute_cmd_remote(
+                #     cmd=rm_cmd(self._dangling_remote_fs_obj),
+                #     label=f"Remove imitated workspace outside runpath",
+                # )
                 self._dangling_remote_fs_obj = None
 
         if self.cfg.delete_pushed:

--- a/testplan/common/remote/remote_service.py
+++ b/testplan/common/remote/remote_service.py
@@ -244,10 +244,10 @@ class RemoteService(Resource, RemoteResource):
             self.rpyc_connection.modules.os.kill(self.rpyc_pid, signal.SIGTERM)
         except EOFError:
             pass
-
-        # actually if remote rpyc server is shutdown, ssh proc is also finished
-        # but calling kill_process just in case
-        if self.proc:
-            kill_process(self.proc, self.cfg.stop_timeout)
+        finally:
+            # if remote rpyc server is shutdown successfully, ssh proc is also finished
+            # otherwise we need to manual kill this orphaned ssh procc
+            if self.proc:
+                kill_process(self.proc, self.cfg.stop_timeout)
 
         self.status.change(self.STATUS.STOPPED)

--- a/testplan/common/remote/remote_service.py
+++ b/testplan/common/remote/remote_service.py
@@ -240,9 +240,8 @@ class RemoteService(Resource, RemoteResource):
         """
         Stops remote rpyc process.
         """
-        remote_pid = self.rpyc_connection.modules.os.getpid()
         try:
-            self.rpyc_connection.modules.os.kill(remote_pid, signal.SIGTERM)
+            self.rpyc_connection.modules.os.kill(self.rpyc_pid, signal.SIGTERM)
         except EOFError:
             pass
 

--- a/testplan/common/utils/path.py
+++ b/testplan/common/utils/path.py
@@ -254,7 +254,7 @@ def rebase_path(path, old_base, new_base):
     """
 
     rel_path = os.path.relpath(path, old_base).split(os.sep)
-    return "/".join([new_base] + rel_path)
+    return os.path.join(new_base, *rel_path)
 
 
 def is_subdir(child, parent):

--- a/testplan/common/utils/remote.py
+++ b/testplan/common/utils/remote.py
@@ -1,11 +1,12 @@
 """Remote execution utilities."""
 
+import getpass
 import os
 import platform
+import shlex
 import socket
-import sys
-import getpass
 import subprocess
+import sys
 
 IS_WIN = platform.system() == "Windows"
 USER = getpass.getuser()
@@ -119,19 +120,19 @@ def copy_cmd(source, target, exclude=None, port=None, deref_links=False):
 
 def link_cmd(path, link):
     """Returns link creation command."""
-    return " ".join(["ln", "-sfn", path, link])
+    return " ".join(["/bin/ln", "-sfn", shlex.quote(path), shlex.quote(link)])
 
 
 def mkdir_cmd(path):
     """Return mkdir command"""
-    return " ".join(["/bin/mkdir", "-p", path])
+    return " ".join(["/bin/mkdir", "-p", shlex.quote(path)])
 
 
 def rm_cmd(path):
     """Return rm command"""
-    return " ".join(["/bin/rm", "-rf", path])
+    return " ".join(["/bin/rm", "-rf", shlex.quote(path)])
 
 
 def filepath_exist_cmd(path):
     """Checks if filepath exists."""
-    return " ".join(["test", "-e", path])
+    return " ".join(["/bin/test", "-e", shlex.quote(path)])

--- a/testplan/exporters/testing/json/base.py
+++ b/testplan/exporters/testing/json/base.py
@@ -113,7 +113,7 @@ class JSONExporter(Exporter):
         result = None
         json_path = pathlib.Path(self.cfg.json_path).resolve()
 
-        if len(source):
+        if not source.is_empty():
             json_path.parent.mkdir(parents=True, exist_ok=True)
 
             test_plan_schema = TestReportSchema()

--- a/testplan/exporters/testing/pdf/__init__.py
+++ b/testplan/exporters/testing/pdf/__init__.py
@@ -250,7 +250,7 @@ class PDFExporter(Exporter):
             exporter=self, export_context=export_context
         )
         result = None
-        if len(source):
+        if not source.is_empty():
             pdf_path = self.create_pdf(source)
             self.logger.user_info("PDF generated at %s", pdf_path)
 

--- a/testplan/exporters/testing/webserver/base.py
+++ b/testplan/exporters/testing/webserver/base.py
@@ -87,7 +87,7 @@ class WebServerExporter(Exporter):
             exporter=self, export_context=export_context
         )
         result = None
-        if len(source):
+        if not source.is_empty():
             exporter = JSONExporter(
                 json_path=self.cfg.json_path, split_json_report=False
             )

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -5,6 +5,7 @@ import os
 import random
 import re
 import time
+import traceback
 import uuid
 import webbrowser
 from collections import OrderedDict
@@ -25,6 +26,7 @@ from typing import (
     Union,
 )
 
+import exceptiongroup
 from schema import And, Or, Use
 from testplan import defaults
 from testplan.common.config import ConfigOption
@@ -581,11 +583,53 @@ class TestRunner(Runnable):
         remote_service.parent = self
         remote_service.cfg.parent = self.cfg
         self.remote_services[name] = remote_service
-        remote_service.start()
+
+    def skip_step(self, step):
+        if isinstance(
+            self.result.step_results.get("_start_remote_services", None),
+            Exception,
+        ):
+            if step in (
+                self._pre_exporters,
+                self._invoke_exporters,
+                self._post_exporters,
+                self._stop_remote_services,
+            ):
+                return False
+            return True
+        return False
+
+    def _start_remote_services(self):
+        for rmt_svc in self.remote_services.values():
+            try:
+                rmt_svc.start()
+            except Exception as e:
+                msg = traceback.format_exc()
+                self.logger.error(msg)
+                self.report.logger.error(msg)
+                self.report.status_override = Status.ERROR
+                # skip the rest, set step return value
+                return e
 
     def _stop_remote_services(self):
+        es = []
         for rmt_svc in self.remote_services.values():
-            rmt_svc.stop()
+            try:
+                rmt_svc.stop()
+            except Exception as e:
+                msg = traceback.format_exc()
+                self.logger.error(msg)
+                # NOTE: rmt svc cannot be closed before report export due to
+                # NOTE: rmt ref being used during report export, it's
+                # NOTE: meaningless to update report obj here
+                self.report.status_override = Status.ERROR
+                es.append(e)
+        if es:
+            if len(es) > 1:
+                return exceptiongroup.ExceptionGroup(
+                    "multiple remote services failed to stop", es
+                )
+            return es[0]
 
     def _clone_task_for_part(self, task_info, _task_arguments, part):
         _task_arguments["part"] = part
@@ -1120,6 +1164,7 @@ class TestRunner(Runnable):
         """Runnable steps to be executed before resources started."""
         self._add_step(self.timer.start, "run")
         super(TestRunner, self).add_pre_resource_steps()
+        self._add_step(self._start_remote_services)
         self._add_step(self.make_runpath_dirs)
         self._add_step(self._configure_file_logger)
         self._add_step(self.calculate_pool_size)
@@ -1460,6 +1505,8 @@ class TestRunner(Runnable):
         """Stop the web server if it is running."""
         if self._web_server_thread is not None:
             self._web_server_thread.stop()
+        # XXX: to be refactored after aborting logic implemented for rmt svcs
+        self._stop_remote_services()
         self._stop_resource_monitor()
         self._close_file_logger()
 

--- a/testplan/runners/pools/remote.py
+++ b/testplan/runners/pools/remote.py
@@ -16,7 +16,7 @@ from testplan.common.remote.remote_resource import (
     UnboundRemoteResourceConfig,
 )
 from testplan.common.utils.logger import TESTPLAN_LOGGER
-from testplan.common.utils.path import rebase_path
+from testplan.common.utils.path import fix_home_prefix, rebase_path
 from testplan.common.utils.remote import copy_cmd, ssh_cmd
 from testplan.common.utils.timing import get_sleeper, wait
 
@@ -80,7 +80,7 @@ class RemoteWorker(ProcessWorker, RemoteResource):
 
     def _set_child_script(self) -> None:
         """Specify the remote worker executable file."""
-        self._child_paths.local = self._child_path()
+        self._child_paths.local = fix_home_prefix(self._child_path())
         self._child_paths.remote = rebase_path(
             self._child_paths.local,
             self._testplan_import_path.local,

--- a/testplan/testing/environment/graph.py
+++ b/testplan/testing/environment/graph.py
@@ -119,7 +119,7 @@ def parse_dependency(input: dict) -> DriverDepGraph:
             isinstance(k, (Driver, RemoteDriver))
             or (
                 isinstance(k, Iterable)
-                and all(isinstance(x, Driver) for x in k)
+                and all(isinstance(x, (Driver, RemoteDriver)) for x in k)
             )
         ):
             raise _type_err(


### PR DESCRIPTION
## Bug / Requirement Description

TODO

## Solution description

- turn remote service start into steps, thus delay remote driver construction on remote host
- fix certain remote cmd gen utils
- explicitly disallow remote resource usage if remote hosts being windows
- fix empty report check in certain exporters
- add cleanup for dangling symlink/dir due to workspace imitation on remote host, rearrange some source in remote resource as well
- fix a bug in driver dep graph type check

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
