### PR TITLE
Revert adding a pool_lock to handle_taskpull_request to prevent the main thread from being stuck due to slow restarts of worker

### DIFF
--- a/testplan/runners/pools/base.py
+++ b/testplan/runners/pools/base.py
@@ -402,9 +402,7 @@ class Pool(Executor):
         self._workers = entity.Environment(parent=self)
         self._conn = self.CONN_MANAGER()
         self._conn.parent = self
-        # RLock because _handle_taskpull_request holds the lock and may
-        # call self._early_stop_worker, which RemotePool re-acquires.
-        self._pool_lock = threading.RLock()
+        self._pool_lock = threading.Lock()
         self._metadata: Optional[Dict[str, str]] = None
         # Will set False when Pool is starting.
         self._exit_loop = True
@@ -585,73 +583,62 @@ class Pool(Executor):
                     worker.respond(response.make(Message.DiscardPending))
                     return
 
-            # Serialize with _handle_inactive so the monitor can't
-            # decommission `worker` mid-assignment and orphan the task.
-            with self._pool_lock:
-                # Re-check: active may have flipped between the
-                # top-level check and acquiring the lock.
-                if not worker.active:
-                    worker.respond(response.make(Message.Stop))
-                    return
+            for _ in range(request.data):
+                try:
+                    priority, uid = self.unassigned.get()
+                except queue.Empty:
+                    self.logger.debug("No tasks to assign to %s", worker)
+                    if self._early_stop_worker(worker):
+                        worker.respond(response.make(Message.Stop))
+                        return
+                    break
 
-                for _ in range(request.data):
-                    try:
-                        priority, uid = self.unassigned.get()
-                    except queue.Empty:
-                        self.logger.debug("No tasks to assign to %s", worker)
-                        if self._early_stop_worker(worker):
-                            worker.respond(response.make(Message.Stop))
-                            return
-                        break
+                task = self._input[uid]
+                worker.rebase_task_path(task)
 
-                    task = self._input[uid]
-                    worker.rebase_task_path(task)
-
-                    if self._can_assign_task(task):
-                        if (
-                            self._task_reassign_cnt[uid]
-                            > self._task_reassign_limit
-                        ):
-                            self._discard_task(
-                                uid,
-                                f"{self._input[uid]} already reached pool reassign limit:"
-                                f" {self._task_reassign_limit}",
-                            )
-                            continue
-                        else:
-                            if self._can_assign_task_to_worker(task, worker):
-                                self.logger.user_info(
-                                    "Scheduling %s to %s %s",
-                                    task,
-                                    worker,
-                                    "(rerun {})".format(task.rerun_cnt)
-                                    if task.rerun_cnt > 0
-                                    else "",
-                                )
-                                worker.assigned.add(uid)
-                                tasks.append(task)
-                                task.executors.setdefault(self.cfg.name, set())
-                                task.executors[self.cfg.name].add(worker.uid())
-                                self.record_execution(uid)
-                            else:
-                                self.logger.user_info(
-                                    "Cannot schedule %s to %s", task, worker
-                                )
-                                self.unassigned.put(task.priority, uid)
-                                self._task_reassign_cnt[uid] += 1
-                    else:
-                        # Later may create a default local pool as failover option
+                if self._can_assign_task(task):
+                    if (
+                        self._task_reassign_cnt[uid]
+                        > self._task_reassign_limit
+                    ):
                         self._discard_task(
                             uid,
-                            f"{self._input[uid]} cannot be executed in {self}",
+                            f"{self._input[uid]} already reached pool reassign limit:"
+                            f" {self._task_reassign_limit}",
                         )
-
-                if tasks:
-                    worker.respond(
-                        response.make(Message.TaskSending, data=tasks)
+                        continue
+                    else:
+                        if self._can_assign_task_to_worker(task, worker):
+                            self.logger.user_info(
+                                "Scheduling %s to %s %s",
+                                task,
+                                worker,
+                                "(rerun {})".format(task.rerun_cnt)
+                                if task.rerun_cnt > 0
+                                else "",
+                            )
+                            worker.assigned.add(uid)
+                            tasks.append(task)
+                            task.executors.setdefault(self.cfg.name, set())
+                            task.executors[self.cfg.name].add(worker.uid())
+                            self.record_execution(uid)
+                        else:
+                            self.logger.user_info(
+                                "Cannot schedule %s to %s", task, worker
+                            )
+                            self.unassigned.put(task.priority, uid)
+                            self._task_reassign_cnt[uid] += 1
+                else:
+                    # Later may create a default local pool as failover option
+                    self._discard_task(
+                        uid,
+                        f"{self._input[uid]} cannot be executed in {self}",
                     )
-                    worker.requesting = request.data - len(tasks)
-                    return
+
+            if tasks:
+                worker.respond(response.make(Message.TaskSending, data=tasks))
+                worker.requesting = request.data - len(tasks)
+                return
 
         worker.requesting = request.data
         worker.respond(response.make(Message.Ack))

--- a/tests/unit/testplan/runners/pools/test_pool_base.py
+++ b/tests/unit/testplan/runners/pools/test_pool_base.py
@@ -285,38 +285,6 @@ class TestPoolIsolated:
 
             assert pool.unassigned.size() == unassigned_before
 
-    def test_handle_taskpull_inactive_under_pool_lock(self):
-        """
-        Re-check under _pool_lock catches a worker decommissioned
-        after the top-level active-check: reply Stop, no orphan.
-        """
-        pool = pools_base.Pool(
-            name="MyPool", size=1, worker_type=ControllableWorker
-        )
-        pool.cfg.set_local("skip_strategy", SkipStrategy.noop())
-        pool._start_monitor_thread = False
-
-        with pool:
-            worker = pool._workers["0"]
-            task = Task(target=Runnable(5))
-            pool.add(task, uid=task.uid())
-
-            worker._should_abort = True
-            assert not worker.active
-
-            msg_factory = communication.Message(**worker.metadata)
-            request = msg_factory.make(msg_factory.TaskPullRequest, data=1)
-            response = communication.Message(**pool._metadata)
-
-            unassigned_before = pool.unassigned.size()
-            pool._handle_taskpull_request(worker, request, response)
-
-            assert pool.unassigned.size() == unassigned_before
-            assert task.uid() not in worker.assigned
-
-            received = worker.transport.receive()
-            assert received.cmd == communication.Message.Stop
-
     def test_handle_request_handler_raises_with_disconnected_transport(self):
         """
         Handler raises and disconnects mid-flight; handle_request must


### PR DESCRIPTION
## Bug / Requirement Description
Requiring the pool lock for taskpull_request means the main thread will be stuck when workers_monitoring is handling a slow restart of worker. This means heartbeat requests will not be answered to and workers may exit prematurely.

## Solution description
Remove the pool lock first. Decide how to handle the edge case of a worker being deactivated mid taskpullrequest in a later pr

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
