### PR TITLE
Fix/xfail condition to accept description being none

### DIFF
--- a/doc/en/introduction.rst
+++ b/doc/en/introduction.rst
@@ -350,13 +350,7 @@ Command line
                                 },
                                 "Flaky GTest:SuiteName:CaseName": {
                                     "reason": "test not stable",
-                                    "strict": false,
-                                    "condition": {
-                                        "failed": {
-                                            "type": "Equal",
-                                            "description": "some part of description of that failed assertion"
-                                        }
-                                    }
+                                    "strict": false
                                 },
                                 "Fatal MultiTest:Environment Start:Starting": {
                                     "reason": "env does not start",
@@ -366,6 +360,26 @@ Command line
                                 "Flaky MultiTest:Suite Name:\*": {
                                     "reason": "everything under that suite flaky",
                                     "strict": true
+                                },
+                                "Flaky MultiTest:Suite Name:Case 1": {
+                                    "reason": "test not stable",
+                                    "strict": false,
+                                    "condition": {
+                                        "failed": {
+                                            "type": "Equal",
+                                            "description": "pattern with number \\d+"
+                                        }
+                                    }
+                                },
+                                "Flaky MultiTest:Suite Name:Case 2": {
+                                    "reason": "test not stable",
+                                    "strict": false,
+                                    "condition": {
+                                        "failed": {
+                                            "type": "DictMatch",
+                                            "description": null
+                                        }
+                                    }
                                 }
                             }
 

--- a/doc/newsfragments/3584_changed.xfail_condition_description.rst
+++ b/doc/newsfragments/3584_changed.xfail_condition_description.rst
@@ -1,0 +1,1 @@
+:ref:`Xfail` ``condition`` parameter now accepts a ``failed`` entry with ``description`` of value ``None`` to match assertions whose description are not set.

--- a/testplan/parser.py
+++ b/testplan/parser.py
@@ -191,13 +191,7 @@ A typical input JSON looks like below:
     },
     "Flaky GTest:SuiteName:CaseName": {
         "reason": "test not stable",
-        "strict": false,
-        "condition": {
-            "failed": {
-                "type": "Equal",
-                "description": "some part of description of that failed assertion"
-            }
-        }
+        "strict": false
     },
     "Fatal MultiTest:Environment Start:Starting": {
         "reason": "env does not start",
@@ -207,7 +201,27 @@ A typical input JSON looks like below:
     "Flaky MultiTest:Suite Name:*": {
         "reason": "everything under that suite flaky",
         "strict": true
-    }
+    },
+    "Flaky MultiTest:Suite Name:Case 1": {
+        "reason": "test not stable",
+        "strict": false,
+        "condition": {
+            "failed": {
+                "type": "Equal",
+                "description": "pattern with number \\d+"
+            }
+        }
+    },
+    "Flaky MultiTest:Suite Name:Case 2": {
+        "reason": "test not stable",
+        "strict": false,
+        "condition": {
+            "failed": {
+                "type": "DictMatch",
+                "description": null
+            }
+        }
+    },
 }
 
 with each entry looks like:

--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -71,7 +71,7 @@ TESTCASE_XFAIL_CONDITION_SCHEMA = schema.Schema(
             schema.Optional("error"): schema.Use(re.compile),
             schema.Optional("failed"): {
                 "type": str,
-                "description": schema.Use(re.compile),
+                "description": schema.Or(None, schema.Use(re.compile)),
             },
         },
         schema.Or(

--- a/tests/functional/testplan/testing/multitest/test_xfail.py
+++ b/tests/functional/testplan/testing/multitest/test_xfail.py
@@ -279,6 +279,18 @@ class AssertionXfailSuite:
             description="b1 dict match",
         )
 
+    @testcase
+    def both_fail_no_description(self, env, result):
+        """Both a1 and b1 fail."""
+        result.dict.match(
+            {"foo": 1},
+            {"foo": 2},
+        )
+        result.dict.match(
+            {"bar": 1},
+            {"bar": 2},
+        )
+
 
 def test_dynamic_xfail_testcase_condition_failed():
     plan = TestplanMock(
@@ -352,9 +364,54 @@ def test_dynamic_xfail_testcase_condition_failed():
 
 
 @pytest.mark.parametrize(
+    "condition, xfail_cases",
+    [
+        (
+            {"failed": {"type": "DictMatch", "description": ".*"}},
+            {
+                "only_a1_fails",
+                "both_fail_condition_b1",
+                "both_fail_condition_a1",
+            },
+        ),
+        (
+            {"failed": {"type": "DictMatch", "description": None}},
+            {"both_fail_no_description"},
+        ),
+    ],
+    ids=count(0),
+)
+def test_dynamic_xfail_special_condition(condition, xfail_cases):
+    xfail_tests = {
+        f"Assertion Xfail MT:AssertionXfailSuite:{case}": {
+            "reason": "",
+            "strict": True,
+            "condition": condition,
+        }
+        for case in xfail_cases
+    }
+    plan = TestplanMock(
+        name="dynamic_xfail_special_condition",
+        xfail_tests=xfail_tests,
+    )
+    plan.add(
+        MultiTest(
+            name="Assertion Xfail MT",
+            suites=[AssertionXfailSuite()],
+        )
+    )
+    result = plan.run()
+
+    suite_report = result.report["Assertion Xfail MT"]["AssertionXfailSuite"]
+    for case in xfail_cases:
+        assert suite_report[case].status == Status.XFAIL
+
+
+@pytest.mark.parametrize(
     "bad_condition",
     [
         {"failed": {"passed": False}},
+        {"failed": {"type": "DictMatch"}},
         {"failed": {"type": "DictMatch"}, "error": "some pattern"},
     ],
     ids=count(0),


### PR DESCRIPTION
## Bug / Requirement Description
we have description being none in reports, but xfail condition doesn't allow desc being none previously

## Solution description
see change

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
