### PR TITLE
Speed up testplan startup by deferring LocationMetadata resolution and fix filepath for testcases wrapped with functools.wrap

### DIFF
--- a/doc/newsfragments/3828_changed.defer_location_metadata.rst
+++ b/doc/newsfragments/3828_changed.defer_location_metadata.rst
@@ -1,1 +1,1 @@
-Sped up testplan startup by deferring ``LocationMetadata`` resolution from import time to listing time, and skipping test metadata collection on runs where no lister is active. Also fixed ``LocationMetadata.from_object`` reporting a wrapper helper's file alongside the original function's line number when the testcase was decorated through ``functools.wraps``.
+Speed up testplan startup by skipping unnecessary source code location resolution, and fix source code location resolution for decorated testcases.

--- a/doc/newsfragments/3828_changed.defer_location_metadata.rst
+++ b/doc/newsfragments/3828_changed.defer_location_metadata.rst
@@ -1,0 +1,1 @@
+Sped up testplan startup by deferring ``LocationMetadata`` resolution from import time to listing time, and skipping test metadata collection on runs where no lister is active. Also fixed ``LocationMetadata.from_object`` reporting a wrapper helper's file alongside the original function's line number when the testcase was decorated through ``functools.wraps``.

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -91,6 +91,7 @@ from testplan.testing import common, filtering, listing, ordering, tagging
 from testplan.testing.base import Test, TestResult
 from testplan.testing.listing import Lister
 from testplan.testing.multitest import MultiTest
+from testplan.testing.multitest.test_metadata import TestMetadata
 from testplan.testing.result import Result
 
 if sys.version_info < (3, 11):
@@ -469,7 +470,7 @@ class TestRunner(Runnable):
         # TODO: check options sanity?
         super(TestRunner, self).__init__(**options)
         # uid to resource, in definition order
-        self._test_metadata: List[Any] = []
+        self._test_metadata: List[TestMetadata] = []
         self._tests: MutableMapping[str, str] = OrderedDict()
         self.result.report = TestReport(
             name=self.cfg.name,
@@ -534,7 +535,8 @@ class TestRunner(Runnable):
                 exporter.parent = self  # type: ignore[attr-defined]
         return self._exporters
 
-    def get_test_metadata(self) -> List[Any]:
+    def get_test_metadata(self) -> List[TestMetadata]:
+        # Only populated when a metadata-based lister is active; empty otherwise.
         return self._test_metadata
 
     def disable_reset_report_uid(self) -> None:
@@ -1238,19 +1240,27 @@ class TestRunner(Runnable):
         if self._is_interactive_run():
             self._register_task_for_interactive(task_info)
 
-        self._register_task(
-            resource, target, uid, task_info.materialized_test.get_metadata()
+        metadata = (
+            task_info.materialized_test.get_metadata()
+            if lister is not None and lister.metadata_based
+            else None
         )
+        self._register_task(resource, target, uid, metadata)
         return uid
 
     def _is_interactive_run(self) -> bool:
         return self.cfg.interactive_port is not None
 
     def _register_task(
-        self, resource: str, target: TestTask, uid: str, metadata: Any
+        self,
+        resource: str,
+        target: TestTask,
+        uid: str,
+        metadata: Optional[TestMetadata],
     ) -> None:
         self._tests[uid] = resource
-        self._test_metadata.append(metadata)
+        if metadata is not None:
+            self._test_metadata.append(metadata)
         self.resources[resource].add(target, uid)  # type: ignore[attr-defined]
 
     def _assemble_task_info(

--- a/testplan/testing/multitest/suite.py
+++ b/testplan/testing/multitest/suite.py
@@ -30,8 +30,17 @@ __PARAMETRIZATION_TEMPLATE__: List[str] = []
 __GENERATED_TESTCASES__: List[Any] = []
 
 
+# Cached resolved static metadata; populated lazily on first read in
+# ``get_testcase_metadata`` / ``get_suite_metadata``.
 TESTCASE_METADATA_ATTRIBUTE = "__testcase_metadata__"
 TESTSUITE_METADATA_ATTRIBUTE = "__testsuite_metadata__"
+
+# Reference to the object whose source location should be used when resolving
+# metadata. For non-parametrized testcases and suites this is the function /
+# class itself; for parametrized variants it points to the original template
+# function so all variants share one resolution.
+TESTCASE_METADATA_SOURCE_ATTRIBUTE = "__testcase_metadata_source__"
+TESTSUITE_METADATA_SOURCE_ATTRIBUTE = "__testsuite_metadata_source__"
 
 
 def _reset_globals() -> None:
@@ -249,8 +258,8 @@ def _gen_skipped_case(skip_reason: str, orig_case: Any) -> Any:
     _f.__should_skip__ = True  # type: ignore[attr-defined]
     setattr(
         _f,
-        TESTCASE_METADATA_ATTRIBUTE,
-        getattr(orig_case, TESTCASE_METADATA_ATTRIBUTE),
+        TESTCASE_METADATA_SOURCE_ATTRIBUTE,
+        getattr(orig_case, TESTCASE_METADATA_SOURCE_ATTRIBUTE),
     )
     # NOTE: interactive reloader will regenerate the skipped testcase
     #             so it will need the __skip__ attribute.
@@ -460,11 +469,7 @@ def _testsuite(klass: Any) -> Any:
     # Suite resolved, clear global variables for resolving the next suite.
     _reset_globals()
 
-    setattr(
-        klass,
-        TESTSUITE_METADATA_ATTRIBUTE,
-        TestSuiteStaticMetadata(LocationMetadata.from_object(klass)),
-    )
+    setattr(klass, TESTSUITE_METADATA_SOURCE_ATTRIBUTE, klass)
 
     return klass
 
@@ -610,12 +615,6 @@ def _testcase(function: Any) -> Any:
     return _testcase_meta()(function)
 
 
-def add_testcase_metadata(
-    func: Callable[..., Any], metadata: TestCaseStaticMetadata
-) -> None:
-    setattr(func, TESTCASE_METADATA_ATTRIBUTE, metadata)
-
-
 def _testcase_meta(
     name: Optional[str] = None,
     tags: Any = None,
@@ -710,12 +709,7 @@ def _testcase_meta(
 
                 __GENERATED_TESTCASES__.append(func)
 
-                add_testcase_metadata(
-                    func,
-                    TestCaseStaticMetadata(
-                        LocationMetadata.from_object(function)
-                    ),
-                )
+                setattr(func, TESTCASE_METADATA_SOURCE_ATTRIBUTE, function)
 
             return function
 
@@ -743,10 +737,7 @@ def _testcase_meta(
 
             __TESTCASES__.append(function.__name__)
 
-            add_testcase_metadata(
-                function,
-                TestCaseStaticMetadata(LocationMetadata.from_object(function)),
-            )
+            setattr(function, TESTCASE_METADATA_SOURCE_ATTRIBUTE, function)
             return function
 
     return wrapper
@@ -969,10 +960,15 @@ def timeout(seconds: int) -> Callable[..., Any]:
 
 
 def get_testcase_metadata(testcase: Any) -> TestCaseMetadata:
-    static_metadata = getattr(
-        testcase,
-        TESTCASE_METADATA_ATTRIBUTE,
-    )
+    # Cache on the source object so all parametrized variants of the same
+    # template share one resolution.
+    source = getattr(testcase, TESTCASE_METADATA_SOURCE_ATTRIBUTE)
+    static_metadata = getattr(source, TESTCASE_METADATA_ATTRIBUTE, None)
+    if static_metadata is None:
+        static_metadata = TestCaseStaticMetadata(
+            LocationMetadata.from_object(source)
+        )
+        setattr(source, TESTCASE_METADATA_ATTRIBUTE, static_metadata)
 
     return TestCaseMetadata(
         **dataclasses.asdict(static_metadata),
@@ -984,14 +980,19 @@ def get_testcase_metadata(testcase: Any) -> TestCaseMetadata:
 def get_suite_metadata(
     suite: Any, include_testcases: bool = True
 ) -> TestSuiteMetadata:
-    static_metadata: TestSuiteStaticMetadata = getattr(
-        suite, TESTSUITE_METADATA_ATTRIBUTE
-    )
+    source = getattr(type(suite), TESTSUITE_METADATA_SOURCE_ATTRIBUTE)
+    static_metadata = getattr(source, TESTSUITE_METADATA_ATTRIBUTE, None)
+    if static_metadata is None:
+        static_metadata = TestSuiteStaticMetadata(
+            LocationMetadata.from_object(source)
+        )
+        setattr(source, TESTSUITE_METADATA_ATTRIBUTE, static_metadata)
+
     testcase_metadata = (
         [
             get_testcase_metadata(tc)
             for _, tc in inspect.getmembers(suite)
-            if hasattr(tc, TESTCASE_METADATA_ATTRIBUTE)
+            if hasattr(tc, TESTCASE_METADATA_SOURCE_ATTRIBUTE)
         ]
         if include_testcases
         else []

--- a/testplan/testing/multitest/suite.py
+++ b/testplan/testing/multitest/suite.py
@@ -31,16 +31,14 @@ __GENERATED_TESTCASES__: List[Any] = []
 
 
 # Cached resolved static metadata; populated lazily on first read in
-# ``get_testcase_metadata`` / ``get_suite_metadata``.
-TESTCASE_METADATA_ATTRIBUTE = "__testcase_metadata__"
-TESTSUITE_METADATA_ATTRIBUTE = "__testsuite_metadata__"
+# ``get_testcase_metadata``.
+TESTCASE_METADATA = "__testcase_metadata__"
 
 # Reference to the object whose source location should be used when resolving
-# metadata. For non-parametrized testcases and suites this is the function /
-# class itself; for parametrized variants it points to the original template
+# testcase metadata. For non-parametrized testcases this is the function
+# itself; for parametrized variants it points to the original template
 # function so all variants share one resolution.
-TESTCASE_METADATA_SOURCE_ATTRIBUTE = "__testcase_metadata_source__"
-TESTSUITE_METADATA_SOURCE_ATTRIBUTE = "__testsuite_metadata_source__"
+TESTCASE_METADATA_SOURCE = "__testcase_metadata_source__"
 
 
 def _reset_globals() -> None:
@@ -258,8 +256,8 @@ def _gen_skipped_case(skip_reason: str, orig_case: Any) -> Any:
     _f.__should_skip__ = True  # type: ignore[attr-defined]
     setattr(
         _f,
-        TESTCASE_METADATA_SOURCE_ATTRIBUTE,
-        getattr(orig_case, TESTCASE_METADATA_SOURCE_ATTRIBUTE),
+        TESTCASE_METADATA_SOURCE,
+        getattr(orig_case, TESTCASE_METADATA_SOURCE),
     )
     # NOTE: interactive reloader will regenerate the skipped testcase
     #             so it will need the __skip__ attribute.
@@ -468,8 +466,6 @@ def _testsuite(klass: Any) -> Any:
 
     # Suite resolved, clear global variables for resolving the next suite.
     _reset_globals()
-
-    setattr(klass, TESTSUITE_METADATA_SOURCE_ATTRIBUTE, klass)
 
     return klass
 
@@ -709,7 +705,7 @@ def _testcase_meta(
 
                 __GENERATED_TESTCASES__.append(func)
 
-                setattr(func, TESTCASE_METADATA_SOURCE_ATTRIBUTE, function)
+                setattr(func, TESTCASE_METADATA_SOURCE, function)
 
             return function
 
@@ -737,7 +733,7 @@ def _testcase_meta(
 
             __TESTCASES__.append(function.__name__)
 
-            setattr(function, TESTCASE_METADATA_SOURCE_ATTRIBUTE, function)
+            setattr(function, TESTCASE_METADATA_SOURCE, function)
             return function
 
     return wrapper
@@ -962,13 +958,13 @@ def timeout(seconds: int) -> Callable[..., Any]:
 def get_testcase_metadata(testcase: Any) -> TestCaseMetadata:
     # Cache on the source object so all parametrized variants of the same
     # template share one resolution.
-    source = getattr(testcase, TESTCASE_METADATA_SOURCE_ATTRIBUTE)
-    static_metadata = getattr(source, TESTCASE_METADATA_ATTRIBUTE, None)
+    source = getattr(testcase, TESTCASE_METADATA_SOURCE)
+    static_metadata = getattr(source, TESTCASE_METADATA, None)
     if static_metadata is None:
         static_metadata = TestCaseStaticMetadata(
             LocationMetadata.from_object(source)
         )
-        setattr(source, TESTCASE_METADATA_ATTRIBUTE, static_metadata)
+        setattr(source, TESTCASE_METADATA, static_metadata)
 
     return TestCaseMetadata(
         **dataclasses.asdict(static_metadata),
@@ -980,19 +976,15 @@ def get_testcase_metadata(testcase: Any) -> TestCaseMetadata:
 def get_suite_metadata(
     suite: Any, include_testcases: bool = True
 ) -> TestSuiteMetadata:
-    source = getattr(type(suite), TESTSUITE_METADATA_SOURCE_ATTRIBUTE)
-    static_metadata = getattr(source, TESTSUITE_METADATA_ATTRIBUTE, None)
-    if static_metadata is None:
-        static_metadata = TestSuiteStaticMetadata(
-            LocationMetadata.from_object(source)
-        )
-        setattr(source, TESTSUITE_METADATA_ATTRIBUTE, static_metadata)
+    static_metadata = TestSuiteStaticMetadata(
+        LocationMetadata.from_object(type(suite))
+    )
 
     testcase_metadata = (
         [
             get_testcase_metadata(tc)
             for _, tc in inspect.getmembers(suite)
-            if hasattr(tc, TESTCASE_METADATA_SOURCE_ATTRIBUTE)
+            if hasattr(tc, TESTCASE_METADATA_SOURCE)
         ]
         if include_testcases
         else []

--- a/testplan/testing/multitest/test_metadata.py
+++ b/testplan/testing/multitest/test_metadata.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from inspect import getsourcefile, getsourcelines
+from inspect import getsourcefile, getsourcelines, isclass, unwrap
 from typing import List, Optional, Union
 
 LOCATION_METADATA_ATTRIBUTE = "__location_metadata__"
@@ -19,8 +19,12 @@ class LocationMetadata:
             return getattr(obj, LOCATION_METADATA_ATTRIBUTE)  # type: ignore[no-any-return]
         try:
             object_name = obj.__name__  # type: ignore[attr-defined]
-            file = getsourcefile(obj)  # type: ignore[arg-type]
-            _, line_no = getsourcelines(obj)  # type: ignore[arg-type]
+            # ``getsourcelines`` follows ``functools.wraps``'s ``__wrapped__``
+            # chain but ``getsourcefile`` does not, so resolve both from the
+            # same unwrapped target.
+            target = obj if isclass(obj) else unwrap(obj)  # type: ignore[arg-type]
+            file = getsourcefile(target)
+            _, line_no = getsourcelines(target)
         except Exception:
             return None  # we do best effort here
         else:

--- a/tests/unit/testplan/runnable/test_base.py
+++ b/tests/unit/testplan/runnable/test_base.py
@@ -2,6 +2,7 @@ import pytest
 import os
 import psutil
 
+from testplan.base import TestplanMock
 from testplan.common.report import ReportCategories
 from testplan.common.utils.exceptions import RunpathInUseError
 from testplan.report import Status
@@ -11,6 +12,8 @@ from testplan.runnable.base import (
     result_for_failed_task,
     TestRunner,
 )
+from testplan.testing.listing import SimpleJsonLister
+from testplan.testing.multitest import MultiTest, suite
 
 
 def test_result_for_failed_task():
@@ -235,3 +238,31 @@ class TestRemovePidFile:
         """No error when _pidfile_path attribute was never set."""
         plan = TestRunner(name="test", parse_cmdline=False)
         plan._remove_pidfile()  # must not raise
+
+
+class TestMetadataCollection:
+    """Per-test metadata is only accumulated when a metadata-based lister is active."""
+
+    def _build_multitest(self, name="MT"):
+        @suite.testsuite
+        class Suite:
+            @suite.testcase
+            def case(self, env, result):
+                pass
+
+        return MultiTest(name=name, suites=[Suite()])
+
+    def test_no_lister_skips_metadata(self, mockplan):
+        """Without a lister, ``get_test_metadata`` stays empty after ``add``."""
+        mockplan.add(self._build_multitest("plain"))
+        assert mockplan.runnable.get_test_metadata() == []
+
+    def test_metadata_lister_populates_metadata(self, runpath):
+        """A metadata-based lister causes per-test metadata to be collected."""
+        plan = TestplanMock(
+            "metadata_listing", runpath=runpath, test_lister=SimpleJsonLister()
+        )
+        plan.add(self._build_multitest("listed"))
+        metadata = plan.runnable.get_test_metadata()
+        assert len(metadata) == 1
+        assert metadata[0].name == "listed"

--- a/tests/unit/testplan/testing/multitest/test_suite.py
+++ b/tests/unit/testplan/testing/multitest/test_suite.py
@@ -1,6 +1,8 @@
 """Unit tests for the testplan.testing.multitest.suite module."""
 
+import functools
 import re
+from unittest import mock
 
 import pytest
 
@@ -8,6 +10,7 @@ from testplan.common.utils.exceptions import should_raise
 from testplan.common.utils.interface import MethodSignatureMismatch
 from testplan.common.utils.strings import format_description
 from testplan.testing.multitest import suite
+from testplan.testing.multitest import test_metadata
 from testplan.testing import tagging
 
 
@@ -248,3 +251,93 @@ def test_skip_if_signature():
 )
 def test_format_description(text, expected):
     format_description(text) == expected
+
+
+def test_location_metadata_not_resolved_at_decoration_time():
+    """Decorating a suite/testcase must not call ``LocationMetadata.from_object``."""
+    with mock.patch.object(
+        test_metadata.LocationMetadata,
+        "from_object",
+        wraps=test_metadata.LocationMetadata.from_object,
+    ) as spy:
+
+        @suite.testsuite
+        class LazyMetadataSuite:
+            @suite.testcase
+            def case_one(self, env, result):
+                pass
+
+            @suite.testcase(parameters=tuple(range(5)))
+            def case_param(self, env, result, value):
+                pass
+
+        assert spy.call_count == 0
+
+
+def test_parametrized_testcases_share_one_location_resolution():
+    """All variants of a parametrized template resolve metadata once."""
+
+    @suite.testsuite
+    class CachedParamSuite:
+        @suite.testcase(parameters=tuple(range(20)))
+        def case(self, env, result, value):
+            pass
+
+    instance = CachedParamSuite()
+    testcases = instance.get_testcases()
+    assert len(testcases) == 20
+
+    with mock.patch.object(
+        test_metadata.LocationMetadata,
+        "from_object",
+        wraps=test_metadata.LocationMetadata.from_object,
+    ) as spy:
+        for tc in testcases:
+            suite.get_testcase_metadata(tc)
+
+        assert spy.call_count == 1
+
+
+def test_skipped_case_reports_original_location():
+    """``_gen_skipped_case`` must preserve the original testcase's location."""
+
+    @suite.testsuite
+    class OriginalSuite:
+        @suite.testcase
+        def case_x(self, env, result):
+            pass
+
+    # ``_gen_skipped_case`` runs against the bound method
+    # taken from a suite instance.
+    instance = OriginalSuite()
+    orig_case = getattr(instance, "case_x")
+    original_metadata = suite.get_testcase_metadata(orig_case)
+
+    skipped = suite._gen_skipped_case("manual skip", orig_case)
+    skipped_metadata = suite.get_testcase_metadata(skipped)
+
+    assert skipped_metadata.location == original_metadata.location
+
+
+def test_location_metadata_unwraps_functools_wraps():
+    """``from_object`` resolves to the original through ``functools.wraps``."""
+
+    def deco(fn):
+        @functools.wraps(fn)
+        def inner(*args, **kwargs):
+            return fn(*args, **kwargs)
+
+        return inner
+
+    def original():
+        pass
+
+    wrapped = deco(original)
+
+    loc_original = test_metadata.LocationMetadata.from_object(original)
+    loc_wrapped = test_metadata.LocationMetadata.from_object(wrapped)
+
+    assert loc_original is not None
+    assert loc_wrapped is not None
+    assert loc_wrapped.file == loc_original.file
+    assert loc_wrapped.line_no == loc_original.line_no


### PR DESCRIPTION
## Bug / Requirement Description
LocationMetadata.from_object is called on every testsuite and testcase decoration. This call is slow due to the repeated calls of getsourcelines and getsourcefile. This info is also only used when --info json is used.
The file path is also wrong for testcases wrapped with functools.wrap, pointing at the wrapper file path instead of the testcase.

## Solution description
Defer LocationMetadata.from_object to only when listing and only list if there is a lister present.
Fix the functools.wrap case by calling unwrap before getsourcelines and getsourcefile.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [X] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
