### PR TITLE
Require Node 22+

### DIFF
--- a/testplan/web_ui/testing/package.json
+++ b/testplan/web_ui/testing/package.json
@@ -2,9 +2,8 @@
   "name": "@morgan-stanley/testplan",
   "version": "0.2.0",
   "private": true,
-  "packageManager": "pnpm@10.32.1",
   "engines": {
-    "node": ">=24.0.0",
+    "node": ">=22.0.0",
     "npm": ">=11.11.1",
     "pnpm": ">=10.32.1"
   },


### PR DESCRIPTION
## Bug / Requirement Description
Require Node 22+ (instead of 24 added in the Github Actions Node upgrade PR)

## Solution description
Modified package.json

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
