### PR TITLE
Fix/compatibility issue when tpsreport handling old format report

### DIFF
--- a/testplan/common/report/schemas.py
+++ b/testplan/common/report/schemas.py
@@ -91,6 +91,18 @@ class ReportLogSchema(Schema):
     lineno = fields.Integer()
     uid = fields.UUID()
 
+    @pre_load
+    def accept_old_isoformat(self, data, **kwargs):
+        try:
+            if data.get("created", None) and isinstance(data["created"], str):
+                data["created"] = datetime.datetime.fromisoformat(
+                    data["created"]
+                ).timestamp()
+            return data
+        except ValueError as e:
+            # no need to defer
+            raise ValueError("Invalid value when loading Interval.") from e
+
 
 class ReportSchema(schemas.TreeNodeSchema):
     """Schema for ``base.Report``."""

--- a/testplan/common/serialization/fields.py
+++ b/testplan/common/serialization/fields.py
@@ -214,6 +214,9 @@ class RowComparisonField(fields.Field):
 class SliceComparisonField(fields.Field):
     """Serialization logic for SliceComparison"""
 
+    # TODO: strip actual & expected to save more space, as these value could
+    # TODO: be retrieved from context
+
     def _serialize(self, value, attr, obj, **kwargs):
         def str_or_iterable(val):
             return val if isinstance(val, str) else native_or_pformat_list(val)

--- a/testplan/exporters/testing/pdf/renderers/entries/assertions.py
+++ b/testplan/exporters/testing/pdf/renderers/entries/assertions.py
@@ -378,17 +378,18 @@ def append_comparison_data(data, row, depth, start_idx):
     """TODO."""
     offset, key, match, left, right = row
 
-    if match == "p":
+    # NOTE: "Passed" etc. for compatibility with old assertion structure
+    if match in ("p", "Passed"):
         match = "Passed"
         item_color = colors.black
         status_color = colors.green
         font = const.FONT
-    elif match == "f":
+    elif match in ("f", "Failed"):
         match = "Failed"
         item_color = colors.black
         status_color = colors.red
         font = const.FONT_BOLD
-    elif match == "i":
+    elif match in ("i", "Ignored"):
         match = "Ignored"
         item_color = colors.grey
         status_color = colors.grey
@@ -422,7 +423,17 @@ class DictMatchRenderer(AssertionRenderer):
     """FixMatch renderer for serialized assertion entries."""
 
     def get_detail(self, source, depth, row_idx):
-        comparison = delta_decode_level(source["comparison"])
+        # NOTE: for compatibility with old assertion structure
+        comparison = (
+            source["comparison"]
+            if all(
+                map(
+                    lambda x: isinstance(x, list) and len(x) == 5,
+                    source["comparison"],
+                )
+            )
+            else delta_decode_level(source["comparison"])
+        )
 
         data = []
         for idx, row in enumerate(comparison):
@@ -500,12 +511,18 @@ class DictMatchAllRenderer(AssertionRenderer):
     """FixMatchAll renderer for serialized assertion entries."""
 
     def get_detail(self, source, depth, row_idx):
-        matches = source["matches"]
+        # NOTE: for compatibility with old assertion structure
+        if source["matches"].get("matches"):
+            matches = source["matches"]["matches"]
+        else:
+            matches = source["matches"]
+            for match in matches:
+                match["comparison"] = delta_decode_level(match["comparison"])
 
         data = []
         counter = 0
         for match in matches:
-            comparison = delta_decode_level(match["comparison"])
+            comparison = match["comparison"]
             description = match["description"]
             passed = match["passed"]
 

--- a/testplan/exporters/testing/pdf/renderers/entries/base.py
+++ b/testplan/exporters/testing/pdf/renderers/entries/base.py
@@ -321,7 +321,16 @@ class DictLogRenderer(SerializedEntryRenderer):
         """
         header = self.get_header(source, depth, row_idx)
         row_idx += 1
-        flattened_dict = delta_decode_level(source["flattened_dict"])
+        flattened_dict = (
+            source["flattened_dict"]
+            if all(
+                map(
+                    lambda x: isinstance(x, list) and len(x) == 3,
+                    source["flattened_dict"],
+                )
+            )
+            else delta_decode_level(source["flattened_dict"])
+        )
 
         if len(flattened_dict) == 0:
             return header + RowData(

--- a/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/__tests__/DictMatchAssertion.test.js
+++ b/testplan/web_ui/testing/src/AssertionPane/AssertionTypes/DictAssertions/__tests__/DictMatchAssertion.test.js
@@ -33,10 +33,10 @@ const newSimpleProps = () => ({
   assertion: {
     actual_description: null,
     comparison: [
-      ["foo", "Passed", ["int", "1"], ["int", "1"]],
-      ["bar", "Failed", ["int", "2"], ["int", "5"]],
-      ["baz", "Ignored", ["int", "2"], ["int", "5"]],
-      ["extra-key", "Failed", [null, "ABSENT"], ["int", "10"]],
+      ["foo", "p", ["int", "1"], ["int", "1"]],
+      ["bar", "f", ["int", "2"], ["int", "5"]],
+      ["baz", "i", ["int", "2"], ["int", "5"]],
+      ["extra-key", "f", [null, "ABSENT"], ["int", "10"]],
     ],
     description: "simple dict match",
     exclude_keys: null,

--- a/tests/functional/testplan/cli/data/curr2.data
+++ b/tests/functional/testplan/cli/data/curr2.data
@@ -1,0 +1,696 @@
+{
+  "type": "TestReport",
+  "name": "Dict Assertions Example",
+  "description": null,
+  "definition_name": "Dict Assertions Example",
+  "uid": "",
+  "entries": [
+    {
+      "type": "TestGroupReport",
+      "name": "Dict Assertions Test",
+      "description": null,
+      "definition_name": "Dict Assertions Test",
+      "uid": "",
+      "entries": [
+        {
+          "type": "TestGroupReport",
+          "name": "DictSuite",
+          "description": "`result.dict` namespace can be used for applying advanced\nassertion rules to dictionaries, which can be nested.",
+          "definition_name": "DictSuite",
+          "uid": "",
+          "entries": [
+            {
+              "type": "TestCaseReport",
+              "name": "test_dict_namespace",
+              "description": null,
+              "definition_name": "test_dict_namespace",
+              "uid": "",
+              "entries": [
+                {
+                  "type": "DictMatch",
+                  "meta_type": "assertion",
+                  "timestamp": 1742279752.403672,
+                  "description": "Simple dict match",
+                  "passed": false,
+                  "include_keys": null,
+                  "exclude_keys": [
+                    "baz_excluded"
+                  ],
+                  "actual_description": null,
+                  "expected_description": null,
+                  "comparison": [
+                    [
+                      "foo",
+                      "p",
+                      [
+                        "int",
+                        1
+                      ],
+                      [
+                        "int",
+                        1
+                      ]
+                    ],
+                    [
+                      "bar",
+                      "f",
+                      [
+                        "int",
+                        2
+                      ],
+                      [
+                        "int",
+                        5
+                      ]
+                    ],
+                    [
+                      "baz_excluded",
+                      "i",
+                      [
+                        "int",
+                        2
+                      ],
+                      [
+                        "int",
+                        5
+                      ]
+                    ],
+                    [
+                      "extra-key",
+                      "f",
+                      [
+                        null,
+                        "ABSENT"
+                      ],
+                      [
+                        "int",
+                        10
+                      ]
+                    ]
+                  ]
+                },
+                {
+                  "type": "DictMatch",
+                  "meta_type": "assertion",
+                  "timestamp": 1742279752.404407,
+                  "description": "Nested dict match",
+                  "passed": false,
+                  "include_keys": null,
+                  "exclude_keys": null,
+                  "actual_description": null,
+                  "expected_description": null,
+                  "comparison": [
+                    [
+                      "foo",
+                      "f",
+                      "",
+                      ""
+                    ],
+                    1,
+                    [
+                      "alpha",
+                      "f",
+                      "",
+                      ""
+                    ],
+                    [
+                      "",
+                      "p",
+                      [
+                        "int",
+                        1
+                      ],
+                      [
+                        "int",
+                        1
+                      ]
+                    ],
+                    [
+                      "",
+                      "p",
+                      [
+                        "int",
+                        2
+                      ],
+                      [
+                        "int",
+                        2
+                      ]
+                    ],
+                    [
+                      "",
+                      "f",
+                      [
+                        "int",
+                        3
+                      ],
+                      [
+                        null,
+                        null
+                      ]
+                    ],
+                    [
+                      "beta",
+                      "f",
+                      "",
+                      ""
+                    ],
+                    1,
+                    [
+                      "color",
+                      "f",
+                      [
+                        "str",
+                        "red"
+                      ],
+                      [
+                        "str",
+                        "blue"
+                      ]
+                    ]
+                  ]
+                },
+                {
+                  "type": "DictMatch",
+                  "meta_type": "assertion",
+                  "timestamp": 1742279752.405666,
+                  "description": "Dict match: Custom comparators",
+                  "passed": true,
+                  "include_keys": null,
+                  "exclude_keys": null,
+                  "actual_description": null,
+                  "expected_description": null,
+                  "comparison": [
+                    [
+                      "foo",
+                      "p",
+                      "",
+                      ""
+                    ],
+                    [
+                      "",
+                      "p",
+                      [
+                        "int",
+                        1
+                      ],
+                      [
+                        "int",
+                        1
+                      ]
+                    ],
+                    [
+                      "",
+                      "p",
+                      [
+                        "int",
+                        2
+                      ],
+                      [
+                        "int",
+                        2
+                      ]
+                    ],
+                    [
+                      "",
+                      "p",
+                      [
+                        "int",
+                        3
+                      ],
+                      [
+                        "func",
+                        "<lambda>"
+                      ]
+                    ],
+                    [
+                      "bar",
+                      "p",
+                      "",
+                      ""
+                    ],
+                    1,
+                    [
+                      "color",
+                      "p",
+                      [
+                        "str",
+                        "blue"
+                      ],
+                      [
+                        "func",
+                        "VAL in ['blue', 'red', 'yellow']"
+                      ]
+                    ],
+                    -1,
+                    [
+                      "baz",
+                      "p",
+                      [
+                        "str",
+                        "hello world"
+                      ],
+                      [
+                        "REGEX",
+                        "\\w+ world"
+                      ]
+                    ]
+                  ]
+                },
+                {
+                  "type": "DictMatch",
+                  "meta_type": "assertion",
+                  "timestamp": 1742279752.406276,
+                  "description": "default assertion passes because the values are numerically equal",
+                  "passed": true,
+                  "include_keys": null,
+                  "exclude_keys": null,
+                  "actual_description": null,
+                  "expected_description": null,
+                  "comparison": [
+                    [
+                      "foo",
+                      "p",
+                      [
+                        "int",
+                        1
+                      ],
+                      [
+                        "float",
+                        1
+                      ]
+                    ],
+                    [
+                      "bar",
+                      "p",
+                      [
+                        "int",
+                        2
+                      ],
+                      [
+                        "float",
+                        2
+                      ]
+                    ],
+                    [
+                      "baz",
+                      "p",
+                      [
+                        "int",
+                        3
+                      ],
+                      [
+                        "float",
+                        3
+                      ]
+                    ]
+                  ]
+                },
+                {
+                  "type": "DictMatch",
+                  "meta_type": "assertion",
+                  "timestamp": 1742279752.406727,
+                  "description": "when we check types the assertion will fail",
+                  "passed": false,
+                  "include_keys": null,
+                  "exclude_keys": null,
+                  "actual_description": null,
+                  "expected_description": null,
+                  "comparison": [
+                    [
+                      "foo",
+                      "f",
+                      [
+                        "int",
+                        1
+                      ],
+                      [
+                        "float",
+                        1
+                      ]
+                    ],
+                    [
+                      "bar",
+                      "f",
+                      [
+                        "int",
+                        2
+                      ],
+                      [
+                        "float",
+                        2
+                      ]
+                    ],
+                    [
+                      "baz",
+                      "f",
+                      [
+                        "int",
+                        3
+                      ],
+                      [
+                        "float",
+                        3
+                      ]
+                    ]
+                  ]
+                },
+                {
+                  "type": "DictMatch",
+                  "meta_type": "assertion",
+                  "timestamp": 1742279752.407155,
+                  "description": "use a custom comparison function to check within a tolerance",
+                  "passed": true,
+                  "include_keys": null,
+                  "exclude_keys": null,
+                  "actual_description": null,
+                  "expected_description": null,
+                  "comparison": [
+                    [
+                      "foo",
+                      "p",
+                      [
+                        "float",
+                        1.02
+                      ],
+                      [
+                        "float",
+                        0.98
+                      ]
+                    ],
+                    [
+                      "bar",
+                      "p",
+                      [
+                        "float",
+                        2.28
+                      ],
+                      [
+                        "float",
+                        2.33
+                      ]
+                    ],
+                    [
+                      "baz",
+                      "p",
+                      [
+                        "float",
+                        3.5
+                      ],
+                      [
+                        "float",
+                        3.46
+                      ]
+                    ]
+                  ]
+                },
+                {
+                  "type": "DictMatch",
+                  "meta_type": "assertion",
+                  "timestamp": 1742279752.407574,
+                  "description": "only report the failing comparison",
+                  "passed": false,
+                  "include_keys": null,
+                  "exclude_keys": null,
+                  "actual_description": null,
+                  "expected_description": null,
+                  "comparison": [
+                    [
+                      "bad_key",
+                      "f",
+                      [
+                        "str",
+                        "actual"
+                      ],
+                      [
+                        "str",
+                        "expected"
+                      ]
+                    ]
+                  ]
+                },
+                {
+                  "type": "DictCheck",
+                  "meta_type": "assertion",
+                  "timestamp": 1742279752.407989,
+                  "description": null,
+                  "passed": false,
+                  "has_keys": [
+                    "foo",
+                    "alpha"
+                  ],
+                  "has_keys_diff": [
+                    "alpha"
+                  ],
+                  "absent_keys": [
+                    "bar",
+                    "beta"
+                  ],
+                  "absent_keys_diff": [
+                    "bar"
+                  ]
+                },
+                {
+                  "type": "DictLog",
+                  "meta_type": "entry",
+                  "timestamp": 1742279752.408453,
+                  "description": null,
+                  "flattened_dict": [
+                    [
+                      "foo",
+                      ""
+                    ],
+                    [
+                      "",
+                      [
+                        "int",
+                        1
+                      ]
+                    ],
+                    [
+                      "",
+                      [
+                        "int",
+                        2
+                      ]
+                    ],
+                    [
+                      "",
+                      [
+                        "int",
+                        3
+                      ]
+                    ],
+                    [
+                      "bar",
+                      ""
+                    ],
+                    1,
+                    [
+                      "color",
+                      [
+                        "str",
+                        "blue"
+                      ]
+                    ],
+                    -1,
+                    [
+                      "baz",
+                      [
+                        "str",
+                        "hello world"
+                      ]
+                    ]
+                  ]
+                }
+              ],
+              "status": "failed",
+              "runtime_status": "finished",
+              "logs": [],
+              "hash": 0,
+              "parent_uids": [
+                "Dict Assertions Example",
+                "Dict Assertions Test",
+                "DictSuite"
+              ],
+              "timer": {
+                "run": [
+                  {
+                    "start": 1742279752.403532,
+                    "end": 1742279752.408835
+                  }
+                ]
+              },
+              "category": "testcase",
+              "counter": {
+                "passed": 0,
+                "failed": 1,
+                "total": 1
+              },
+              "tags": {}
+            }
+          ],
+          "status": "failed",
+          "runtime_status": "finished",
+          "logs": [],
+          "hash": 0,
+          "parent_uids": [
+            "Dict Assertions Example",
+            "Dict Assertions Test"
+          ],
+          "timer": {
+            "run": [
+              {
+                "start": 1742279752.403301,
+                "end": 1742279752.414916
+              }
+            ]
+          },
+          "counter": {
+            "passed": 0,
+            "failed": 1,
+            "total": 1
+          },
+          "children": [],
+          "strict_order": false,
+          "category": "testsuite",
+          "tags": {}
+        }
+      ],
+      "status": "failed",
+      "runtime_status": "finished",
+      "logs": [],
+      "hash": 0,
+      "parent_uids": [
+        "Dict Assertions Example"
+      ],
+      "timer": {
+        "setup": [
+          {
+            "start": 1742279752.347652,
+            "end": 1742279752.397521
+          }
+        ],
+        "run": [
+          {
+            "start": 1742279752.403069,
+            "end": 1742279752.415244
+          }
+        ],
+        "teardown": [
+          {
+            "start": 1742279752.425912,
+            "end": 1742279752.462896
+          }
+        ]
+      },
+      "counter": {
+        "passed": 0,
+        "failed": 1,
+        "total": 1
+      },
+      "children": [],
+      "part": null,
+      "env_status": "STOPPED",
+      "timezone": "Asia/Hong_Kong",
+      "host": null,
+      "category": "multitest",
+      "tags": {}
+    }
+  ],
+  "status": "failed",
+  "runtime_status": "finished",
+  "logs": [],
+  "hash": 0,
+  "parent_uids": [],
+  "timer": {
+    "run": [
+      {
+        "start": 1742279751.978102,
+        "end": 1742279752.827802
+      }
+    ]
+  },
+  "counter": {
+    "passed": 0,
+    "failed": 1,
+    "total": 1
+  },
+  "children": [
+    {
+      "name": "LocalRunner[local_runner]",
+      "timer": {
+        "lifespan": [
+          {
+            "start": 1742279752.322121,
+            "end": 1742279752.675158
+          }
+        ],
+        "setup": [
+          {
+            "start": 1742279752.322386,
+            "end": 1742279752.323062
+          }
+        ],
+        "teardown": [
+          {
+            "start": 1742279752.574896,
+            "end": null
+          }
+        ]
+      },
+      "children": []
+    },
+    {
+      "name": "Environments[environments]",
+      "timer": {
+        "lifespan": [
+          {
+            "start": 1742279752.322838,
+            "end": 1742279752.574817
+          }
+        ],
+        "setup": [
+          {
+            "start": 1742279752.323025,
+            "end": 1742279752.323136
+          }
+        ],
+        "teardown": [
+          {
+            "start": 1742279752.574768,
+            "end": 1742279752.675261
+          }
+        ]
+      },
+      "children": []
+    }
+  ],
+  "category": "testplan",
+  "meta": {},
+  "label": null,
+  "tags_index": {},
+  "information": [
+    [
+      "testplan_version",
+      "25.1.0"
+    ],
+    [
+      "user",
+      "unknown"
+    ],
+    [
+      "command_line_string",
+      "./test_plan_dict.py --json examples_assertion_dict.json"
+    ],
+    [
+      "python_version",
+      "3.12.3"
+    ]
+  ],
+  "resource_meta_path": null,
+  "timezone": "Asia/Hong_Kong",
+  "attachments": {},
+  "timeout": 14400,
+  "version": 1
+}

--- a/tests/functional/testplan/cli/data/old2.data
+++ b/tests/functional/testplan/cli/data/old2.data
@@ -1,0 +1,791 @@
+{
+  "type": "TestReport",
+  "name": "Dict Assertions Example",
+  "description": null,
+  "definition_name": "Dict Assertions Example",
+  "uid": "",
+  "entries": [
+    {
+      "type": "TestGroupReport",
+      "name": "Dict Assertions Test",
+      "description": null,
+      "definition_name": "Dict Assertions Test",
+      "uid": "",
+      "entries": [
+        {
+          "type": "TestGroupReport",
+          "name": "DictSuite",
+          "description": "`result.dict` namespace can be used for applying advanced\nassertion rules to dictionaries, which can be nested.",
+          "definition_name": "DictSuite",
+          "uid": "",
+          "entries": [
+            {
+              "type": "TestCaseReport",
+              "name": "test_dict_namespace",
+              "description": null,
+              "definition_name": "test_dict_namespace",
+              "uid": "",
+              "entries": [
+                {
+                  "utc_time": "2025-03-18T07:16:54.512319+00:00",
+                  "machine_time": "2025-03-18T15:16:54.512326+08:00",
+                  "type": "DictMatch",
+                  "meta_type": "assertion",
+                  "description": "Simple dict match",
+                  "line_no": null,
+                  "category": "DEFAULT",
+                  "flag": "DEFAULT",
+                  "file_path": null,
+                  "code_context": null,
+                  "passed": false,
+                  "include_keys": null,
+                  "exclude_keys": [
+                    "baz_excluded"
+                  ],
+                  "actual_description": null,
+                  "expected_description": null,
+                  "comparison": [
+                    [
+                      0,
+                      "foo",
+                      "Passed",
+                      [
+                        "int",
+                        "1"
+                      ],
+                      [
+                        "int",
+                        "1"
+                      ]
+                    ],
+                    [
+                      0,
+                      "bar",
+                      "Failed",
+                      [
+                        "int",
+                        "2"
+                      ],
+                      [
+                        "int",
+                        "5"
+                      ]
+                    ],
+                    [
+                      0,
+                      "baz_excluded",
+                      "Ignored",
+                      [
+                        "int",
+                        "2"
+                      ],
+                      [
+                        "int",
+                        "5"
+                      ]
+                    ],
+                    [
+                      0,
+                      "extra-key",
+                      "Failed",
+                      [
+                        null,
+                        "ABSENT"
+                      ],
+                      [
+                        "int",
+                        "10"
+                      ]
+                    ]
+                  ]
+                },
+                {
+                  "utc_time": "2025-03-18T07:16:54.513104+00:00",
+                  "machine_time": "2025-03-18T15:16:54.513114+08:00",
+                  "type": "DictMatch",
+                  "meta_type": "assertion",
+                  "description": "Nested dict match",
+                  "line_no": null,
+                  "category": "DEFAULT",
+                  "flag": "DEFAULT",
+                  "file_path": null,
+                  "code_context": null,
+                  "passed": false,
+                  "include_keys": null,
+                  "exclude_keys": null,
+                  "actual_description": null,
+                  "expected_description": null,
+                  "comparison": [
+                    [
+                      0,
+                      "foo",
+                      "Failed",
+                      "",
+                      ""
+                    ],
+                    [
+                      1,
+                      "alpha",
+                      "Failed",
+                      "",
+                      ""
+                    ],
+                    [
+                      1,
+                      "",
+                      "Passed",
+                      [
+                        "int",
+                        "1"
+                      ],
+                      [
+                        "int",
+                        "1"
+                      ]
+                    ],
+                    [
+                      1,
+                      "",
+                      "Passed",
+                      [
+                        "int",
+                        "2"
+                      ],
+                      [
+                        "int",
+                        "2"
+                      ]
+                    ],
+                    [
+                      1,
+                      "",
+                      "Failed",
+                      [
+                        "int",
+                        "3"
+                      ],
+                      [
+                        null,
+                        null
+                      ]
+                    ],
+                    [
+                      1,
+                      "beta",
+                      "Failed",
+                      "",
+                      ""
+                    ],
+                    [
+                      2,
+                      "color",
+                      "Failed",
+                      [
+                        "str",
+                        "red"
+                      ],
+                      [
+                        "str",
+                        "blue"
+                      ]
+                    ]
+                  ]
+                },
+                {
+                  "utc_time": "2025-03-18T07:16:54.514033+00:00",
+                  "machine_time": "2025-03-18T15:16:54.514041+08:00",
+                  "type": "DictMatch",
+                  "meta_type": "assertion",
+                  "description": "Dict match: Custom comparators",
+                  "line_no": null,
+                  "category": "DEFAULT",
+                  "flag": "DEFAULT",
+                  "file_path": null,
+                  "code_context": null,
+                  "passed": true,
+                  "include_keys": null,
+                  "exclude_keys": null,
+                  "actual_description": null,
+                  "expected_description": null,
+                  "comparison": [
+                    [
+                      0,
+                      "foo",
+                      "Passed",
+                      "",
+                      ""
+                    ],
+                    [
+                      0,
+                      "",
+                      "Passed",
+                      [
+                        "int",
+                        "1"
+                      ],
+                      [
+                        "int",
+                        "1"
+                      ]
+                    ],
+                    [
+                      0,
+                      "",
+                      "Passed",
+                      [
+                        "int",
+                        "2"
+                      ],
+                      [
+                        "int",
+                        "2"
+                      ]
+                    ],
+                    [
+                      0,
+                      "",
+                      "Passed",
+                      [
+                        "int",
+                        "3"
+                      ],
+                      [
+                        "func",
+                        "<lambda>"
+                      ]
+                    ],
+                    [
+                      0,
+                      "bar",
+                      "Passed",
+                      "",
+                      ""
+                    ],
+                    [
+                      1,
+                      "color",
+                      "Passed",
+                      [
+                        "str",
+                        "blue"
+                      ],
+                      [
+                        "func",
+                        "VAL in ['blue', 'red', 'yellow']"
+                      ]
+                    ],
+                    [
+                      0,
+                      "baz",
+                      "Passed",
+                      [
+                        "str",
+                        "hello world"
+                      ],
+                      [
+                        "REGEX",
+                        "\\w+ world"
+                      ]
+                    ]
+                  ]
+                },
+                {
+                  "utc_time": "2025-03-18T07:16:54.514557+00:00",
+                  "machine_time": "2025-03-18T15:16:54.514564+08:00",
+                  "type": "DictMatch",
+                  "meta_type": "assertion",
+                  "description": "default assertion passes because the values are numerically equal",
+                  "line_no": null,
+                  "category": "DEFAULT",
+                  "flag": "DEFAULT",
+                  "file_path": null,
+                  "code_context": null,
+                  "passed": true,
+                  "include_keys": null,
+                  "exclude_keys": null,
+                  "actual_description": null,
+                  "expected_description": null,
+                  "comparison": [
+                    [
+                      0,
+                      "foo",
+                      "Passed",
+                      [
+                        "int",
+                        "1"
+                      ],
+                      [
+                        "float",
+                        1
+                      ]
+                    ],
+                    [
+                      0,
+                      "bar",
+                      "Passed",
+                      [
+                        "int",
+                        "2"
+                      ],
+                      [
+                        "float",
+                        2
+                      ]
+                    ],
+                    [
+                      0,
+                      "baz",
+                      "Passed",
+                      [
+                        "int",
+                        "3"
+                      ],
+                      [
+                        "float",
+                        3
+                      ]
+                    ]
+                  ]
+                },
+                {
+                  "utc_time": "2025-03-18T07:16:54.514973+00:00",
+                  "machine_time": "2025-03-18T15:16:54.514979+08:00",
+                  "type": "DictMatch",
+                  "meta_type": "assertion",
+                  "description": "when we check types the assertion will fail",
+                  "line_no": null,
+                  "category": "DEFAULT",
+                  "flag": "DEFAULT",
+                  "file_path": null,
+                  "code_context": null,
+                  "passed": false,
+                  "include_keys": null,
+                  "exclude_keys": null,
+                  "actual_description": null,
+                  "expected_description": null,
+                  "comparison": [
+                    [
+                      0,
+                      "foo",
+                      "Failed",
+                      [
+                        "int",
+                        "1"
+                      ],
+                      [
+                        "float",
+                        1
+                      ]
+                    ],
+                    [
+                      0,
+                      "bar",
+                      "Failed",
+                      [
+                        "int",
+                        "2"
+                      ],
+                      [
+                        "float",
+                        2
+                      ]
+                    ],
+                    [
+                      0,
+                      "baz",
+                      "Failed",
+                      [
+                        "int",
+                        "3"
+                      ],
+                      [
+                        "float",
+                        3
+                      ]
+                    ]
+                  ]
+                },
+                {
+                  "utc_time": "2025-03-18T07:16:54.515314+00:00",
+                  "machine_time": "2025-03-18T15:16:54.515319+08:00",
+                  "type": "DictMatch",
+                  "meta_type": "assertion",
+                  "description": "use a custom comparison function to check within a tolerance",
+                  "line_no": null,
+                  "category": "DEFAULT",
+                  "flag": "DEFAULT",
+                  "file_path": null,
+                  "code_context": null,
+                  "passed": true,
+                  "include_keys": null,
+                  "exclude_keys": null,
+                  "actual_description": null,
+                  "expected_description": null,
+                  "comparison": [
+                    [
+                      0,
+                      "foo",
+                      "Passed",
+                      [
+                        "float",
+                        1.02
+                      ],
+                      [
+                        "float",
+                        0.98
+                      ]
+                    ],
+                    [
+                      0,
+                      "bar",
+                      "Passed",
+                      [
+                        "float",
+                        2.28
+                      ],
+                      [
+                        "float",
+                        2.33
+                      ]
+                    ],
+                    [
+                      0,
+                      "baz",
+                      "Passed",
+                      [
+                        "float",
+                        3.5
+                      ],
+                      [
+                        "float",
+                        3.46
+                      ]
+                    ]
+                  ]
+                },
+                {
+                  "utc_time": "2025-03-18T07:16:54.515681+00:00",
+                  "machine_time": "2025-03-18T15:16:54.515688+08:00",
+                  "type": "DictMatch",
+                  "meta_type": "assertion",
+                  "description": "only report the failing comparison",
+                  "line_no": null,
+                  "category": "DEFAULT",
+                  "flag": "DEFAULT",
+                  "file_path": null,
+                  "code_context": null,
+                  "passed": false,
+                  "include_keys": null,
+                  "exclude_keys": null,
+                  "actual_description": null,
+                  "expected_description": null,
+                  "comparison": [
+                    [
+                      0,
+                      "bad_key",
+                      "Failed",
+                      [
+                        "str",
+                        "actual"
+                      ],
+                      [
+                        "str",
+                        "expected"
+                      ]
+                    ]
+                  ]
+                },
+                {
+                  "utc_time": "2025-03-18T07:16:54.516077+00:00",
+                  "machine_time": "2025-03-18T15:16:54.516086+08:00",
+                  "type": "DictCheck",
+                  "meta_type": "assertion",
+                  "description": null,
+                  "line_no": null,
+                  "category": "DEFAULT",
+                  "flag": "DEFAULT",
+                  "file_path": null,
+                  "code_context": null,
+                  "passed": false,
+                  "has_keys": [
+                    "foo",
+                    "alpha"
+                  ],
+                  "has_keys_diff": [
+                    "alpha"
+                  ],
+                  "absent_keys": [
+                    "bar",
+                    "beta"
+                  ],
+                  "absent_keys_diff": [
+                    "bar"
+                  ]
+                },
+                {
+                  "utc_time": "2025-03-18T07:16:54.516505+00:00",
+                  "machine_time": "2025-03-18T15:16:54.516512+08:00",
+                  "type": "DictLog",
+                  "meta_type": "entry",
+                  "description": null,
+                  "line_no": null,
+                  "category": "DEFAULT",
+                  "flag": "DEFAULT",
+                  "file_path": null,
+                  "code_context": null,
+                  "flattened_dict": [
+                    [
+                      0,
+                      "foo",
+                      ""
+                    ],
+                    [
+                      0,
+                      "",
+                      [
+                        "int",
+                        "1"
+                      ]
+                    ],
+                    [
+                      0,
+                      "",
+                      [
+                        "int",
+                        "2"
+                      ]
+                    ],
+                    [
+                      0,
+                      "",
+                      [
+                        "int",
+                        "3"
+                      ]
+                    ],
+                    [
+                      0,
+                      "bar",
+                      ""
+                    ],
+                    [
+                      1,
+                      "color",
+                      [
+                        "str",
+                        "blue"
+                      ]
+                    ],
+                    [
+                      0,
+                      "baz",
+                      [
+                        "str",
+                        "hello world"
+                      ]
+                    ]
+                  ]
+                }
+              ],
+              "status_override": null,
+              "status_reason": null,
+              "status": "failed",
+              "runtime_status": "finished",
+              "logs": [],
+              "hash": 0,
+              "parent_uids": [
+                "Dict Assertions Example",
+                "Dict Assertions Test",
+                "DictSuite"
+              ],
+              "timer": {
+                "run": [
+                  {
+                    "start": "2025-03-18T07:16:54.512227+00:00",
+                    "end": "2025-03-18T07:16:54.516854+00:00"
+                  }
+                ]
+              },
+              "category": "testcase",
+              "counter": {
+                "passed": 0,
+                "failed": 1,
+                "total": 1
+              },
+              "tags": {}
+            }
+          ],
+          "status_override": null,
+          "status_reason": null,
+          "status": "failed",
+          "runtime_status": "finished",
+          "logs": [],
+          "hash": 0,
+          "parent_uids": [
+            "Dict Assertions Example",
+            "Dict Assertions Test"
+          ],
+          "timer": {
+            "run": [
+              {
+                "start": "2025-03-18T07:16:54.512024+00:00",
+                "end": "2025-03-18T07:16:54.521610+00:00"
+              }
+            ]
+          },
+          "counter": {
+            "passed": 0,
+            "failed": 1,
+            "total": 1
+          },
+          "children": [],
+          "part": null,
+          "fix_spec_path": null,
+          "env_status": null,
+          "strict_order": false,
+          "category": "testsuite",
+          "tags": {},
+          "host": null
+        }
+      ],
+      "status_override": null,
+      "status_reason": null,
+      "status": "failed",
+      "runtime_status": "finished",
+      "logs": [],
+      "hash": 0,
+      "parent_uids": [
+        "Dict Assertions Example"
+      ],
+      "timer": {
+        "setup": [
+          {
+            "start": "2025-03-18T07:16:54.456764+00:00",
+            "end": "2025-03-18T07:16:54.506405+00:00"
+          }
+        ],
+        "run": [
+          {
+            "start": "2025-03-18T07:16:54.511840+00:00",
+            "end": "2025-03-18T07:16:54.521991+00:00"
+          }
+        ],
+        "teardown": [
+          {
+            "start": "2025-03-18T07:16:54.532773+00:00",
+            "end": "2025-03-18T07:16:54.569714+00:00"
+          }
+        ]
+      },
+      "counter": {
+        "passed": 0,
+        "failed": 1,
+        "total": 1
+      },
+      "children": [],
+      "part": null,
+      "fix_spec_path": null,
+      "env_status": "STOPPED",
+      "strict_order": false,
+      "category": "multitest",
+      "tags": {},
+      "host": null
+    }
+  ],
+  "status_override": null,
+  "status_reason": null,
+  "status": "failed",
+  "runtime_status": "finished",
+  "logs": [],
+  "hash": 0,
+  "parent_uids": [],
+  "timer": {
+    "run": [
+      {
+        "start": "2025-03-18T07:16:54.081509+00:00",
+        "end": "2025-03-18T07:16:54.935976+00:00"
+      }
+    ]
+  },
+  "counter": {
+    "passed": 0,
+    "failed": 1,
+    "total": 1
+  },
+  "children": [
+    {
+      "name": "LocalRunner[local_runner]",
+      "timer": {
+        "lifespan": [
+          {
+            "start": "2025-03-18T07:16:54.429888+00:00",
+            "end": "2025-03-18T07:16:54.783378+00:00"
+          }
+        ],
+        "setup": [
+          {
+            "start": "2025-03-18T07:16:54.430166+00:00",
+            "end": "2025-03-18T07:16:54.430869+00:00"
+          }
+        ],
+        "teardown": [
+          {
+            "start": "2025-03-18T07:16:54.683101+00:00",
+            "end": null
+          }
+        ]
+      },
+      "children": []
+    },
+    {
+      "name": "Environments[environments]",
+      "timer": {
+        "lifespan": [
+          {
+            "start": "2025-03-18T07:16:54.430575+00:00",
+            "end": "2025-03-18T07:16:54.682939+00:00"
+          }
+        ],
+        "setup": [
+          {
+            "start": "2025-03-18T07:16:54.430827+00:00",
+            "end": "2025-03-18T07:16:54.430960+00:00"
+          }
+        ],
+        "teardown": [
+          {
+            "start": "2025-03-18T07:16:54.682875+00:00",
+            "end": "2025-03-18T07:16:54.783436+00:00"
+          }
+        ]
+      },
+      "children": []
+    }
+  ],
+  "category": "testplan",
+  "meta": {},
+  "label": null,
+  "tags_index": {},
+  "information": [
+    [
+      "testplan_version",
+      "25.1.0"
+    ],
+    [
+      "user",
+      "unknown"
+    ],
+    [
+      "command_line_string",
+      "./test_plan_dict.py --json examples_assertion_dict.json"
+    ],
+    [
+      "python_version",
+      "3.12.3"
+    ]
+  ],
+  "resource_meta_path": null,
+  "attachments": {},
+  "timeout": 14400,
+  "version": 1
+}


### PR DESCRIPTION
## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
