### PR TITLE
Upgrade UI config to use pnpm 11

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -21,7 +21,7 @@ runs:
         node-version: "24"
     - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       with:
-        version: 10.32.1
+        version: 11.1.2
     - run: uv pip install --system doit setuptools -c constraints.txt
       shell: bash
     - run: CI=false doit -v2 build${{ (inputs.is_dev_build == 'true' && '_dev') || '' }}

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Set up PNPM
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
-          version: 10.32.1
+          version: 11.1.2
       - name: Setup
         run: uv pip install --system doit
       - name: Build

--- a/doc/newsfragments/3689_changed.upgrade_pnpm_to_v11.rst
+++ b/doc/newsfragments/3689_changed.upgrade_pnpm_to_v11.rst
@@ -1,0 +1,1 @@
+Upgrade web UI package manager configuration to use pnpm 11.

--- a/testplan/web_ui/testing/package.json
+++ b/testplan/web_ui/testing/package.json
@@ -5,14 +5,7 @@
   "engines": {
     "node": ">=22.0.0",
     "npm": ">=11.11.1",
-    "pnpm": ">=10.32.1"
-  },
-  "pnpm": {
-    "overrides": {
-      "react": "^17.0.2",
-      "@types/react": "^17.0.2",
-      "cheerio": "1.0.0-rc.12"
-    }
+    "pnpm": ">=11.1.2"
   },
   "dependencies": {
     "@babel/core": "^7.22.0",

--- a/testplan/web_ui/testing/pnpm-lock.yaml
+++ b/testplan/web_ui/testing/pnpm-lock.yaml
@@ -91,12 +91,12 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
-      eslint-plugin-react:
-        specifier: ^7.32.2
-        version: 7.37.5(eslint@8.57.1)
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
+      eslint-plugin-react:
+        specifier: ^7.32.2
+        version: 7.37.5(eslint@8.57.1)
       history:
         specifier: ~4.10.1
         version: 4.10.1

--- a/testplan/web_ui/testing/pnpm-workspace.yaml
+++ b/testplan/web_ui/testing/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+allowBuilds:
+  '@fortawesome/fontawesome-common-types': false
+  core-js: false
+  core-js-pure: false
+  es5-ext: false
+overrides:
+  react: ^17.0.2
+  '@types/react': ^17.0.2
+  cheerio: 1.0.0-rc.12


### PR DESCRIPTION
## Bug / Requirement Description
pnpm v11 is available, but our v10 config is not fully compatible with the new release.

## Solution description
Modified the config.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
