### PR TITLE
Set execute permission bit for copied App binary

### DIFF
--- a/doc/newsfragments/3234_changed.fix_app_binary_permissions.rst
+++ b/doc/newsfragments/3234_changed.fix_app_binary_permissions.rst
@@ -1,0 +1,1 @@
+Copy permission bits for the copied binary in App.

--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -300,6 +300,7 @@ class App(Driver):
 
             if self.cfg.binary_strategy == "copy":
                 shutil.copyfile(self.resolved_bin, target)
+                shutil.copymode(self.resolved_bin, target)
                 self._binary = target
             elif self.cfg.binary_strategy == "link" and not IS_WIN:
                 os.symlink(os.path.abspath(self.resolved_bin), target)


### PR DESCRIPTION
## Bug / Requirement Description
When copying the binary in App.binary, the permission bits don't get copied. A missing execution permission bit leads to failure to start the driver.

## Solution description
Use `shutil.copymode` to set the permission bits identical to the source binary.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
