### PR TITLE
Fix AttributeError in get_test_context for xfail'd + skip_if testcases

### DIFF
--- a/doc/newsfragments/3856_changed.xfail_skip_if_attribute_error.rst
+++ b/doc/newsfragments/3856_changed.xfail_skip_if_attribute_error.rst
@@ -1,0 +1,1 @@
+Fix ``AttributeError: 'function' object has no attribute '__func__'`` raised in ``get_test_context`` when a testcase listed in ``--xfail-tests`` (or ``xfail_tests=``) is also skipped by a ``@skip_if`` predicate.

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -4,6 +4,7 @@ import collections.abc
 import concurrent.futures
 import functools
 import itertools
+import types
 import warnings
 from typing import (
     Any,
@@ -466,7 +467,16 @@ class MultiTest(testing_base.Test):
                     )
                     data = xfail_data.get(testcase_instance, None)
                     if data is not None:
-                        testcase.__func__.__xfail__ = {
+                        # When a ``@skip_if`` predicate fires, the testcase
+                        # slot holds a plain function (a generated skipped
+                        # case) instead of a bound method, so ``__func__`` is
+                        # absent. Set ``__xfail__`` on whichever we have.
+                        func: Any = (
+                            testcase.__func__
+                            if isinstance(testcase, types.MethodType)
+                            else testcase
+                        )
+                        func.__xfail__ = {
                             "reason": data["reason"],
                             "strict": data["strict"],
                             "condition": data.get("condition"),

--- a/tests/functional/testplan/testing/multitest/test_xfail.py
+++ b/tests/functional/testplan/testing/multitest/test_xfail.py
@@ -12,6 +12,7 @@ from schema import SchemaError
 from testplan import TestplanMock
 from testplan.common.report.base import Status
 from testplan.testing.multitest import MultiTest, testcase, testsuite, xfail
+from testplan.testing.multitest.suite import skip_if
 
 from .test_multitest_drivers import BaseDriver, VulnerableDriver1
 
@@ -588,3 +589,44 @@ def test_xfail_cli():
         starting = env_start["entries"][0]
         assert starting["name"] == "Starting"
         assert starting["status_override"] == "xfail"
+
+
+@testsuite
+class SkipIfXfailSuite:
+    """A suite whose xfail'd testcase is also skipped via ``@skip_if``."""
+
+    @skip_if(lambda testsuite: True)
+    @testcase
+    def skipped_case(self, env, result):
+        result.true(False, description="should never run")
+
+
+def test_dynamic_xfail_with_skip_if():
+    """
+    Regression test for the crash where a testcase listed in ``xfail_tests``
+    that is also skipped by a ``@skip_if`` predicate raised
+    ``AttributeError: 'function' object has no attribute '__func__'`` in
+    ``get_test_context``.
+
+    When ``@skip_if`` fires, the testcase slot on the suite instance holds a
+    plain function rather than a bound method, so ``__func__`` is absent.
+    Building/running the plan must not crash.
+    """
+    plan = TestplanMock(
+        name="dynamic_xfail_with_skip_if",
+        xfail_tests={
+            "Skip Xfail MT:SkipIfXfailSuite:skipped_case": {
+                "reason": "skipped and xfail'd at the same time",
+                "strict": False,
+            },
+        },
+    )
+    plan.add(MultiTest(name="Skip Xfail MT", suites=[SkipIfXfailSuite()]))
+
+    # Must not raise AttributeError during plan setup / run.
+    result = plan.run()
+
+    # A skipped testcase produces no result, so the xfail annotation is a
+    # no-op; the run simply completes without the testcase passing/failing.
+    suite_report = result.report["Skip Xfail MT"]["SkipIfXfailSuite"]
+    assert suite_report["skipped_case"] is not None


### PR DESCRIPTION
When a testcase listed in --xfail-tests (or xfail_tests=) also has a @skip_if predicate that fires, the testcase slot on the suite instance holds a plain function (the generated skipped case) rather than a bound method. The xfail-CLI path in get_test_context unconditionally accessed testcase.__func__, which raised:

    AttributeError: 'function' object has no attribute '__func__'

Guard the access so __xfail__ is set on the function directly when the slot is not a bound method. Add a regression test and newsfragment.

## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
