### PR TITLE
Refactor/drivers w dependency defined start & stop in threadpool

### DIFF
--- a/doc/newsfragments/3835_changed.threaded_driver_dependencies.rst
+++ b/doc/newsfragments/3835_changed.threaded_driver_dependencies.rst
@@ -1,0 +1,1 @@
+Start and stop dependency-managed drivers within a bounded thread pool to prevent slow driver operations from blocking others.

--- a/doc/newsfragments/3835_changed.threaded_driver_dependencies.rst
+++ b/doc/newsfragments/3835_changed.threaded_driver_dependencies.rst
@@ -1,1 +1,3 @@
 Start and stop dependency-managed drivers within a bounded thread pool to prevent slow driver operations from blocking others.
+
+This may improve overall environment startup time, but stricter dependency definitions or driver implementations may be required where shared state is not safe for concurrent execution.

--- a/examples/Driver/Dependency/test_plan.py
+++ b/examples/Driver/Dependency/test_plan.py
@@ -72,6 +72,10 @@ def main(plan):
             dependencies={
                 server_1: client_1,
                 server_2: (client_2, client_3),
+                # NOTE: client_2 should connect to server_2 before client_3,
+                # NOTE: since server accepts connection solely based on
+                # NOTE: sequence of connecting
+                client_2: client_3,
             },
         )
     )

--- a/testplan/testing/environment/base.py
+++ b/testplan/testing/environment/base.py
@@ -1,5 +1,6 @@
 import copy
 import time
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Dict, TYPE_CHECKING, Optional
 
@@ -10,8 +11,10 @@ from testplan.testing.environment.graph import DriverDepGraph
 
 if TYPE_CHECKING:
     from testplan.testing.base import Test
+    from testplan.testing.environment.graph import D
 
 MINIMUM_CHECK_INTERVAL = 0.1
+MAX_WORKER_THREADS = 32
 
 
 @dataclass
@@ -49,6 +52,14 @@ class DriverPocketwatch:
             return True
         return False
 
+    @property
+    def sleep_interval(self) -> float:
+        t = self.curr_interval
+        self.curr_interval = min(
+            self.curr_interval * self.multiplier, self.interval_cap
+        )
+        return t
+
 
 class TestEnvironment(Environment):
     def __init__(self, parent: Optional["Test"] = None):
@@ -62,6 +73,7 @@ class TestEnvironment(Environment):
         if dependency is None:
             return
 
+        d: D
         for d in dependency.vertices.values():
             if (
                 d.uid() not in self._resources
@@ -95,9 +107,115 @@ class TestEnvironment(Environment):
             "TestEnvironment.stop_in_pool: Would not be invoked by design."
         )
 
+    def _run_single_driver_start(
+        self, driver: "D", watch: DriverPocketwatch
+    ) -> None:
+        """
+        Worker invoked in a per-driver thread. Triggers driver start (which
+        returns quickly because `async_start=True`), then polls
+        ``started_check`` paced by ``watch`` until the driver is ready or a
+        timeout occurs. Records exceptions into ``self.start_exceptions``.
+
+        Raises no exception; failure is signalled by recording into the
+        exception store and returning.
+        """
+        try:
+            watch.record_start()
+            driver.start()
+        except Exception:
+            self._record_resource_exception(
+                message="While starting driver {resource}:\n"
+                "{traceback_exc}\n{fetch_msg}",
+                resource=driver,  # type: ignore[arg-type]
+                msg_store=self.start_exceptions,
+            )
+            raise _DriverStartFailure()
+
+        try:
+            while True:
+                time.sleep(watch.sleep_interval)
+                res = driver.started_check()
+                if res:
+                    # TODO: with thread-based impl this scenario should barely
+                    # TODO: happen, need to remove this branch later
+                    if time.time() >= watch.start_time + watch.total_wait:
+                        driver.logger.error(
+                            "Timeout when starting %s despite"
+                            " it's probably started now. %s",
+                            driver,
+                            TimeoutExceptionInfo(watch.start_time).msg(),
+                        )
+                    driver._after_started()
+                    driver.logger.info("%s started", driver)
+                    return
+                if time.time() >= watch.start_time + watch.total_wait:
+                    raise TimeoutException(
+                        f"Timeout when starting {driver}. "
+                        f"{TimeoutExceptionInfo(watch.start_time).msg()}"
+                    )
+        except Exception:
+            self._record_resource_exception(
+                message="While waiting for driver {resource} to start:\n"
+                "{traceback_exc}\n{fetch_msg}",
+                resource=driver,  # type: ignore[arg-type]
+                msg_store=self.start_exceptions,
+            )
+            raise _DriverStartFailure()
+
+    def _run_single_driver_stop(
+        self, driver: "D", watch: DriverPocketwatch
+    ) -> None:
+        """
+        Worker invoked in a per-driver thread. Triggers driver stop, then
+        polls ``stopped_check_with_watch`` until the driver has stopped or
+        a timeout occurs. Records exceptions and force-stops the driver
+        on failure.
+
+        Raises ``_DriverStopFailure`` to signal a failure to the orchestrator.
+        ---
+        personally i don't quite like the idea of stopped_check_with_watch,
+        but i don't come up with a better way
+        """
+        try:
+            watch.record_start()
+            driver.stop()
+        except Exception:
+            self._record_resource_exception(
+                message="While stopping driver {resource}"
+                ":\n{traceback_exc}\n{fetch_msg}",
+                resource=driver,  # type: ignore[arg-type]
+                msg_store=self.stop_exceptions,
+            )
+            driver.force_stop()
+            driver.logger.info("%s force stopped", driver)
+            raise _DriverStopFailure()
+
+        try:
+            while True:
+                time.sleep(watch.sleep_interval)
+                # TODO: extra hook on driver to suppress stop timeout?
+                if driver.stopped_check_with_watch(watch):
+                    driver._mark_stopped()
+                    driver.logger.info("%s stopped", driver)
+                    return
+        except Exception:
+            self._record_resource_exception(
+                message="While waiting for driver {resource} to stop:\n"
+                "{traceback_exc}\n{fetch_msg}",
+                resource=driver,  # type: ignore[arg-type]
+                msg_store=self.stop_exceptions,
+            )
+            driver.force_stop()
+            driver.logger.info("%s force stopped", driver)
+            raise _DriverStopFailure()
+
     def start(self) -> None:
         """
         Start the drivers either in the legacy way or following dependency.
+
+        When a dependency graph is set, each eligible driver is started in
+        its own worker thread (bounded by a per-call thread pool). The
+        dependency graph still gates which drivers may begin.
         """
         if self._orig_dependency is None:
             # we got no dependency declared, go with the legacy way
@@ -118,67 +236,50 @@ class TestEnvironment(Environment):
                     v.start_timeout, v.started_check_interval
                 )
 
-        while not self._rt_dependency.all_drivers_processed():
-            # schedule new drivers
-            for driver in self._rt_dependency.drivers_to_process():
-                try:
-                    self._pocketwatches[driver.uid()].record_start()
-                    driver.start()
-                except Exception:
-                    self._record_resource_exception(
-                        message="While starting driver {resource}:\n"
-                        "{traceback_exc}\n{fetch_msg}",
-                        resource=driver,  # type: ignore[arg-type]
-                        msg_store=self.start_exceptions,
-                    )
-                    # exception occurred, skip rest of drivers
-                    self._rt_dependency.purge_drivers_to_process()
-                    self._rt_dependency.mark_processing(driver)
-                    self._rt_dependency.mark_failed_to_process(driver)
-                    break
-                else:
-                    self._rt_dependency.mark_processing(driver)
-
-            # check current drivers
-            for driver in self._rt_dependency.drivers_processing():
-                watch: DriverPocketwatch = self._pocketwatches[driver.uid()]
-                try:
-                    res = None
-                    if watch.should_check():
-                        res = driver.started_check()
-                    if res:
-                        if time.time() >= watch.start_time + watch.total_wait:
-                            driver.logger.error(
-                                "Timeout when starting %s despite"
-                                " it's probably started now. %s",
-                                driver,
-                                TimeoutExceptionInfo(watch.start_time).msg(),
-                            )
-                        driver._after_started()
-                        driver.logger.info("%s started", driver)
-                        self._rt_dependency.mark_processed(driver)
-                    elif time.time() >= watch.start_time + watch.total_wait:
-                        raise TimeoutException(
-                            f"Timeout when starting {driver}. "
-                            f"{TimeoutExceptionInfo(watch.start_time).msg()}"
+        n_workers = max(min(MAX_WORKER_THREADS, len(self._rt_dependency)), 1)
+        futures: Dict[int, Future] = {}
+        scheduling_halted = False
+        with ThreadPoolExecutor(max_workers=n_workers) as pool:
+            while not self._rt_dependency.all_drivers_processed():
+                # schedule new drivers (unless a failure has halted scheduling)
+                if not scheduling_halted:
+                    for driver in self._rt_dependency.drivers_to_process():
+                        watch = self._pocketwatches[driver.uid()]
+                        futures[id(driver)] = pool.submit(
+                            self._run_single_driver_start, driver, watch
                         )
-                except Exception:
-                    self._record_resource_exception(
-                        message="While waiting for driver {resource} to start:\n"
-                        "{traceback_exc}\n{fetch_msg}",
-                        resource=driver,  # type: ignore[arg-type]
-                        msg_store=self.start_exceptions,
-                    )
-                    # exception occurred, skip rest of drivers
-                    # continue here as we tend to have fully started drivers
-                    self._rt_dependency.purge_drivers_to_process()
-                    self._rt_dependency.mark_failed_to_process(driver)
+                        self._rt_dependency.mark_processing(driver)
 
-            time.sleep(MINIMUM_CHECK_INTERVAL)
+                # check current drivers
+                progressed = False
+                while not progressed:
+                    time.sleep(MINIMUM_CHECK_INTERVAL)
+                    for driver in self._rt_dependency.drivers_processing():
+                        fut = futures[id(driver)]
+                        if not fut.done():
+                            continue
+                        progressed = True
+                        exc = fut.exception()
+                        del futures[id(driver)]
+                        if exc is None:
+                            self._rt_dependency.mark_processed(driver)
+                        else:
+                            # exception details have already been recorded
+                            # by the worker. Halt new scheduling but let
+                            # in-flight drivers finish naturally.
+                            if not scheduling_halted:
+                                self._rt_dependency.purge_drivers_to_process()
+                                scheduling_halted = True
+                            self._rt_dependency.mark_failed_to_process(driver)
 
     def stop(self, is_reversed: bool = False) -> None:
         """
         Stop drivers while skipping previously skipped ones.
+
+        When a dependency graph is set, each eligible driver is stopped in
+        its own worker thread (bounded by a per-call thread pool), following
+        the transposed dependency graph. Failures do not halt scheduling -
+        teardown is best-effort across all drivers.
         """
         if self._orig_dependency is None:
             return super().stop(is_reversed=is_reversed)
@@ -203,45 +304,42 @@ class TestEnvironment(Environment):
                     v.stop_timeout, v.stopped_check_interval
                 )
 
-        while not self._rt_dependency.all_drivers_processed():
-            # schedule new drivers
-            for driver in self._rt_dependency.drivers_to_process():
-                try:
-                    self._pocketwatches[driver.uid()].record_start()
-                    driver.stop()
-                except Exception as e:
-                    self._record_resource_exception(
-                        message="While stopping driver {resource}"
-                        ":\n{traceback_exc}\n{fetch_msg}",
-                        resource=driver,  # type: ignore[arg-type]
-                        msg_store=self.stop_exceptions,
+        n_workers = max(min(MAX_WORKER_THREADS, len(self._rt_dependency)), 1)
+        futures: Dict[int, Future] = {}
+        with ThreadPoolExecutor(max_workers=n_workers) as pool:
+            while not self._rt_dependency.all_drivers_processed():
+                # schedule new drivers - unlike start(), failures do not
+                # stop scheduling (teardown is best-effort)
+                for driver in self._rt_dependency.drivers_to_process():
+                    watch = self._pocketwatches[driver.uid()]
+                    futures[id(driver)] = pool.submit(
+                        self._run_single_driver_stop, driver, watch
                     )
-                    # driver status should be STOPPED even it failed to stop
-                    driver.force_stop()
-                    driver.logger.info("%s force stopped", driver)
-                    self._rt_dependency.mark_processing(driver)
-                    self._rt_dependency.mark_failed_to_process(driver)
-                else:
                     self._rt_dependency.mark_processing(driver)
 
-            # check current drivers
-            for driver in self._rt_dependency.drivers_processing():
-                watch: DriverPocketwatch = self._pocketwatches[driver.uid()]
-                try:
-                    if driver.stopped_check_with_watch(watch):
-                        driver._mark_stopped()
-                        driver.logger.info("%s stopped", driver)
-                        self._rt_dependency.mark_processed(driver)
-                except Exception:
-                    self._record_resource_exception(
-                        message="While waiting for driver {resource} to stop:\n"
-                        "{traceback_exc}\n{fetch_msg}",
-                        resource=driver,  # type: ignore[arg-type]
-                        msg_store=self.stop_exceptions,
-                    )
-                    # driver status should be STOPPED even it failed to stop
-                    driver.force_stop()
-                    driver.logger.info("%s force stopped", driver)
-                    self._rt_dependency.mark_failed_to_process(driver)
+                # check current drivers
+                progressed = False
+                while not progressed:
+                    time.sleep(MINIMUM_CHECK_INTERVAL)
 
-            time.sleep(MINIMUM_CHECK_INTERVAL)
+                    for driver in self._rt_dependency.drivers_processing():
+                        fut = futures[id(driver)]
+                        if not fut.done():
+                            continue
+                        progressed = True
+                        exc = fut.exception()
+                        del futures[id(driver)]
+                        if exc is None:
+                            self._rt_dependency.mark_processed(driver)
+                        else:
+                            # exception details have already been recorded
+                            # by the worker; the driver was force-stopped.
+                            self._rt_dependency.mark_failed_to_process(driver)
+
+
+class _DriverStartFailure(Exception):
+    """Internal sentinel raised by start workers to signal failure."""
+
+
+class _DriverStopFailure(Exception):
+    """Internal sentinel raised by stop workers to signal failure."""

--- a/testplan/testing/environment/base.py
+++ b/testplan/testing/environment/base.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from testplan.testing.environment.graph import D
 
 MINIMUM_CHECK_INTERVAL = 0.1
-MAX_WORKER_THREADS = 32
+DEFAULT_CONCURRENT_DRIVER_OP_WORKER_UPPERLIMIT = 32
 
 
 @dataclass
@@ -236,7 +236,13 @@ class TestEnvironment(Environment):
                     v.start_timeout, v.started_check_interval
                 )
 
-        n_workers = max(min(MAX_WORKER_THREADS, len(self._rt_dependency)), 1)
+        n_workers = max(
+            min(
+                DEFAULT_CONCURRENT_DRIVER_OP_WORKER_UPPERLIMIT,
+                len(self._rt_dependency),
+            ),
+            1,
+        )
         futures: Dict[int, Future] = {}
         scheduling_halted = False
         with ThreadPoolExecutor(max_workers=n_workers) as pool:
@@ -304,7 +310,13 @@ class TestEnvironment(Environment):
                     v.stop_timeout, v.stopped_check_interval
                 )
 
-        n_workers = max(min(MAX_WORKER_THREADS, len(self._rt_dependency)), 1)
+        n_workers = max(
+            min(
+                DEFAULT_CONCURRENT_DRIVER_OP_WORKER_UPPERLIMIT,
+                len(self._rt_dependency),
+            ),
+            1,
+        )
         futures: Dict[int, Future] = {}
         with ThreadPoolExecutor(max_workers=n_workers) as pool:
             while not self._rt_dependency.all_drivers_processed():

--- a/testplan/testing/multitest/driver/app.py
+++ b/testplan/testing/multitest/driver/app.py
@@ -353,7 +353,7 @@ class App(Driver):
     @property
     def hostname(self) -> str:
         """
-        :return: hostname where the ETSApp is running
+        :return: hostname where the App is running
         """
         return socket.gethostname()
 

--- a/tests/unit/testplan/testing/environment/common.py
+++ b/tests/unit/testplan/testing/environment/common.py
@@ -1,6 +1,5 @@
 import time
 from functools import reduce
-from unittest.mock import call
 
 from testplan.common.utils.timing import DEFAULT_INTERVAL
 from testplan.testing.multitest.driver import Driver
@@ -28,15 +27,22 @@ class MockDriver(Driver):
         mock=None,
         check_wait=0,
         check_interval=DEFAULT_INTERVAL,
-        total_wait=0,
+        starting_wait=0,
+        total_start_wait=0,
+        stopping_wait=0,
+        total_stop_wait=0,
         **options,
     ):
         super().__init__(name, **options)
         self._mock = mock
         self._check_wait = check_wait
         self._check_interval = check_interval
-        self._total_wait = total_wait
+        self._starting_wait = starting_wait
+        self._total_start_wait = total_start_wait
+        self._stopping_wait = stopping_wait
+        self._total_stop_wait = total_stop_wait
         self._start_time = None
+        self._stop_time = None
 
     def pre_start(self):
         self._mock.pre(self.name)
@@ -44,6 +50,8 @@ class MockDriver(Driver):
 
     def starting(self):
         self._start_time = time.time()
+        if self._starting_wait:
+            time.sleep(self._starting_wait)
         super().starting()
 
     @property
@@ -52,13 +60,25 @@ class MockDriver(Driver):
 
     def started_check(self):
         time.sleep(self._check_wait)
-        if time.time() >= self._start_time + self._total_wait:
-            return True
-        return False
+        return time.time() >= self._start_time + self._total_start_wait
 
     def post_start(self):
         self._mock.post(self.name)
         super().post_start()
+
+    def stopping(self):
+        self._stop_time = time.time()
+        if self._stopping_wait:
+            time.sleep(self._stopping_wait)
+        super().stopping()
+
+    @property
+    def stopped_check_interval(self):
+        return self._check_interval
+
+    def stopped_check(self):
+        time.sleep(self._check_wait)
+        return time.time() >= self._stop_time + self._total_stop_wait
 
     def custom_method(self, *args, **kwargs):
         self._mock.custom_method(*args, **kwargs)

--- a/tests/unit/testplan/testing/environment/test_base.py
+++ b/tests/unit/testplan/testing/environment/test_base.py
@@ -1,3 +1,4 @@
+import time
 from unittest.mock import call
 
 import pytest
@@ -175,7 +176,7 @@ class TestSlowDrivers:
     def test_scheduling_1(self, mocker):
         m = mocker.Mock()
         env = TestEnvironment()
-        a = MockDriver("a", m, total_wait=1)
+        a = MockDriver("a", m, total_start_wait=1)
         b = MockDriver("b", m)
         c = MockDriver("c", m)
         d = MockDriver("d", m)
@@ -195,8 +196,8 @@ class TestSlowDrivers:
     def test_scheduling_2(self, mocker):
         m = mocker.Mock()
         env = TestEnvironment()
-        a = MockDriver("a", m, total_wait=0.5)
-        b = MockDriver("b", m, total_wait=2)
+        a = MockDriver("a", m, total_start_wait=0.5)
+        b = MockDriver("b", m, total_start_wait=2)
         c = MockDriver("c", m)
         d = MockDriver("d", m)
         for d_ in [a, b, c, d]:
@@ -211,7 +212,7 @@ class TestSlowDrivers:
     def test_scheduling_3(self, mocker):
         m = mocker.Mock()
         env = TestEnvironment()
-        a = MockDriver("a", m, total_wait=0.5)
+        a = MockDriver("a", m, total_start_wait=0.5)
         b = MockDriver("b", m)
         c = MockDriver("c", m, check_interval=1)
         for d_ in [a, b, c]:
@@ -252,7 +253,7 @@ class TestExceptionThrown:
         )
         assert a.status == a.status.STARTING
         assert b.status == b.status.NONE
-        assert c.status == c.status.NONE
+        assert c.status == c.status.STARTED
         env.stop()
 
     def test_started_check_failed(self, mocker):
@@ -324,7 +325,7 @@ class TestExceptionThrown:
     def test_timeout_ordinary(self, mocker):
         m = mocker.Mock()
         env = TestEnvironment()
-        a = MockDriver("a", m, total_wait=2, timeout=1)
+        a = MockDriver("a", m, total_start_wait=2, timeout=1)
         b = MockDriver("b", m)
 
         for d_ in [a, b]:
@@ -337,6 +338,7 @@ class TestExceptionThrown:
         )
         assert a.status == a.status.STARTING
         assert b.status == b.status.NONE
+        env.stop()
 
     def test_timeout_critical(self, mocker):
         m = mocker.Mock()
@@ -351,4 +353,213 @@ class TestExceptionThrown:
         assert len(env.start_exceptions) == 0
         assert a.status == a.status.STARTED
         assert b.status == b.status.STARTED
+        env.stop()
+
+    def test_both_failures_recorded(self, mocker):
+        """
+        Two independent drivers both fail in `starting` simultaneously.
+        Both exceptions must be captured in ``env.start_exceptions``.
+        An independent third driver must still reach STARTED.
+        """
+        m = mocker.Mock()
+        env = TestEnvironment()
+        a = FlakyDriver("a", m, pass_starting=False)
+        b = FlakyDriver("b", m, pass_starting=False)
+        c = FlakyDriver("c", m)
+        for d_ in [a, b, c]:
+            env.add(d_)
+        env.set_dependency(parse_dependency({}))
+        env.start()
+
+        assert len(env.start_exceptions) == 2
+        keys = list(env.start_exceptions.keys())
+        assert a in keys and b in keys
+        for drv in (a, b):
+            assert "While starting driver FlakyDriver[{}]:".format(
+                drv.name
+            ) in str(env.start_exceptions[drv])
+        assert a.status == a.status.STARTING
+        assert b.status == b.status.STARTING
+        assert c.status == c.status.STARTED
+        env.stop()
+
+    def test_dependency_failure(self, mocker):
+        """
+        With dep ``{(a, b): c}``, c depends on both a and b. b fails to
+        start; a is independent and starts successfully in parallel.
+        c must NOT be scheduled (status remains NONE).
+        """
+        m = mocker.Mock()
+        env = TestEnvironment()
+        a = FlakyDriver("a", m)
+        b = FlakyDriver("b", m, pass_starting=False)
+        c = FlakyDriver("c", m)
+        for d_ in [a, b, c]:
+            env.add(d_)
+        env.set_dependency(parse_dependency({(a, b): c}))
+        env.start()
+
+        assert len(env.start_exceptions) == 1
+        assert "While starting driver FlakyDriver[b]:" in str(
+            list(env.start_exceptions.values())[0]
+        )
+        assert a.status == a.status.STARTED
+        assert b.status == b.status.STARTING
+        assert c.status == c.status.NONE
+        env.stop()
+
+
+class TestThreadedScheduling:
+    def test_slow_driver_not_block_fast_peers_on_start(self, mocker):
+        """
+        With an empty dependency dict all drivers are scheduled at once.
+        A slow driver A (long ``starting`` + long ``started_check``) must
+        not block fast peers B and C: B and C should each have a short
+        per-driver setup time, while A's setup time covers the full slow
+        wait. Total ``env.start()`` wall time should also be on the
+        order of A's wait, not the sum.
+        """
+
+        m = mocker.Mock()
+        env = TestEnvironment()
+        a = MockDriver(
+            "a", m, check_wait=1.0, total_start_wait=2, starting_wait=0.5
+        )
+        b = MockDriver("b", m)
+        c = MockDriver("c", m)
+        for d_ in [a, b, c]:
+            env.add(d_)
+        env.set_dependency(parse_dependency({}))
+
+        t0 = time.time()
+        env.start()
+        elapsed = time.time() - t0
+
+        assert a.status == a.status.STARTED
+        assert b.status == b.status.STARTED
+        assert c.status == c.status.STARTED
+
+        # B and C must finish well before A
+        a_setup = a.timer.last(key="setup").elapsed
+        b_setup = b.timer.last(key="setup").elapsed
+        c_setup = c.timer.last(key="setup").elapsed
+        assert a_setup >= 2, f"A setup unexpectedly fast: {a_setup}s"
+        assert b_setup < 0.5, f"B setup unexpectedly slow: {b_setup}s"
+        assert c_setup < 0.5, f"C setup unexpectedly slow: {c_setup}s"
+
+        # B and C must show as processed before A in the dep graph
+        processed = env._rt_dependency.processed
+        assert processed.index(id(b)) < processed.index(id(a))
+        assert processed.index(id(c)) < processed.index(id(a))
+
+        # Total wall time should be ~A's wait (parallel), not the sum
+        assert elapsed < a_setup + 0.3, (
+            f"env.start() took {elapsed}s, suggests serial scheduling"
+        )
+        env.stop()
+
+    def test_slow_driver_not_block_fast_peers_on_stop(self, mocker):
+        """
+        Stop-side mirror of ``test_slow_driver_not_block_fast_peers``.
+        A slow driver A on stop (long ``stopping`` + long
+        ``stopped_check``) must not block fast peers B and C during
+        ``env.stop()``.
+        """
+        m = mocker.Mock()
+        env = TestEnvironment()
+        a = MockDriver("a", m, stopping_wait=0.5, total_stop_wait=1.5)
+        b = MockDriver("b", m)
+        c = MockDriver("c", m)
+        for d_ in [a, b, c]:
+            env.add(d_)
+        env.set_dependency(parse_dependency({}))
+        env.start()
+
+        t0 = time.time()
+        env.stop()
+        elapsed = time.time() - t0
+
+        assert a.status == a.status.STOPPED
+        assert b.status == b.status.STOPPED
+        assert c.status == c.status.STOPPED
+
+        a_teardown = a.timer.last(key="teardown").elapsed
+        b_teardown = b.timer.last(key="teardown").elapsed
+        c_teardown = c.timer.last(key="teardown").elapsed
+        assert a_teardown >= 1.5, (
+            f"A teardown unexpectedly fast: {a_teardown}s"
+        )
+        assert b_teardown < 0.5, f"B teardown unexpectedly slow: {b_teardown}s"
+        assert c_teardown < 0.5, f"C teardown unexpectedly slow: {c_teardown}s"
+
+        # B and C must show as processed before A in the (stop) dep graph
+        processed = env._rt_dependency.processed
+        assert processed.index(id(b)) < processed.index(id(a))
+        assert processed.index(id(c)) < processed.index(id(a))
+
+        # Total wall time should be ~A's teardown (parallel), not the sum
+        assert elapsed < a_teardown + 0.3, (
+            f"env.stop() took {elapsed}s, suggests serial teardown"
+        )
+
+    def test_pool_size_capping_with_late_joiner(self, mocker):
+        """
+        Patch ``MAX_WORKER_THREADS`` to 4 with five independent drivers
+        a, b, c, d, e (a/c/d/e slow, b fast). The first scheduling round
+        fills all 4 slots with a, b, c, d. b finishes quickly and frees
+        a slot which e then takes; e runs alongside a, c, d for its own
+        slow duration. Total elapsed should not be less than ~slow_a
+        (the longest single window) and overall validates that the pool
+        cap is honored (e cannot start in parallel with a from t=0).
+        """
+        mocker.patch("testplan.testing.environment.base.MAX_WORKER_THREADS", 4)
+        m = mocker.Mock()
+        slow, fast = 1.0, 0.2
+        env = TestEnvironment()
+        a = MockDriver("a", m, starting_wait=slow)
+        b = MockDriver("b", m, starting_wait=fast)
+        c = MockDriver("c", m, starting_wait=slow)
+        d = MockDriver("d", m, starting_wait=slow)
+        e = MockDriver("e", m, starting_wait=slow)
+        for d_ in [a, b, c, d, e]:
+            env.add(d_)
+        env.set_dependency(parse_dependency({}))
+
+        t0 = time.time()
+        env.start()
+        elapsed = time.time() - t0
+
+        for drv in (a, b, c, d, e):
+            assert drv.status == drv.status.STARTED
+
+        a_setup = a.timer.last(key="setup").elapsed
+        b_setup = b.timer.last(key="setup").elapsed
+        e_setup = e.timer.last(key="setup").elapsed
+        assert a_setup >= slow
+        assert e_setup >= slow
+        assert b_setup < slow, f"B setup unexpectedly slow: {b_setup}s"
+
+        # e could not start at t=0 (pool was full with a/b/c/d); it had
+        # to wait for b's slot to free. Validate that e started strictly
+        # after b finished -- proves the pool cap is honored.
+        b_ended = b.timer.last(key="setup").end
+        e_started = e.timer.last(key="setup").start
+        assert e_started >= b_ended, (
+            f"e started at {e_started} but b ended at {b_ended}; "
+            f"pool cap of 4 not enforced (e ran in parallel with all "
+            f"4 initial drivers)"
+        )
+
+        # Once b's slot is reused by e, all 4 slow drivers run in
+        # parallel within the pool, so total elapsed should be ~slow,
+        # not 2*slow. Bound it tightly to confirm e was not serialized
+        # behind a slow driver.
+        assert elapsed < 2 * slow, (
+            f"env.start() took {elapsed}s; expected < {2 * slow}s "
+            f"(pool of 4 should let a/c/d/e run concurrently after b)"
+        )
+        assert elapsed >= slow + fast, (
+            f"env.start() took {elapsed}s; expected >= {slow + fast}s "
+            f"(at least b + e)"
+        )
         env.stop()

--- a/tests/unit/testplan/testing/environment/test_base.py
+++ b/tests/unit/testplan/testing/environment/test_base.py
@@ -504,15 +504,18 @@ class TestThreadedScheduling:
 
     def test_pool_size_capping_with_late_joiner(self, mocker):
         """
-        Patch ``MAX_WORKER_THREADS`` to 4 with five independent drivers
-        a, b, c, d, e (a/c/d/e slow, b fast). The first scheduling round
-        fills all 4 slots with a, b, c, d. b finishes quickly and frees
-        a slot which e then takes; e runs alongside a, c, d for its own
-        slow duration. Total elapsed should not be less than ~slow_a
-        (the longest single window) and overall validates that the pool
-        cap is honored (e cannot start in parallel with a from t=0).
+        Patch ``DEFAULT_CONCURRENT_DRIVER_OP_WORKER_UPPERLIMIT`` to 4
+        with five independent drivers a, b, c, d, e (a/c/d/e slow, b fast).
+        The first scheduling round fills all 4 slots with a, b, c, d. b
+        finishes quickly and frees a slot which e then takes; e runs alongside
+        a, c, d for its own slow duration. Total elapsed should not be less
+        than ~slow_a (the longest single window) and overall validates that
+        the pool cap is honored (e cannot start in parallel with a from t=0).
         """
-        mocker.patch("testplan.testing.environment.base.MAX_WORKER_THREADS", 4)
+        mocker.patch(
+            "testplan.testing.environment.base.DEFAULT_CONCURRENT_DRIVER_OP_WORKER_UPPERLIMIT",
+            4,
+        )
         m = mocker.Mock()
         slow, fast = 1.0, 0.2
         env = TestEnvironment()


### PR DESCRIPTION
## Bug / Requirement Description
^

## Solution description
see change

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
