### PR TITLE
Fix/set tz to UTC when tzlocal returns local

### DIFF
--- a/doc/newsfragments/3301_changed.tz_local_force_utc.rst
+++ b/doc/newsfragments/3301_changed.tz_local_force_utc.rst
@@ -1,0 +1,1 @@
+Set ``timezone`` entries in Testplan reports to ``UTC`` when local timezone detection fails.

--- a/testplan/common/utils/timing.py
+++ b/testplan/common/utils/timing.py
@@ -283,7 +283,17 @@ def now() -> datetime.datetime:
 @lru_cache(None)
 def iana_tz() -> str:
     """IANA TZ identifier"""
-    return str(tzlocal.get_localzone())
+    tz = str(tzlocal.get_localzone())
+    if tz == "local":
+        # tzlocal cannot determine the local timezone, raise warning
+        from testplan.common.utils.logger import TESTPLAN_LOGGER
+
+        TESTPLAN_LOGGER.warning(
+            "CANNOT DETERMINE LOCAL TIMEZONE ON MACHINE, please check your "
+            "system configuration. FORCE USING UTC HERE."
+        )
+        tz = "UTC"
+    return tz
 
 
 _Interval = collections.namedtuple("_Interval", "start end")


### PR DESCRIPTION
## Bug / Requirement Description
^

## Solution description
^

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
