### PR TITLE
Misc/upgrade pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/cut_version.yml
+++ b/.github/workflows/cut_version.yml
@@ -79,12 +79,12 @@ jobs:
 
       - name: Publish to Test PyPI
         if: ${{github.ref_name == 'test_pypi'}}
-        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
       - name: Publish to PyPI
         if: ${{github.ref_name != 'test_pypi'}}
-        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Bug / Requirement Description
previous version has twine<6, doesn't support metadata version 2.4 (generated by newer version of setuptools)

## Solution description
upgrade this gh action to 1.12.4

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
