### PR TITLE
Fix/pytest util & rlock in `change_directory` instead

### DIFF
--- a/testplan/common/utils/path.py
+++ b/testplan/common/utils/path.py
@@ -70,14 +70,15 @@ def default_runpath(entity: Any) -> str:
 
 
 PWD = "PWD"
-CHDIR_LOCK = threading.Lock()
+CHDIR_LOCK = threading.RLock()
 
 
 @contextlib.contextmanager
 def change_directory(directory: Optional[str]) -> Generator[None, None, None]:
     """
     A context manager that changes working directory and returns to original on
-    exit.
+    exit. Note this context manager holds a ``threading.RLock`` during its
+    entire lifespan.
 
     :param directory: Directory to change into.
     :type directory: ``str``

--- a/tests/helpers/example_runner.py
+++ b/tests/helpers/example_runner.py
@@ -7,7 +7,7 @@ import traceback
 
 import pytest
 
-from testplan.common.utils.path import change_directory
+from testplan.common.utils.path import fix_home_prefix
 
 
 SUCCES_EXIT_CODES = (
@@ -27,6 +27,7 @@ def run_example_in_process(
     if caplog is not None:
         caplog.clear()
 
+    root = fix_home_prefix(root)
     sys_path = copy.copy(sys.path)
     sys_argv = copy.copy(sys.argv)
 
@@ -42,10 +43,22 @@ def run_example_in_process(
         sys.path.insert(0, root)
         sys.argv = [""] + cmdline_args
 
-        with change_directory(root), open(filename) as file_obj:
-            file_obj.readline()
-            second_line = file_obj.readline().strip()
-            runpy.run_path(os.path.join(root, filename), run_name="__main__")
+        cwd = os.getcwd()
+        old_pwd = os.environ.get("PWD", None)
+        os.chdir(root)
+        try:
+            with open(filename) as file_obj:
+                file_obj.readline()
+                second_line = file_obj.readline().strip()
+                runpy.run_path(
+                    os.path.join(root, filename), run_name="__main__"
+                )
+        finally:
+            os.chdir(cwd)
+            if old_pwd:
+                os.environ["PWD"] = old_pwd
+            elif "PWD" in os.environ:
+                del os.environ["PWD"]
 
     except SystemExit as e:
         if e.code not in SUCCES_EXIT_CODES:

--- a/tests/unit/testplan/common/utils/test_path.py
+++ b/tests/unit/testplan/common/utils/test_path.py
@@ -61,3 +61,11 @@ def test_change_directory_thread_safe(tmpdir):
             assert result2[0] == result2[1], (
                 "thread 2 did not return to original directory"
             )
+
+
+def test_change_directory_rlock(tmpdir):
+    # as long as this test doesn't hang
+    cwd = os.getcwd()
+    with path.change_directory(str(tmpdir)):
+        with path.change_directory(cwd):
+            pass


### PR DESCRIPTION
## Bug / Requirement Description
^

## Solution description
^

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
