### PR TITLE
Feature!/allow preserve testcase entries when applying report filter

### DIFF
--- a/doc/en/introduction.rst
+++ b/doc/en/introduction.rst
@@ -416,8 +416,12 @@ Command line
                             to exclude certain testcases from the report. Use "PS" will select passed and skipped testcases only, and use "ps" will
                             select all the testcases that are not passed and not skipped. Note using upper-case and lower-case letters together
                             is not allowed due to potential ambiguity.
-      --omit-passed         Equivalent to "--report-filter=p", cannot be used with "--report-filter" together.
-      --omit-skipped        Equivalent to "--report-filter=s", cannot be used with "--report-filter" together.
+      --only-drop-assertions
+                            Only drop assertions of filtered out report entries while preserve the hierarchical testcase entries when
+                            "report-filter" is set, useful when need to see which testcases were executed but don't care about their
+                            detailed assertions.
+      --omit-passed         Equivalent to "--report-filter=p --only-drop-assertions", cannot be used with "--report-filter" together.
+      --omit-skipped        Equivalent to "--report-filter=s --only-drop-assertions", cannot be used with "--report-filter" together.
       --pdf                 File path for PDF report.
       --pdf-style           (default: extended-summary)
 

--- a/doc/en/introduction.rst
+++ b/doc/en/introduction.rst
@@ -411,17 +411,12 @@ Command line
                             "extended-summary" - Display assertion details for failing tests, testcase level statuses for the rest.
 
                             "detailed" - Display details of all tests & assertions.
-      --report-filter       Only include testcases with execution result Error (E), Failed (F), Incomplete (I), Passed (P), Skipped (S),
-                            Unstable (U), Unknown (X), XFail (A), XPass (B) and XPass-Strict (C) in Testplan report. Use lower-case characters
-                            to exclude certain testcases from the report. Use "PS" will select passed and skipped testcases only, and use "ps" will
-                            select all the testcases that are not passed and not skipped. Note using upper-case and lower-case letters together
-                            is not allowed due to potential ambiguity.
-      --only-drop-assertions
-                            Only drop assertions of filtered out report entries while preserve the hierarchical testcase entries when
-                            "report-filter" is set, useful when need to see which testcases were executed but don't care about their
-                            detailed assertions.
-      --omit-passed         Equivalent to "--report-filter=p --only-drop-assertions", cannot be used with "--report-filter" together.
-      --omit-skipped        Equivalent to "--report-filter=s --only-drop-assertions", cannot be used with "--report-filter" together.
+      --report-exclude {E,F,I,P,S,U,X,A,B,C,e,f,i,p,s,u,x,a,b,c...}
+                            Filter out testcases with result status Error (E), Failed (F), Incomplete (I), Passed (P), Skipped (S),
+                            Unstable (U), Unknown (X), XFail (A), XPass (B) and XPass-Strict (C) in Testplan report. Use lower-case
+                            characters to only remove assertions while preserving testcase report entries. E.g. "PS" will remove both
+                            passed and skipped testcases, "ps" will remove assertions of passed and skipped testcases.
+      --omit-passed         Equivalent to "--report-exclude=p", cannot be used with "--report-exclude" together.
       --pdf                 File path for PDF report.
       --pdf-style           (default: extended-summary)
 

--- a/doc/newsfragments/3393_changed.report_filter_cli_arg.rst
+++ b/doc/newsfragments/3393_changed.report_filter_cli_arg.rst
@@ -1,3 +1,5 @@
-Remove command line argument ``--report-filter``, part of its functionality now can be achieved using ``--report-exclude``. Please check its help message for more details.
-``--omit-passed`` now preserves testcase entries while removing assertions within them, i.e. those passed testcase entries still appear in the report without any assertions.
-Remove command line argument ``--omit-skipped``.
+Several changes to report filtering command line arguments. **This is a breaking change.**
+
+* Remove command line argument ``--report-filter``, part of its functionality can be achieved using ``--report-exclude`` instead. Please check its help message for more details.
+* Remove command line argument ``--omit-skipped``.
+* Change the behavior of command line argument ``--omit-passed``, now it preserves passed case entries in the report while omitting their assertions.

--- a/doc/newsfragments/3393_changed.report_filter_cli_arg.rst
+++ b/doc/newsfragments/3393_changed.report_filter_cli_arg.rst
@@ -1,0 +1,3 @@
+Remove command line argument ``--report-filter``, part of its functionality now can be achieved using ``--report-exclude``. Please check its help message for more details.
+``--omit-passed`` now preserves testcase entries while removing assertions within them, i.e. those passed testcase entries still appear in the report without any assertions.
+Remove command line argument ``--omit-skipped``.

--- a/testplan/common/report/base.py
+++ b/testplan/common/report/base.py
@@ -932,7 +932,8 @@ class BaseReportGroup(Report):
 
     def filter_cases(
         self,
-        predicate: Callable[["BaseReportGroup"], bool],
+        predicate: Callable[[Report], bool],
+        preserve_structure: bool,
         is_root: bool = False,
     ) -> Self:
         """
@@ -945,12 +946,17 @@ class BaseReportGroup(Report):
         for entry in report_obj.entries:
             if hasattr(entry, "filter_cases"):
                 statuses.append(entry.status)
-                entry = entry.filter_cases(predicate)
+                entry = entry.filter_cases(predicate, preserve_structure)
                 if len(entry):
                     entries.append(entry)
             else:
                 statuses.append(entry.status)
                 if predicate(entry):
+                    entries.append(entry)
+                elif preserve_structure:
+                    # entry.counter not cleared here
+                    entry.entries.clear()
+                    entry.logs.clear()
                     entries.append(entry)
 
         report_obj.entries = entries

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -15,7 +15,7 @@ from testplan import defaults
 from testplan.common.utils import logger
 from testplan.common.utils.json import json_load_from_path
 from testplan.report.testing import (
-    ReportFilterAction,
+    CustomReportFilterAction,
     ReportTagsAction,
     styles,
 )
@@ -331,8 +331,7 @@ Test filter, runs tests that match ALL of the given tags.
             ),
         )
 
-        report_filter_group = report_group.add_mutually_exclusive_group()
-        report_filter_group.add_argument(
+        report_group.add_argument(
             "--report-filter",
             metavar="{E,F,I,P,S,U,X,A,B,C,...}",
             dest="reporting_filter",
@@ -348,20 +347,31 @@ Test filter, runs tests that match ALL of the given tags.
             "allowed due to potential ambiguity.",
         )
 
-        report_filter_group.add_argument(
-            "--omit-passed",
-            nargs=0,
-            action=ReportFilterAction.use_filter("p"),
-            help='Equivalent to "--report-filter=p", cannot be used with '
-            '"--report-filter" together.',
+        report_group.add_argument(
+            "--only-drop-assertions",
+            action="store_true",
+            dest="reporting_filter_preserve_structure",
+            default=False,
+            help="Only drop assertions of filtered out report entries while "
+            'preserve the hierarchical testcase entries when "report-filter" '
+            "is set, useful when need to see which testcases were executed "
+            "but don't care about their detailed assertions.",
         )
 
-        report_filter_group.add_argument(
+        report_group.add_argument(
+            "--omit-passed",
+            nargs=0,
+            action=CustomReportFilterAction.use_filter("p"),
+            help='Equivalent to "--report-filter=p --only-drop-assertions", '
+            'cannot be used with "--report-filter" together.',
+        )
+
+        report_group.add_argument(
             "--omit-skipped",
             nargs=0,
-            action=ReportFilterAction.use_filter("s"),
-            help='Equivalent to "--report-filter=s", cannot be used with '
-            '"--report-filter" together.',
+            action=CustomReportFilterAction.use_filter("s"),
+            help='Equivalent to "--report-filter=s --only-drop-assertions", '
+            'cannot be used with "--report-filter" together.',
         )
 
         report_group.add_argument(

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -15,7 +15,7 @@ from testplan import defaults
 from testplan.common.utils import logger
 from testplan.common.utils.json import json_load_from_path
 from testplan.report.testing import (
-    CustomReportFilterAction,
+    ReportFilterAction,
     ReportTagsAction,
     styles,
 )
@@ -331,47 +331,28 @@ Test filter, runs tests that match ALL of the given tags.
             ),
         )
 
-        report_group.add_argument(
-            "--report-filter",
-            metavar="{E,F,I,P,S,U,X,A,B,C,...}",
-            dest="reporting_filter",
+        mutex_report_group = report_group.add_mutually_exclusive_group()
+
+        mutex_report_group.add_argument(
+            "--report-exclude",
+            metavar="{E,F,I,P,S,U,X,A,B,C,e,f,i,p,s,u,x,a,b,c...}",
+            dest="reporting_exclude_filter",
             type=str,
-            help="Only include testcases with execution result Error (E), "
+            help="Filter out testcases with result status Error (E), "
             "Failed (F), Incomplete (I), Passed (P), Skipped (S), "
             "Unstable (U), Unknown (X), XFail (A), XPass (B) and "
             "XPass-Strict (C) in Testplan report. Use lower-case characters "
-            'to exclude certain testcases from the report. Use "PS" will '
-            'select passed and skipped testcases only, and use "ps" will '
-            "select all the testcases that are not passed and not skipped. "
-            "Note using upper-case and lower-case letters together is not "
-            "allowed due to potential ambiguity.",
+            "to only remove assertions while preserving testcase report "
+            'entries. E.g. "PS" will remove both passed and skipped testcases, '
+            '"ps" will remove assertions of passed and skipped testcases.',
         )
 
-        report_group.add_argument(
-            "--only-drop-assertions",
-            action="store_true",
-            dest="reporting_filter_preserve_structure",
-            default=False,
-            help="Only drop assertions of filtered out report entries while "
-            'preserve the hierarchical testcase entries when "report-filter" '
-            "is set, useful when need to see which testcases were executed "
-            "but don't care about their detailed assertions.",
-        )
-
-        report_group.add_argument(
+        mutex_report_group.add_argument(
             "--omit-passed",
             nargs=0,
-            action=CustomReportFilterAction.use_filter("p"),
-            help='Equivalent to "--report-filter=p --only-drop-assertions", '
-            'cannot be used with "--report-filter" together.',
-        )
-
-        report_group.add_argument(
-            "--omit-skipped",
-            nargs=0,
-            action=CustomReportFilterAction.use_filter("s"),
-            help='Equivalent to "--report-filter=s --only-drop-assertions", '
-            'cannot be used with "--report-filter" together.',
+            action=ReportFilterAction.use_filter("p"),
+            help='Equivalent to "--report-exclude=p", '
+            'cannot be used with "--report-exclude" together.',
         )
 
         report_group.add_argument(

--- a/testplan/report/filter.py
+++ b/testplan/report/filter.py
@@ -50,17 +50,12 @@ class ReportingFilter(Entity):
         "C": Status.XPASS_STRICT,
     }
 
-    def __call__(
-        self, report: TestReport, preserve_structure: bool
-    ) -> TestReport:
+    def __call__(self, report: TestReport) -> TestReport:
         """
         Execute self on TestReport.
         """
-        if self.cfg.sign:
-            func = lambda x: any(f == x.status for f in self.cfg.flags)
-        else:
-            func = lambda x: all(f != x.status for f in self.cfg.flags)
-        return report.filter_cases(func, preserve_structure, is_root=True)
+        func = lambda x: all(f != x.status for f in self.cfg.flags)
+        return report.filter_cases(func, not self.cfg.sign, is_root=True)
 
     @classmethod
     def parse(cls, cli_options: str) -> Self:

--- a/testplan/report/filter.py
+++ b/testplan/report/filter.py
@@ -50,7 +50,9 @@ class ReportingFilter(Entity):
         "C": Status.XPASS_STRICT,
     }
 
-    def __call__(self, report: TestReport) -> TestReport:
+    def __call__(
+        self, report: TestReport, preserve_structure: bool
+    ) -> TestReport:
         """
         Execute self on TestReport.
         """
@@ -58,7 +60,7 @@ class ReportingFilter(Entity):
             func = lambda x: any(f == x.status for f in self.cfg.flags)
         else:
             func = lambda x: all(f != x.status for f in self.cfg.flags)
-        return report.filter_cases(func, is_root=True)
+        return report.filter_cases(func, preserve_structure, is_root=True)
 
     @classmethod
     def parse(cls, cli_options: str) -> Self:

--- a/testplan/report/testing/__init__.py
+++ b/testplan/report/testing/__init__.py
@@ -6,4 +6,4 @@ from .base import (
     TestGroupReport,
     TestReport,
 )
-from .parser import ReportFilterAction, ReportTagsAction
+from .parser import CustomReportFilterAction, ReportTagsAction

--- a/testplan/report/testing/__init__.py
+++ b/testplan/report/testing/__init__.py
@@ -6,4 +6,4 @@ from .base import (
     TestGroupReport,
     TestReport,
 )
-from .parser import CustomReportFilterAction, ReportTagsAction
+from .parser import ReportFilterAction, ReportTagsAction

--- a/testplan/report/testing/parser.py
+++ b/testplan/report/testing/parser.py
@@ -41,32 +41,20 @@ class ReportTagsAction(argparse.Action):
         setattr(namespace, self.dest, items)
 
 
-class CustomReportFilterAction(argparse.Action):
+class ReportFilterAction(argparse.Action):
     """
-    Argparse action serving higher-precedence shortcuts for report filters.
+    Argparse action serving as shortcuts for report filters.
     """
-
-    MUTEX_DESTS = ["reporting_filter", "omit_passed", "omit_skipped"]
 
     def __init__(self, filter_rep: str, *args, **kwargs):
         self.filter_rep = filter_rep
         super().__init__(*args, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        if any(
-            getattr(namespace, dest)
-            for dest in self.MUTEX_DESTS
-            if dest != self.dest
-        ):
-            parser.error(
-                f'argument "{option_string}" not allowed with other report '
-                f'filter argument "{self.option_strings[0]}"'
-            )
-        setattr(namespace, "reporting_filter", self.filter_rep)
-        setattr(namespace, "reporting_filter_preserve_structure", True)
+        setattr(namespace, "reporting_exclude_filter", self.filter_rep)
 
     @staticmethod
     def use_filter(filter_rep: str):
-        return lambda *args, **kwargs: CustomReportFilterAction(
+        return lambda *args, **kwargs: ReportFilterAction(
             filter_rep, *args, **kwargs
         )

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -290,6 +290,9 @@ class TestRunnerConfig(RunnableConfig):
             ConfigOption("reporting_filter", default=None): Or(
                 And(str, Use(ReportingFilter.parse)), None
             ),
+            ConfigOption(
+                "reporting_filter_preserve_structure", default=False
+            ): bool,
             ConfigOption("xfail_tests", default=None): Or(dict, None),
             ConfigOption("runtime_data", default={}): Or(dict, None),
             ConfigOption(
@@ -1666,7 +1669,10 @@ class TestRunner(Runnable):
     def _pre_exporters(self):
         # Apply report filter if one exists
         if self.cfg.reporting_filter is not None:
-            self.result.report = self.cfg.reporting_filter(self.result.report)
+            self.result.report = self.cfg.reporting_filter(
+                self.result.report,
+                self.cfg.reporting_filter_preserve_structure,
+            )
 
         # Attach resource monitor data
         if self.resource_monitor_server:

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -287,12 +287,9 @@ class TestRunnerConfig(RunnableConfig):
             ),
             ConfigOption("tracing_tests_output", default="-"): str,
             ConfigOption("resource_monitor", default=False): bool,
-            ConfigOption("reporting_filter", default=None): Or(
+            ConfigOption("reporting_exclude_filter", default=None): Or(
                 And(str, Use(ReportingFilter.parse)), None
             ),
-            ConfigOption(
-                "reporting_filter_preserve_structure", default=False
-            ): bool,
             ConfigOption("xfail_tests", default=None): Or(dict, None),
             ConfigOption("runtime_data", default={}): Or(dict, None),
             ConfigOption(
@@ -1668,10 +1665,9 @@ class TestRunner(Runnable):
 
     def _pre_exporters(self):
         # Apply report filter if one exists
-        if self.cfg.reporting_filter is not None:
-            self.result.report = self.cfg.reporting_filter(
-                self.result.report,
-                self.cfg.reporting_filter_preserve_structure,
+        if self.cfg.reporting_exclude_filter is not None:
+            self.result.report = self.cfg.reporting_exclude_filter(
+                self.result.report
             )
 
         # Attach resource monitor data

--- a/tests/functional/testplan/report/testing/test_filter.py
+++ b/tests/functional/testplan/report/testing/test_filter.py
@@ -3,6 +3,7 @@ import sys
 
 import testplan.testing.multitest.suite as suite
 from testplan import TestplanMock
+from testplan.common.utils.testing import argv_overridden
 from testplan.testing.multitest import MultiTest
 from tests.unit.testplan.testing.test_pytest import pytest_test_inst
 
@@ -15,11 +16,13 @@ class OneSuite:
 
     @suite.testcase
     def failing(self, env, result):
+        result.true(True)
         result.true(False)
 
     @suite.testcase
     @suite.xfail(reason="coding after drinking")
     def expect_to_fail(self, env, result):
+        result.true(True)
         result.true(False)
 
 
@@ -139,3 +142,85 @@ def test_pytest_report_filter_not_skipped(pytest_test_inst):
         pt_report["pytest_tests.py::TestPytestMarks"].entries[0].name
         != "test_skipped"
     )
+
+
+def _do_assert(exp_structure, mt_report):
+    for i, i_ in exp_structure.items():
+        assert len(mt_report[i]) == len(i_)
+        for j, j_ in i_.items():
+            if isinstance(j_, int):
+                assert len(mt_report[i][j]) == j_
+            else:
+                assert len(mt_report[i][j]) == len(j_)
+                for k, k_ in j_.items():
+                    assert len(mt_report[i][j][k]) == k_
+
+
+def test_mt_omit_passed():
+    with argv_overridden("--omit-passed"):
+        plan = TestplanMock(
+            name=f"{inspect.currentframe().f_code.co_name}_test",
+            parse_cmdline=True,
+        )
+        plan.add(
+            MultiTest(
+                name="TestMT",
+                suites=[OneSuite(), AnotherSuite(), SkippedSuite()],
+            )
+        )
+        mt_report = plan.run().report["TestMT"]
+
+    exp_structure = {
+        "OneSuite": {"passing": 0, "failing": 2, "expect_to_fail": 2},
+        "AnotherSuite": {
+            "with_param": {
+                "with_param__b_True": 0,
+                "with_param__b_False": 1,
+            },
+            "should_skip": 1,
+            "result_skip_should_skip": 2,
+            "strictly_expect_to_fail": {
+                "strictly_expect_to_fail__b_True": 1,
+                "strictly_expect_to_fail__b_False": 1,
+                "strictly_expect_to_fail__b_None": 1,
+            },
+        },
+        "SkippedSuite": {"should_skip_jr": 1},
+    }
+
+    _do_assert(exp_structure, mt_report)
+
+
+def test_mt_preserve_structure():
+    with argv_overridden("--report-filter=SAB", "--only-drop-assertions"):
+        plan = TestplanMock(
+            name=f"{inspect.currentframe().f_code.co_name}_test",
+            parse_cmdline=True,
+        )
+        plan.add(
+            MultiTest(
+                name="TestMT",
+                suites=[OneSuite(), AnotherSuite(), SkippedSuite()],
+            )
+        )
+        mt_report = plan.run().report["TestMT"]
+
+    exp_structure = {
+        "OneSuite": {"passing": 0, "failing": 0, "expect_to_fail": 2},
+        "AnotherSuite": {
+            "with_param": {
+                "with_param__b_True": 0,
+                "with_param__b_False": 0,
+            },
+            "should_skip": 1,
+            "result_skip_should_skip": 2,
+            "strictly_expect_to_fail": {
+                "strictly_expect_to_fail__b_True": 0,
+                "strictly_expect_to_fail__b_False": 1,
+                "strictly_expect_to_fail__b_None": 1,
+            },
+        },
+        "SkippedSuite": {"should_skip_jr": 1},
+    }
+
+    _do_assert(exp_structure, mt_report)

--- a/tests/functional/testplan/report/testing/test_filter.py
+++ b/tests/functional/testplan/report/testing/test_filter.py
@@ -61,7 +61,7 @@ class SkippedSuite:
 def test_multitest_report_filter_passed():
     plan = TestplanMock(
         name=f"{inspect.currentframe().f_code.co_name}_test",
-        reporting_filter="P",
+        reporting_exclude_filter="EFIUXSABC",
     )
     plan.add(MultiTest(name="TestMT", suites=[OneSuite(), AnotherSuite()]))
     mt_report = plan.run().report["TestMT"]
@@ -76,7 +76,7 @@ def test_multitest_report_filter_passed():
 def test_multitest_report_filter_passed_or_xfail():
     plan = TestplanMock(
         name=f"{inspect.currentframe().f_code.co_name}_test",
-        reporting_filter="PA",
+        reporting_exclude_filter="EFIUXSBC",
     )
     plan.add(
         MultiTest(
@@ -101,7 +101,7 @@ def test_multitest_report_filter_passed_or_xfail():
 def test_multitest_report_filter_not_passed_and_not_failed():
     plan = TestplanMock(
         name=f"{inspect.currentframe().f_code.co_name}_test",
-        reporting_filter="pf",
+        reporting_exclude_filter="PF",
     )
     plan.add(
         MultiTest(
@@ -133,7 +133,7 @@ def test_multitest_report_filter_not_passed_and_not_failed():
 def test_pytest_report_filter_not_skipped(pytest_test_inst):
     plan = TestplanMock(
         name=f"{inspect.currentframe().f_code.co_name}_test",
-        reporting_filter="s",
+        reporting_exclude_filter="S",
     )
     plan.schedule(pytest_test_inst)
     pt_report = plan.run().report["My PyTest"]
@@ -192,7 +192,7 @@ def test_mt_omit_passed():
 
 
 def test_mt_preserve_structure():
-    with argv_overridden("--report-filter=SAB", "--only-drop-assertions"):
+    with argv_overridden("--report-exclude=efpiuxc"):
         plan = TestplanMock(
             name=f"{inspect.currentframe().f_code.co_name}_test",
             parse_cmdline=True,


### PR DESCRIPTION
## Bug / Requirement Description
to preserve case entries in (variations of) "report filter"

## Solution description
remove `--report-filter`, part of its feature replaced by `--report-exclude`
remove `--omit-skipped`, `--omit-passed` behaviour changed

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [x] For new cmdline arg: documentation
