### PR TITLE
Refactor/underlying driver inside RemoteDriver to not initialised locally

### DIFF
--- a/doc/newsfragments/3193_changed.tweak_remote_driver.rst
+++ b/doc/newsfragments/3193_changed.tweak_remote_driver.rst
@@ -1,0 +1,1 @@
+The wrapped driver class within :py:class:`RemoteDriver <testplan.common.remote.remote_driver.RemoteDriver>` is now constructed only on remote host.

--- a/testplan/common/remote/remote_driver.py
+++ b/testplan/common/remote/remote_driver.py
@@ -32,12 +32,6 @@ class RemoteDriver:
         )
         self.__dict__["_handle"] = rmt_driver_cls(**self._options)
 
-    def uid(self) -> str:
-        # driver uid needed in env constructing check
-        # whether remote or local, uid should be the same since it's cfg based
-        # XXX: would it be a bad idea to have it inited locally?
-        return self._driver_cls(**self._options).uid()
-
     def __getattr__(self, name):
         if self._handle is None:
             self._init_handle()

--- a/testplan/testing/environment/base.py
+++ b/testplan/testing/environment/base.py
@@ -80,8 +80,8 @@ class TestEnvironment(Environment):
             # we are in a (specially) managed environment, override
             # `async_start`
             d.async_start = True
-            if d.uid() not in dependency.vertices:
-                dependency.add_vertex(d.uid(), d)
+            if id(d) not in dependency.vertices:
+                dependency.add_vertex(id(d), d)
 
         self._orig_dependency = dependency
 
@@ -107,14 +107,14 @@ class TestEnvironment(Environment):
         self._rt_dependency = copy.copy(self._orig_dependency)
 
         # distribute pocketwatches
-        for k, v in self._rt_dependency.vertices.items():
+        for _, v in self._rt_dependency.vertices.items():
             if isinstance(v.started_check_interval, tuple):
                 curr_interval, interval_cap = v.started_check_interval
-                self._pocketwatches[k] = DriverPocketwatch(
+                self._pocketwatches[v.uid()] = DriverPocketwatch(
                     v.start_timeout, curr_interval, interval_cap
                 )
             else:
-                self._pocketwatches[k] = DriverPocketwatch(
+                self._pocketwatches[v.uid()] = DriverPocketwatch(
                     v.start_timeout, v.started_check_interval
                 )
 
@@ -184,17 +184,17 @@ class TestEnvironment(Environment):
         # filter drivers based on status
         for driver in self._resources.values():
             if driver.status == driver.status.NONE:
-                self._rt_dependency.remove_vertex(driver.uid())
+                self._rt_dependency.remove_vertex(id(driver))
 
         # distribute pocketwatches
-        for k, v in self._rt_dependency.vertices.items():
+        for _, v in self._rt_dependency.vertices.items():
             if isinstance(v.stopped_check_interval, tuple):
                 curr_interval, interval_cap = v.stopped_check_interval
-                self._pocketwatches[k] = DriverPocketwatch(
+                self._pocketwatches[v.uid()] = DriverPocketwatch(
                     v.stop_timeout, curr_interval, interval_cap
                 )
             else:
-                self._pocketwatches[k] = DriverPocketwatch(
+                self._pocketwatches[v.uid()] = DriverPocketwatch(
                     v.stop_timeout, v.stopped_check_interval
                 )
 

--- a/testplan/testing/environment/graph.py
+++ b/testplan/testing/environment/graph.py
@@ -25,8 +25,8 @@ class DriverDepGraph(DirectedGraph[str, D, bool]):
     An always acyclic directed graph, also bookkeeping driver starting status.
     """
 
-    processing: Set[D] = field(default_factory=set)
-    processed: List[D] = field(default_factory=list)
+    processing: Set[str] = field(default_factory=set)
+    processed: List[str] = field(default_factory=list)
 
     @classmethod
     def from_directed_graph(cls, g: DirectedGraph) -> "DriverDepGraph":
@@ -40,16 +40,16 @@ class DriverDepGraph(DirectedGraph[str, D, bool]):
         return cls(g_.vertices, g_.edges, g_.indegrees, g_.outdegrees)
 
     def mark_processing(self, driver: D):
-        self.processing.add(driver.uid())
+        self.processing.add(id(driver))
 
     def mark_processed(self, driver: D):
-        self.processing.remove(driver.uid())
-        self.remove_vertex(driver.uid())
-        self.processed.append(driver.uid())
+        self.processing.remove(id(driver))
+        self.remove_vertex(id(driver))
+        self.processed.append(id(driver))
 
     def mark_failed_to_process(self, driver: D):
-        self.processing.remove(driver.uid())
-        self.remove_vertex(driver.uid())
+        self.processing.remove(id(driver))
+        self.remove_vertex(id(driver))
 
     def drivers_to_process(self) -> List[D]:
         return [
@@ -143,11 +143,11 @@ def parse_dependency(input: dict) -> DriverDepGraph:
             v = (v,)
 
         for s, e in product(k, v):
-            if s.uid() not in g.vertices:
-                g.add_vertex(s.uid(), s)
-            if e.uid() not in g.vertices:
-                g.add_vertex(e.uid(), e)
-            if e.uid() not in g.edges[s.uid()]:
-                g.add_edge(s.uid(), e.uid(), None)
+            if id(s) not in g.vertices:
+                g.add_vertex(id(s), s)
+            if id(e) not in g.vertices:
+                g.add_vertex(id(e), e)
+            if id(e) not in g.edges[id(s)]:
+                g.add_edge(id(s), id(e), None)
 
     return DriverDepGraph.from_directed_graph(g)

--- a/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
+++ b/tests/functional/testplan/testing/multitest/test_multitest_drivers.py
@@ -517,4 +517,6 @@ def test_env_builder(mockplan):
     assert mockplan.run().success is True
     assert len(mt.resources) == 2
     assert mt.resources["dummy_ctx"] == "dummy_value"
-    assert mt.resources._rt_dependency.processed == ["b", "a"]
+    assert mt.resources._rt_dependency.processed == list(
+        map(lambda x: id(mt.resources[x]), ["b", "a"])
+    )

--- a/tests/unit/testplan/testing/environment/common.py
+++ b/tests/unit/testplan/testing/environment/common.py
@@ -7,7 +7,7 @@ from testplan.testing.multitest.driver import Driver
 
 
 def assert_lhs_before_rhs(d_list, lhs, rhs):
-    assert d_list.index(lhs.name) < d_list.index(rhs.name)
+    assert d_list.index(id(lhs)) < d_list.index(id(rhs))
 
 
 def assert_lhs_call_before_rhs_call(mock_calls, l_call, r_call):

--- a/tests/unit/testplan/testing/environment/test_base.py
+++ b/tests/unit/testplan/testing/environment/test_base.py
@@ -105,9 +105,9 @@ class TestFastDrivers:
             env.add(d_)
         env.set_dependency(parse_dependency({a: c, c: b}))
         env.start()
-        assert env._rt_dependency.processed == ["a", "c", "b"]
+        assert env._rt_dependency.processed == [id(a), id(c), id(b)]
         env.stop()
-        assert env._rt_dependency.processed == ["b", "c", "a"]
+        assert env._rt_dependency.processed == [id(b), id(c), id(a)]
 
     def test_empty_dependency(self, mocker):
         m = mocker.Mock()

--- a/tests/unit/testplan/testing/environment/test_graph.py
+++ b/tests/unit/testplan/testing/environment/test_graph.py
@@ -18,7 +18,7 @@ def test_basic_graph():
     assert set(g_.vertices.values()) == {a, b, c, d, e, f}
     for s, e in {(a, c), (b, c), (c, d), (e, d), (e, f)}:
         # if edge doesn't exist, KeyError will be thrown
-        assert g_.edges[s.name][e.name] is None
+        assert g_.edges[id(s)][id(e)] is None
 
 
 def test_empty_graph():
@@ -51,13 +51,13 @@ def test_graph_operation():
     g = parse_dependency({d1: d2, d2: d3})
     g.mark_processing(d1)
     g_ = copy(g)
-    assert "d1" in g_.processing
+    assert id(d1) in g_.processing
     g.mark_processed(d1)
     g_ = copy(g)
-    assert "d1" in g_.processed
-    assert "d1" not in g_.vertices
-    assert g_.edges["d2"]["d3"] is None
+    assert id(d1) in g_.processed
+    assert id(d1) not in g_.vertices
+    assert g_.edges[id(d2)][id(d3)] is None
 
     g_ = g.transpose()
     assert "d1" not in g_.processed
-    assert g_.edges["d3"]["d2"] is None
+    assert g_.edges[id(d3)][id(d2)] is None


### PR DESCRIPTION
## Bug / Requirement Description
initialise underlying driver class locally causing confusion

## Solution description
use id() function instead of uid() method to get driver ids representing keys in dep graphs

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
