### PR TITLE
Reply Stop to messages from inactive workers

### DIFF
--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -25,6 +25,7 @@ from schema import And, Or, Use
 
 from testplan.common import entity
 from testplan.common.config import ConfigOption
+from testplan.common.serialization import serialize
 from testplan.common.utils import selector, strings
 from testplan.common.utils.thread import interruptible_join
 from testplan.common.utils.timing import wait_until_predicate
@@ -524,6 +525,8 @@ class Pool(Executor):
             request.data,
         )
 
+        response = Message(**self._metadata)  # type: ignore[arg-type]
+
         if not worker.active:
             self.logger.warning(
                 "Message from inactive worker %s - %s, %s",
@@ -531,8 +534,17 @@ class Pool(Executor):
                 request.cmd,
                 request.data,
             )
-
-        response = Message(**self._metadata)  # type: ignore[arg-type]
+            stop_response = response.make(Message.Stop)
+            try:
+                worker.respond(stop_response)
+            except RuntimeError:
+                # Worker's transport was disconnected during abort. Reply
+                # on the pool's server socket to keep the ZMQ REQ/REP
+                # contract balanced.
+                conn_sock = getattr(self._conn, "sock", None)
+                if conn_sock is not None:
+                    conn_sock.send(serialize(stop_response))
+            return
 
         if not self.active or self.status == self.STATUS.STOPPING:
             worker.respond(response.make(Message.Stop))

--- a/testplan/runners/pools/child.py
+++ b/testplan/runners/pools/child.py
@@ -215,8 +215,10 @@ class ChildLoop:
                     hb_resp = self._transport.send_and_receive(
                         message.make(message.Heartbeat, data=time.time())
                     )
-                    if hb_resp is None:
-                        self.logger.critical("Pool seems dead, child exits.")
+                    if hb_resp is None or hb_resp.cmd == Message.Stop:
+                        self.logger.critical(
+                            "Pool seems dead or stopping, child exits."
+                        )
                         self.exit_loop()
                         break
                     else:

--- a/tests/unit/testplan/runners/pools/test_pool_base.py
+++ b/tests/unit/testplan/runners/pools/test_pool_base.py
@@ -2,6 +2,7 @@
 
 import os
 import random
+import time
 
 from testplan import Task
 from testplan.common.utils.path import default_runpath
@@ -199,3 +200,81 @@ class TestPoolIsolated:
             worker = pool._workers["0"]
 
         assert worker._restart_count == 0
+
+    def test_inactive_worker_message_replies_stop(self):
+        """
+        A message from an inactive worker must not reach any _handle_* —
+        the pool must immediately reply Stop and leave scheduler state
+        intact.
+        """
+        pool = pools_base.Pool(
+            name="MyPool", size=1, worker_type=ControllableWorker
+        )
+        pool.cfg.set_local("skip_strategy", SkipStrategy.noop())
+        pool._start_monitor_thread = False
+
+        with pool:
+            worker = pool._workers["0"]
+            task = Task(target=Runnable(5))
+            pool.add(task, uid=task.uid())
+
+            # Flip the worker into the same state as a treadmill-aborted
+            # worker: entity.active returns False.
+            worker._should_abort = True
+            assert not worker.active
+
+            msg_factory = communication.Message(**worker.metadata)
+
+            # Heartbeat from inactive worker → expect Stop, last_heartbeat
+            # unchanged.
+            prev_hb = worker.last_heartbeat
+            received = worker.transport.send_and_receive(
+                msg_factory.make(msg_factory.Heartbeat, data=time.time())
+            )
+            assert received.cmd == communication.Message.Stop
+            assert worker.last_heartbeat == prev_hb
+
+            # TaskPullRequest from inactive worker → expect Stop, task
+            # stays in unassigned (i.e. not orphaned).
+            unassigned_before = pool.unassigned.size()
+            received = worker.transport.send_and_receive(
+                msg_factory.make(msg_factory.TaskPullRequest, data=1)
+            )
+            assert received.cmd == communication.Message.Stop
+            assert pool.unassigned.size() == unassigned_before
+
+    def test_inactive_worker_with_disconnected_transport(self):
+        """
+        If the worker's transport is already disconnected when the pool
+        processes a late message, worker.respond raises RuntimeError. The
+        pool must swallow it (for QueueServer there is no .sock to fall
+        back to) rather than propagate — scheduler state stays intact.
+        """
+        pool = pools_base.Pool(
+            name="MyPool", size=1, worker_type=ControllableWorker
+        )
+        pool.cfg.set_local("skip_strategy", SkipStrategy.noop())
+        pool._start_monitor_thread = False
+
+        with pool:
+            worker = pool._workers["0"]
+            task = Task(target=Runnable(5))
+            pool.add(task, uid=task.uid())
+
+            # Both entity and transport inactive — matches state after
+            # _decommission_worker + worker.abort().
+            worker._should_abort = True
+            worker.transport.disconnect()
+            assert not worker.active
+            assert not worker.transport.active
+
+            msg_factory = communication.Message(**worker.metadata)
+            request = msg_factory.make(msg_factory.TaskPullRequest, data=1)
+
+            unassigned_before = pool.unassigned.size()
+
+            # Drive handle_request directly — exceptions would propagate
+            # here (the _loop try/except would otherwise swallow them).
+            pool.handle_request(request)
+
+            assert pool.unassigned.size() == unassigned_before


### PR DESCRIPTION

## Bug / Requirement Description
When a worker is aborted (e.g. heartbeat lag exceeded), Heartbeat and TaskPullRequest messages already in flight arrive at the pool and fall through to the normal handlers. This will raise errors on the respond call and also pops a task UID that nothing owns -- leaving the task orphaned in _input/ongoing at end-of-run.

## Solution description
Early-return a Stop response when worker.active is False, before any handler dispatch. Also fix child.py's heartbeat branch to exit on Stop, mirroring the existing TaskPullRequest handling

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
