### PR TITLE
Fix/make `change_directory` thread-safe

### DIFF
--- a/testplan/common/utils/path.py
+++ b/testplan/common/utils/path.py
@@ -8,6 +8,7 @@ import getpass
 import contextlib
 import tempfile
 import hashlib
+import threading
 from functools import lru_cache
 from typing import Any, Dict, Generator, IO, List, Optional, Set
 
@@ -69,6 +70,7 @@ def default_runpath(entity: Any) -> str:
 
 
 PWD = "PWD"
+CHDIR_LOCK = threading.Lock()
 
 
 @contextlib.contextmanager
@@ -81,22 +83,23 @@ def change_directory(directory: Optional[str]) -> Generator[None, None, None]:
     :type directory: ``str``
     """
 
-    if directory:  # in case we get a None directory, do nothing
-        old_directory = os.getcwd()
-        old_pwd = os.environ.get(PWD, None)
-        directory = fix_home_prefix(directory)
-        os.chdir(directory)
-        if old_pwd:
-            os.environ[PWD] = directory
-    try:
-        yield
-    finally:
-        if directory:
-            os.chdir(old_directory)
+    with CHDIR_LOCK:
+        if directory:  # in case we get a None directory, do nothing
+            old_directory = os.getcwd()
+            old_pwd = os.environ.get(PWD, None)
+            directory = fix_home_prefix(directory)
+            os.chdir(directory)
             if old_pwd:
-                os.environ[PWD] = old_pwd
-            elif PWD in os.environ:
-                del os.environ[PWD]
+                os.environ[PWD] = directory
+        try:
+            yield
+        finally:
+            if directory:
+                os.chdir(old_directory)
+                if old_pwd:
+                    os.environ[PWD] = old_pwd
+                elif PWD in os.environ:
+                    del os.environ[PWD]
 
 
 def makedirs(path: str) -> None:

--- a/tests/unit/testplan/common/utils/test_path.py
+++ b/tests/unit/testplan/common/utils/test_path.py
@@ -2,6 +2,9 @@
 
 import subprocess
 import re
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -32,3 +35,29 @@ def test_hashfile(tmpdir):
     # Check that the has produced by our hash_file utility matches the
     # reference value.
     assert path.hash_file(tmpfile) == ref_sha
+
+
+def test_change_directory_thread_safe(tmpdir):
+
+    barrier = threading.Barrier(2)
+
+    def racing_worker():
+        cwd = os.getcwd()
+        barrier.wait()
+        with path.change_directory(str(tmpdir)):
+            pass
+        probably_tmpdir = os.getcwd()
+        return probably_tmpdir, cwd
+
+    for _ in range(50):
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            future1 = executor.submit(racing_worker)
+            future2 = executor.submit(racing_worker)
+            result1 = future1.result()
+            result2 = future2.result()
+            assert result1[0] == result1[1], (
+                "thread 1 did not return to original directory"
+            )
+            assert result2[0] == result2[1], (
+                "thread 2 did not return to original directory"
+            )


### PR DESCRIPTION
## Bug / Requirement Description
^

## Solution description
^

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
