### PR TITLE
Protect against race conditions for late messages from workers

### DIFF
--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -25,7 +25,6 @@ from schema import And, Or, Use
 
 from testplan.common import entity
 from testplan.common.config import ConfigOption
-from testplan.common.serialization import serialize
 from testplan.common.utils import selector, strings
 from testplan.common.utils.thread import interruptible_join
 from testplan.common.utils.timing import wait_until_predicate
@@ -403,7 +402,9 @@ class Pool(Executor):
         self._workers = entity.Environment(parent=self)
         self._conn = self.CONN_MANAGER()
         self._conn.parent = self
-        self._pool_lock = threading.Lock()
+        # RLock because _handle_taskpull_request holds the lock and may
+        # call self._early_stop_worker, which RemotePool re-acquires.
+        self._pool_lock = threading.RLock()
         self._metadata: Optional[Dict[str, str]] = None
         # Will set False when Pool is starting.
         self._exit_loop = True
@@ -534,16 +535,7 @@ class Pool(Executor):
                 request.cmd,
                 request.data,
             )
-            stop_response = response.make(Message.Stop)
-            try:
-                worker.respond(stop_response)
-            except RuntimeError:
-                # Worker's transport was disconnected during abort. Reply
-                # on the pool's server socket to keep the ZMQ REQ/REP
-                # contract balanced.
-                conn_sock = getattr(self._conn, "sock", None)
-                if conn_sock is not None:
-                    conn_sock.send(serialize(stop_response))
+            worker.respond(response.make(Message.Stop))
             return
 
         if not self.active or self.status == self.STATUS.STOPPING:
@@ -593,62 +585,73 @@ class Pool(Executor):
                     worker.respond(response.make(Message.DiscardPending))
                     return
 
-            for _ in range(request.data):
-                try:
-                    priority, uid = self.unassigned.get()
-                except queue.Empty:
-                    self.logger.debug("No tasks to assign to %s", worker)
-                    if self._early_stop_worker(worker):
-                        worker.respond(response.make(Message.Stop))
-                        return
-                    break
+            # Serialize with _handle_inactive so the monitor can't
+            # decommission `worker` mid-assignment and orphan the task.
+            with self._pool_lock:
+                # Re-check: active may have flipped between the
+                # top-level check and acquiring the lock.
+                if not worker.active:
+                    worker.respond(response.make(Message.Stop))
+                    return
 
-                task = self._input[uid]
-                worker.rebase_task_path(task)
+                for _ in range(request.data):
+                    try:
+                        priority, uid = self.unassigned.get()
+                    except queue.Empty:
+                        self.logger.debug("No tasks to assign to %s", worker)
+                        if self._early_stop_worker(worker):
+                            worker.respond(response.make(Message.Stop))
+                            return
+                        break
 
-                if self._can_assign_task(task):
-                    if (
-                        self._task_reassign_cnt[uid]
-                        > self._task_reassign_limit
-                    ):
+                    task = self._input[uid]
+                    worker.rebase_task_path(task)
+
+                    if self._can_assign_task(task):
+                        if (
+                            self._task_reassign_cnt[uid]
+                            > self._task_reassign_limit
+                        ):
+                            self._discard_task(
+                                uid,
+                                f"{self._input[uid]} already reached pool reassign limit:"
+                                f" {self._task_reassign_limit}",
+                            )
+                            continue
+                        else:
+                            if self._can_assign_task_to_worker(task, worker):
+                                self.logger.user_info(
+                                    "Scheduling %s to %s %s",
+                                    task,
+                                    worker,
+                                    "(rerun {})".format(task.rerun_cnt)
+                                    if task.rerun_cnt > 0
+                                    else "",
+                                )
+                                worker.assigned.add(uid)
+                                tasks.append(task)
+                                task.executors.setdefault(self.cfg.name, set())
+                                task.executors[self.cfg.name].add(worker.uid())
+                                self.record_execution(uid)
+                            else:
+                                self.logger.user_info(
+                                    "Cannot schedule %s to %s", task, worker
+                                )
+                                self.unassigned.put(task.priority, uid)
+                                self._task_reassign_cnt[uid] += 1
+                    else:
+                        # Later may create a default local pool as failover option
                         self._discard_task(
                             uid,
-                            f"{self._input[uid]} already reached pool reassign limit:"
-                            f" {self._task_reassign_limit}",
+                            f"{self._input[uid]} cannot be executed in {self}",
                         )
-                        continue
-                    else:
-                        if self._can_assign_task_to_worker(task, worker):
-                            self.logger.user_info(
-                                "Scheduling %s to %s %s",
-                                task,
-                                worker,
-                                "(rerun {})".format(task.rerun_cnt)
-                                if task.rerun_cnt > 0
-                                else "",
-                            )
-                            worker.assigned.add(uid)
-                            tasks.append(task)
-                            task.executors.setdefault(self.cfg.name, set())
-                            task.executors[self.cfg.name].add(worker.uid())
-                            self.record_execution(uid)
-                        else:
-                            self.logger.user_info(
-                                "Cannot schedule %s to %s", task, worker
-                            )
-                            self.unassigned.put(task.priority, uid)
-                            self._task_reassign_cnt[uid] += 1
-                else:
-                    # Later may create a default local pool as failover option
-                    self._discard_task(
-                        uid,
-                        f"{self._input[uid]} cannot be executed in {self}",
-                    )
 
-            if tasks:
-                worker.respond(response.make(Message.TaskSending, data=tasks))
-                worker.requesting = request.data - len(tasks)
-                return
+                if tasks:
+                    worker.respond(
+                        response.make(Message.TaskSending, data=tasks)
+                    )
+                    worker.requesting = request.data - len(tasks)
+                    return
 
         worker.requesting = request.data
         worker.respond(response.make(Message.Ack))

--- a/testplan/runners/pools/connection.py
+++ b/testplan/runners/pools/connection.py
@@ -146,14 +146,17 @@ class QueueClient(Client):
     def respond(self, message: Message) -> None:
         """
         Used by :py:class:`~testplan.runners.pools.base.Pool` to respond to
-        worker request.
+        worker request. No-op once disconnected — the worker is gone and
+        there is no REP state machine to unwedge.
 
         :param message: Respond message.
         """
         if self.active:
             self.responses.append(message)
         else:
-            raise RuntimeError("Responding to inactive worker")
+            self.logger.debug(
+                "QueueClient inactive; dropping %s response", message.cmd
+            )
 
 
 class ZMQClient(Client):
@@ -237,12 +240,13 @@ class ZMQClient(Client):
         return None
 
 
-class ZMQClientProxy:
+class ZMQClientProxy(logger.Loggable):
     """
     Representative of a process worker's transport in local worker object.
     """
 
     def __init__(self) -> None:
+        super().__init__()
         self.active = False
         self.connection: Optional[zmq.Socket] = None
         self.address: Optional[str] = None
@@ -254,20 +258,30 @@ class ZMQClientProxy:
 
     def disconnect(self) -> None:
         self.active = False
-        self.connection = None
         self.address = None
+        # Retain self.connection so respond can unwedge the REP after
+        # the worker aborts. Socket is owned by ZMQServer.
 
     def respond(self, message: Message) -> None:
         """
         Used by :py:class:`~testplan.runners.pools.base.Pool` to respond to
-        worker request.
+        worker request. When the proxy is disconnected, send Stop on the
+        retained REP socket so it isn't left wedged waiting for a reply.
 
         :param message: Respond message.
         """
         if self.active:
             self.connection.send(serialize(message))  # type: ignore[union-attr]
         else:
-            raise RuntimeError("Responding to inactive worker")
+            self.logger.warning(
+                "ZMQClientProxy disconnected; sending Stop in place of"
+                " %s to keep pool REP unwedged",
+                message.cmd,
+            )
+            self.connection.send(  # type: ignore[union-attr]
+                serialize(Message().make(Message.Stop)),
+                flags=zmq.NOBLOCK,
+            )
 
 
 class Server(entity.Resource, metaclass=abc.ABCMeta):

--- a/tests/unit/testplan/runners/pools/test_pool_base.py
+++ b/tests/unit/testplan/runners/pools/test_pool_base.py
@@ -1,13 +1,18 @@
 """TODO."""
 
 import os
+import queue
 import random
 import time
+from unittest import mock
+
+import zmq
 
 from testplan import Task
+from testplan.common.serialization import deserialize, serialize
 from testplan.common.utils.path import default_runpath
 from testplan.runners.pools import base as pools_base
-from testplan.runners.pools import communication
+from testplan.runners.pools import communication, connection
 from testplan.runners.pools.base import TaskQueue
 from testplan.testing.common import SkipStrategy
 from tests.unit.testplan.runners.pools.tasks.data.sample_tasks import Runnable
@@ -246,9 +251,10 @@ class TestPoolIsolated:
     def test_inactive_worker_with_disconnected_transport(self):
         """
         If the worker's transport is already disconnected when the pool
-        processes a late message, worker.respond raises RuntimeError. The
-        pool must swallow it (for QueueServer there is no .sock to fall
-        back to) rather than propagate — scheduler state stays intact.
+        processes a late message, ``worker.respond`` is a silent no-op
+        on ``QueueClient`` (and unwedges the REP on ``ZMQClientProxy``).
+        ``handle_request`` must complete normally and leave scheduler
+        state intact.
         """
         pool = pools_base.Pool(
             name="MyPool", size=1, worker_type=ControllableWorker
@@ -278,3 +284,130 @@ class TestPoolIsolated:
             pool.handle_request(request)
 
             assert pool.unassigned.size() == unassigned_before
+
+    def test_handle_taskpull_inactive_under_pool_lock(self):
+        """
+        Re-check under _pool_lock catches a worker decommissioned
+        after the top-level active-check: reply Stop, no orphan.
+        """
+        pool = pools_base.Pool(
+            name="MyPool", size=1, worker_type=ControllableWorker
+        )
+        pool.cfg.set_local("skip_strategy", SkipStrategy.noop())
+        pool._start_monitor_thread = False
+
+        with pool:
+            worker = pool._workers["0"]
+            task = Task(target=Runnable(5))
+            pool.add(task, uid=task.uid())
+
+            worker._should_abort = True
+            assert not worker.active
+
+            msg_factory = communication.Message(**worker.metadata)
+            request = msg_factory.make(msg_factory.TaskPullRequest, data=1)
+            response = communication.Message(**pool._metadata)
+
+            unassigned_before = pool.unassigned.size()
+            pool._handle_taskpull_request(worker, request, response)
+
+            assert pool.unassigned.size() == unassigned_before
+            assert task.uid() not in worker.assigned
+
+            received = worker.transport.receive()
+            assert received.cmd == communication.Message.Stop
+
+    def test_handle_request_handler_raises_with_disconnected_transport(self):
+        """
+        Handler raises and disconnects mid-flight; handle_request must
+        swallow and the silent-drop in QueueClient.respond must leave
+        no stale response queued.
+        """
+        pool = pools_base.Pool(
+            name="MyPool", size=1, worker_type=ControllableWorker
+        )
+        pool.cfg.set_local("skip_strategy", SkipStrategy.noop())
+        pool._start_monitor_thread = False
+
+        with pool:
+            worker = pool._workers["0"]
+
+            def evil_handler(w, req, resp):
+                w.transport.disconnect()
+                raise RuntimeError("simulated handler failure")
+
+            pool._request_handlers[communication.Message.ConfigRequest] = (
+                evil_handler
+            )
+
+            msg_factory = communication.Message(**worker.metadata)
+            request = msg_factory.make(msg_factory.ConfigRequest, data=None)
+
+            pool.handle_request(request)
+
+            assert worker.transport.responses == []
+
+
+def test_zmq_proxy_respond_disconnected_sends_stop():
+    """
+    Disconnected proxy: respond unwedges the REP by sending Stop on
+    the retained socket instead of raising.
+    """
+    server = connection.ZMQServer()
+    server._sock = mock.MagicMock()
+    server._address = "127.0.0.1:0"
+
+    proxy = connection.ZMQClientProxy()
+    proxy.connect(server)
+    proxy.disconnect()
+
+    msg = communication.Message().make(
+        communication.Message.TaskSending, data=["task"]
+    )
+    proxy.respond(msg)
+
+    server._sock.send.assert_called_once()
+    decoded = deserialize(server._sock.send.call_args[0][0])
+    assert decoded.cmd == communication.Message.Stop
+
+
+def test_zmq_proxy_respond_after_disconnect_unwedges_real_rep():
+    """
+    Real REP/REQ pair: after recv, REP is in must-send-next. Disconnect +
+    respond must put the REP back into recv-state — a second cycle would
+    EFSM otherwise.
+    """
+    ctx = zmq.Context()
+    rep = ctx.socket(zmq.REP)
+    rep.RCVTIMEO = 1000
+    port = rep.bind_to_random_port("tcp://127.0.0.1")
+    req = ctx.socket(zmq.REQ)
+    req.RCVTIMEO = 1000
+    req.connect(f"tcp://127.0.0.1:{port}")
+    try:
+        heartbeat = communication.Message().make(
+            communication.Message.Heartbeat, data=1
+        )
+        req.send(serialize(heartbeat))
+        assert deserialize(rep.recv()).cmd == communication.Message.Heartbeat
+
+        proxy = connection.ZMQClientProxy()
+        proxy.connection = rep
+        proxy.active = True
+        proxy.disconnect()
+        proxy.respond(
+            communication.Message().make(
+                communication.Message.TaskSending, data=["task"]
+            )
+        )
+
+        # Drain the substituted Stop so REQ is back in send-state.
+        assert deserialize(req.recv()).cmd == communication.Message.Stop
+
+        # If REP weren't unwedged, this recv would raise EFSM.
+        req.send(serialize(heartbeat))
+        assert deserialize(rep.recv()).cmd == communication.Message.Heartbeat
+    finally:
+        req.close()
+        rep.close()
+        ctx.destroy()

--- a/tests/unit/testplan/runners/pools/test_process_worker.py
+++ b/tests/unit/testplan/runners/pools/test_process_worker.py
@@ -1,13 +1,17 @@
 """Unit test for process pool."""
 
+import os
 import platform
 import psutil
 import pytest
 import time
 
-from testplan.runners.pools import process
-from testplan.runners.pools import tasks
+import zmq
+
+from testplan.common.serialization import deserialize, serialize
 from testplan.common.utils import logger
+from testplan.runners.pools import communication, process, tasks
+from testplan.runners.pools.base import Worker
 from testplan.testing.common import SkipStrategy
 
 logger.TESTPLAN_LOGGER.setLevel(logger.DEBUG)
@@ -77,3 +81,77 @@ class TestProcPool:
 
             assert proc_pool.status == proc_pool.status.STOPPED
             assert len(current_proc.children()) == len(start_children)
+
+
+def test_pool_zmq_heartbeat_from_inactive_worker():
+    """
+    Heartbeat from a disconnected worker gets Stop, REP stays unwedged
+    for a second cycle.
+    """
+
+    class StubWorker(process.ProcessWorker):
+        def starting(self):
+            self.status.change(self.STATUS.STARTED)
+
+        def stopping(self):
+            self.status.change(self.STATUS.STOPPED)
+
+        def aborting(self):
+            self._transport.disconnect()
+
+        def _wait_started(self, timeout=None):
+            # Skip ProcessWorker's logfile poll — there's no subprocess.
+            Worker._wait_started(self, timeout=timeout)
+
+        @property
+        def is_alive(self):
+            return self.status.tag == self.STATUS.STARTED
+
+    pool = process.ProcessPool(
+        name="ZMQHBPool",
+        size=1,
+        worker_type=StubWorker,
+        worker_heartbeat=None,
+        async_start=False,
+    )
+    pool.cfg.set_local("skip_strategy", SkipStrategy.noop())
+    pool._start_monitor_thread = False
+
+    with pool:
+        worker = pool._workers["0"]
+
+        ctx = zmq.Context()
+        req = ctx.socket(zmq.REQ)
+        req.RCVTIMEO = 2000
+        req.connect(f"tcp://{pool._conn.address}")
+        try:
+            worker._should_abort = True
+            worker.transport.disconnect()
+            assert not worker.active
+            assert not worker.transport.active
+
+            msg_factory = communication.Message(
+                index=worker.cfg.index, pid=os.getpid()
+            )
+
+            req.send(
+                serialize(
+                    msg_factory.make(
+                        communication.Message.Heartbeat, data=time.time()
+                    )
+                )
+            )
+            assert deserialize(req.recv()).cmd == communication.Message.Stop
+
+            # Second cycle: REP must still be usable.
+            req.send(
+                serialize(
+                    msg_factory.make(
+                        communication.Message.Heartbeat, data=time.time()
+                    )
+                )
+            )
+            assert deserialize(req.recv()).cmd == communication.Message.Stop
+        finally:
+            req.close()
+            ctx.destroy()


### PR DESCRIPTION
## Bug / Requirement Description
There is the possibility of a taskpull leading to an orphan task if the worker is decomissioned halfway through `handle_taskpull`.

## Solution description
Add pool lock to handle_taskpull. Also refactored the fallback of sending a Stop message into ZMQClientProxy

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
