### PR TITLE
Fix bug in interactive mode where filtered runs cause test runtime_status to be stuck at waiting

### DIFF
--- a/doc/newsfragments/3495_changed.fix_interactive_mode_tests_stuck_at_waiting.rst
+++ b/doc/newsfragments/3495_changed.fix_interactive_mode_tests_stuck_at_waiting.rst
@@ -1,0 +1,1 @@
+Fix an issue where the test runs in interactive mode will be stuck at waiting when filter text is present in the search box.

--- a/testplan/web_ui/testing/src/Report/InteractiveReport.js
+++ b/testplan/web_ui/testing/src/Report/InteractiveReport.js
@@ -500,13 +500,18 @@ class InteractiveReportComponent extends BaseReport {
    */
   pruneReportEntry(reportEntry) {
     const { name, category, entries } = reportEntry;
+    if (category === "synthesized") {
+      return null;
+    }
     const pruneEntry = {
       name: name,
       category: category,
     };
 
     if (!isReportLeaf(reportEntry) && !_.isEmpty(entries)) {
-      pruneEntry.entries = entries.map((entry) => this.pruneReportEntry(entry));
+      pruneEntry.entries = entries
+        .map((entry) => this.pruneReportEntry(entry))
+        .filter((entry) => entry !== null);
     }
 
     return pruneEntry;
@@ -528,9 +533,9 @@ class InteractiveReportComponent extends BaseReport {
 
     // the filter text is either "null" or an empty string, use truthy-falsy
     if (this.state.filteredReport.filter.text) {
-      shallowEntry.entries = entries.map((entry) =>
-        this.pruneReportEntry(entry)
-      );
+      shallowEntry.entries = entries
+        .map((entry) => this.pruneReportEntry(entry))
+        .filter((entry) => entry !== null);
     }
 
     return shallowEntry;


### PR DESCRIPTION
## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
