### PR TITLE
Fix/two pytest wrapper changes

### DIFF
--- a/doc/newsfragments/3842_changed.pytest_wrapper.rst
+++ b/doc/newsfragments/3842_changed.pytest_wrapper.rst
@@ -1,0 +1,1 @@
+Fix a bug in the pytest wrapper when reporting failures, and enable it to report skipped, xfail and xpass statuses.

--- a/examples/PyTest/pytest_tests.py
+++ b/examples/PyTest/pytest_tests.py
@@ -35,7 +35,7 @@ class TestPytestBasics:
         Similar to above, except this time the test case will always fail.
         """
         print("test output")
-        assert False
+        assert [1, 2] == [2, 3]
 
     @pytest.mark.parametrize("a,b,c", [(1, 2, 3), (-1, -2, -3), (0, 0, 0)])
     def test_parametrization(self, a, b, c):

--- a/testplan/testing/py_test.py
+++ b/testplan/testing/py_test.py
@@ -503,11 +503,18 @@ class _ReportPlugin:
                 )
 
             if report.failed:
+                # TODO: XPASS_STRICT not distinguished yet, wasxfail wasn't
+                # TODO: actually set
+                # TODO: ref: _pytest/skipping.py::pytest_runtest_makereport
                 self._current_case_report.status_override = Status.FAILED
-            # XXX: report.skipped set to True when xfail, how to distinguish?
-            # elif report.skipped:
-            #     self._current_case_report.status_override = Status.SKIPPED
+            elif report.skipped:
+                if hasattr(report, "wasxfail"):
+                    self._current_case_report.status_override = Status.XFAIL
+                else:
+                    self._current_case_report.status_override = Status.SKIPPED
             else:
+                if hasattr(report, "wasxfail"):
+                    self._current_case_report.status_override = Status.XPASS
                 self._current_case_report.pass_if_empty()
             self._current_case_report.runtime_status = RuntimeStatus.FINISHED
 
@@ -614,6 +621,9 @@ class _ReportPlugin:
         """
         if self._quiet:
             config.pluginmanager.unregister(name="terminalreporter")
+            # NOTE: assertion plugin depends on terminalreporter for
+            # NOTE: highlighting certain expressions within assert...
+            config.pluginmanager.unregister(name="assertion")
 
     def pytest_unconfigure(self, config: Any) -> None:
         """
@@ -654,6 +664,8 @@ class _CollectPlugin:
         """
         if self._quiet:
             config.pluginmanager.unregister(name="terminalreporter")
+            # just be consistent with _ReportPlugin
+            config.pluginmanager.unregister(name="assertion")
 
     def pytest_collection_finish(self, session: Any) -> None:
         """

--- a/tests/functional/testplan/testing/test_py_test.py
+++ b/tests/functional/testplan/testing/test_py_test.py
@@ -1,0 +1,60 @@
+"""Functional tests for the PyTest test runner wrapper."""
+
+import os
+
+import pytest
+
+from testplan import TestplanMock
+from testplan.common.utils import logger
+from testplan.common.utils.context import context
+from testplan.report import Status
+from testplan.testing.multitest.driver.tcp import TCPClient, TCPServer
+from testplan.testing.py_test import PyTest
+
+
+@pytest.fixture
+def mockplan_default_log_level(runpath):
+    """
+    mockplan with logger level reset to USER_INFO
+    """
+    yield TestplanMock("plan", logger_level=logger.USER_INFO, runpath=runpath)
+
+
+@pytest.fixture
+def pytest_test_inst(repo_root_path, root_directory):
+    """Return a PyTest test instance, with the example tests as its target."""
+    # For testing purposes, we want to run the pytest example at
+    # examples/PyTest/pytest_tests.py.
+    example_path = os.path.join(
+        repo_root_path, "examples", "PyTest", "pytest_tests.py"
+    )
+
+    rootdir = os.path.commonprefix([root_directory, os.getcwd()])
+
+    return PyTest(
+        name="My PyTest",
+        description="PyTest example test",
+        target=example_path,
+        extra_args=["--rootdir", rootdir],
+        environment=[
+            TCPServer(name="server", host="localhost", port=0),
+            TCPClient(
+                name="client",
+                host=context("server", "{{host}}"),
+                port=context("server", "{{port}}"),
+            ),
+        ],
+    )
+
+
+def test_assertion_recorded(mockplan_default_log_level, pytest_test_inst):
+    mockplan_default_log_level.schedule(pytest_test_inst, runner=None)
+    assert mockplan_default_log_level.run().run is True
+    # NOTE: ref change within _ReportPlugin
+    failed_assr = mockplan_default_log_level.report["My PyTest"][
+        "pytest_tests.py::TestPytestBasics"
+    ]["test_failure"][0]
+    assert failed_assr["description"] != "Exception raised", (
+        "PyTest wrapper issue reoccurred"
+    )
+    assert mockplan_default_log_level.report.status == Status.FAILED

--- a/tests/unit/testplan/testing/test_pytest.py
+++ b/tests/unit/testplan/testing/test_pytest.py
@@ -8,7 +8,8 @@ import pytest
 from testplan import defaults, report
 from testplan.report import TestCaseReport
 from testplan.report.testing.schemas import TestGroupReportSchema
-from testplan.testing import filtering, py_test as pytest_runner
+from testplan.testing import filtering
+from testplan.testing import py_test as pytest_runner
 from tests.unit.testplan.testing import pytest_expected_data
 
 
@@ -195,10 +196,14 @@ def _check_all_testcounts(counter):
     # One testcase is conditionally skipped when not running on a posix OS, so
     # we have to take this into account when checking the pass/fail/skip counts.
     if os.name == "posix":
-        assert counter["passed"] == 8
+        assert counter["passed"] == 6
+        assert counter["xfail"] == 1
+        assert counter["xpass"] == 1
         assert counter["skipped"] == 1
     else:
-        assert counter["passed"] == 7
+        assert counter["passed"] == 5
+        assert counter["xfail"] == 1
+        assert counter["xpass"] == 1
         assert counter["skipped"] == 2
 
     assert counter["failed"] == 4


### PR DESCRIPTION
## Bug / Requirement Description
- fix bug within failure reporting in pytest wrapper
- enable pytest wrapper to report skipped, xfail & xpass

## Solution description
see comments within pr

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
