### PR TITLE
Mark passing testcase XPASS when xfail condition doesn't match

### DIFF
--- a/testplan/report/testing/base.py
+++ b/testplan/report/testing/base.py
@@ -686,7 +686,7 @@ class TestCaseReport(Report):
         """
         if self.failed and self._xfail_match_condition(condition):
             self.status_override = Status.XFAIL
-        elif self.passed and self._xfail_partial_match_condition(condition):
+        elif self.passed:
             if strict:
                 self.status_override = Status.XPASS_STRICT
             else:
@@ -723,22 +723,6 @@ class TestCaseReport(Report):
             TestCaseReport._xfail_match_assertion(condition["failed"], entry)
             for entry in self.entries
             if entry.get("passed") is False
-        )
-
-    def _xfail_partial_match_condition(
-        self, condition: Optional[dict]
-    ) -> bool:
-        if not condition:
-            return True
-
-        if "error" in condition:
-            return any(
-                condition["error"].search(log_record.get("message", ""))
-                for log_record in self.logs
-            )
-        return any(
-            TestCaseReport._xfail_match_assertion(condition["failed"], entry)
-            for entry in self.entries
         )
 
     @property

--- a/tests/functional/testplan/testing/multitest/test_xfail.py
+++ b/tests/functional/testplan/testing/multitest/test_xfail.py
@@ -292,6 +292,34 @@ class AssertionXfailSuite:
             {"bar": 2},
         )
 
+    @testcase
+    def passing_no_match(self, env, result):
+        """Both pass; xfail condition's type and description match nothing."""
+        result.dict.match(
+            {"foo": 1},
+            {"foo": 1},
+            description="a1 dict match",
+        )
+        result.dict.match(
+            {"bar": 1},
+            {"bar": 1},
+            description="b1 dict match",
+        )
+
+    @testcase
+    def passing_type_only_match(self, env, result):
+        """Both pass; xfail condition's type matches, description doesn't."""
+        result.dict.match(
+            {"foo": 1},
+            {"foo": 1},
+            description="a1 dict match",
+        )
+        result.dict.match(
+            {"bar": 1},
+            {"bar": 1},
+            description="b1 dict match",
+        )
+
 
 def test_dynamic_xfail_testcase_condition_failed():
     plan = TestplanMock(
@@ -337,6 +365,26 @@ def test_dynamic_xfail_testcase_condition_failed():
                     }
                 },
             },
+            "Assertion Xfail MT:AssertionXfailSuite:passing_no_match": {
+                "reason": "passing, condition matches no entry",
+                "strict": True,
+                "condition": {
+                    "failed": {
+                        "type": "IsTrue",
+                        "description": "c1 dict match",
+                    }
+                },
+            },
+            "Assertion Xfail MT:AssertionXfailSuite:passing_type_only_match": {
+                "reason": "passing, condition type matches but description doesn't",
+                "strict": True,
+                "condition": {
+                    "failed": {
+                        "type": "DictMatch",
+                        "description": "c1 dict match",
+                    }
+                },
+            },
         },
     )
     plan.add(
@@ -353,6 +401,8 @@ def test_dynamic_xfail_testcase_condition_failed():
     neither = suite_report["neither_fails"]
     both_b1 = suite_report["both_fail_condition_b1"]
     both_a1 = suite_report["both_fail_condition_a1"]
+    no_match = suite_report["passing_no_match"]
+    type_only_match = suite_report["passing_type_only_match"]
 
     # only_a1_fails: a1 fails but xfail condition=b1 desc -> no b1 -> not xfail
     assert only_a1.status == Status.FAILED
@@ -362,6 +412,10 @@ def test_dynamic_xfail_testcase_condition_failed():
     assert both_b1.status == Status.XFAIL
     # both_fail_condition_a1: a1+b1 fail, xfail condition=a1 desc -> match -> xfail
     assert both_a1.status == Status.XFAIL
+    # passing_no_match: passing, condition matches no entry -> xpass
+    assert no_match.status == Status.XPASS_STRICT
+    # passing_type_only_match: passing, only type matches (AND semantics) -> xpass
+    assert type_only_match.status == Status.XPASS_STRICT
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Bug / Requirement Description

If a testcase has an xfail entry with a condition, but the condition is not met (the condition's type or description is not matched), the testcase is marked PASSED, but it should be XPASS.

| success | condition matched | status |
|---|---|---|
| passing | no condition, simple xfail entry | XPASS |
| passing | condition's type / description not matched | ***PASS ← this is wrong*** |
| passing | condition's type + description matched | XPASS |
| failing | no condition, simple xfail entry | XFAIL |
| failing | condition's type / description not matched | FAIL |
| failing | condition's type + description matched | XFAIL |

## Solution description

Changed XFAIL marking logic.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
