### PR TITLE
Mock scrollIntoView in jsdom to fix flaky BatchReport test

### DIFF
--- a/testplan/web_ui/testing/src/setupTests.js
+++ b/testplan/web_ui/testing/src/setupTests.js
@@ -14,3 +14,6 @@ enableHooks(jest, { dontMockByDefault: true });
 if (typeof window !== "undefined") {
   window.URL.createObjectURL = function () {};
 }
+
+// jsdom does not implement scrollIntoView
+Element.prototype.scrollIntoView = jest.fn();


### PR DESCRIPTION
## Summary
- Added `Element.prototype.scrollIntoView = jest.fn()` to `setupTests.js` to mock the unimplemented jsdom API
- Fixes flaky test: "batch report > Merge Multitest > navigates to correct testcase and fetches assertions file after merge"
- jsdom does not implement `scrollIntoView`, so `TreeView.js:77`'s `useEffect` call intermittently throws a `TypeError` that disrupts the React render cycle

## Test plan
- [ ] Verify the previously flaky test passes consistently
- [ ] Verify no other tests are affected by the global mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)