### PR TITLE
Added an env var to raise an error if parameterized testcase name is too long

### DIFF
--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -1109,6 +1109,12 @@ In the above example, the custom testcase names should be
 ``'Add List 0'`` and ``'Add List 1'``, that is, integer suffixes appended to
 the original testcase names, without any argument showed.
 
+A generated name longer than 255 characters cannot be used, so Testplan warns
+and falls back to the integer-suffixed names described above. Set the
+``TESTPLAN_STRICT_PARAM_NAMES=1`` environment variable to instead raise
+``ParametrizationNameError`` at import time, failing fast rather than degrading
+to index-suffixed names.
+
 .. _parametrization_docstring_func:
 
 Testcase docstring generation

--- a/doc/newsfragments/3852_changed.strict_param_names.rst
+++ b/doc/newsfragments/3852_changed.strict_param_names.rst
@@ -1,0 +1,1 @@
+Setting the ``TESTPLAN_STRICT_PARAM_NAMES=1`` environment variable now makes an over-long parametrized testcase name raise an error instead of falling back to an index-suffixed name with a warning.

--- a/testplan/testing/multitest/parametrization.py
+++ b/testplan/testing/multitest/parametrization.py
@@ -4,6 +4,7 @@ Parametrization support for test cases.
 
 import collections
 import itertools
+import os
 import re
 import warnings
 
@@ -23,9 +24,27 @@ PYTHON_VARIABLE_REGEX = re.compile(PYTHON_VARIABLE_PATTERN)
 # Python attribute names can be of unlimited length but we set a limit here
 MAX_METHOD_NAME_LENGTH = 255
 
+STRICT_PARAM_NAMES_ENV = "TESTPLAN_STRICT_PARAM_NAMES"
+
+
+def _strict_param_names() -> bool:
+    """
+    Whether strict parametrized name generation is enabled. Read from the
+    environment on each call (not cached at import time) so it reflects the
+    running environment and can be toggled in tests.
+    """
+    return os.environ.get(STRICT_PARAM_NAMES_ENV) == "1"
+
 
 class ParametrizationError(ValueError):
     pass
+
+
+class ParametrizationNameError(ParametrizationError):
+    """
+    Raised in strict mode when a proper parametrized testcase name cannot be
+    generated (e.g. it exceeds ``MAX_METHOD_NAME_LENGTH``).
+    """
 
 
 def _check_dict_keys(dictionary, args, required_args):
@@ -331,6 +350,11 @@ def _parametrization_name_func_wrapper(func_name: str, kwargs: dict):
     if len(generated_name) > MAX_METHOD_NAME_LENGTH:
         # Generated method name is a bit too long.
         # Index suffixed names, e.g. "{func_name}__1", "{func_name}__2", will be used.
+        if _strict_param_names():
+            raise ParametrizationNameError(
+                f"Generated method name ({generated_name}) exceeds "
+                f"{MAX_METHOD_NAME_LENGTH} characters."
+            )
         return func_name
 
     return generated_name
@@ -358,6 +382,11 @@ def _parametrization_report_name_func_wrapper(
             )
         if len(generated_name) <= MAX_METHOD_NAME_LENGTH:
             return generated_name
+        elif _strict_param_names():
+            raise ParametrizationNameError(
+                f"Name returned by name_func ({generated_name}) exceeds "
+                f"{MAX_METHOD_NAME_LENGTH} characters."
+            )
         else:
             warnings.warn(
                 f"The name name_func returned ({generated_name}) is too long, using index suffixed names."

--- a/testplan/testing/multitest/parametrization.py
+++ b/testplan/testing/multitest/parametrization.py
@@ -42,9 +42,13 @@ class ParametrizationError(ValueError):
 
 class ParametrizationNameError(ParametrizationError):
     """
-    Raised in strict mode when a proper parametrized testcase name cannot be
-    generated (e.g. it exceeds ``MAX_METHOD_NAME_LENGTH``).
+    Raised in strict mode when a generated parametrized testcase name cannot be used as it exceeds ``MAX_METHOD_NAME_LENGTH``.
     """
+
+    def __init__(self, name: str):
+        super().__init__(
+            f"Generated parametrized testcase name ({name}) exceeds {MAX_METHOD_NAME_LENGTH} characters."
+        )
 
 
 def _check_dict_keys(dictionary, args, required_args):
@@ -351,10 +355,7 @@ def _parametrization_name_func_wrapper(func_name: str, kwargs: dict):
         # Generated method name is a bit too long.
         # Index suffixed names, e.g. "{func_name}__1", "{func_name}__2", will be used.
         if _strict_param_names():
-            raise ParametrizationNameError(
-                f"Generated method name ({generated_name}) exceeds "
-                f"{MAX_METHOD_NAME_LENGTH} characters."
-            )
+            raise ParametrizationNameError(generated_name)
         return func_name
 
     return generated_name
@@ -383,10 +384,7 @@ def _parametrization_report_name_func_wrapper(
         if len(generated_name) <= MAX_METHOD_NAME_LENGTH:
             return generated_name
         elif _strict_param_names():
-            raise ParametrizationNameError(
-                f"Name returned by name_func ({generated_name}) exceeds "
-                f"{MAX_METHOD_NAME_LENGTH} characters."
-            )
+            raise ParametrizationNameError(generated_name)
         else:
             warnings.warn(
                 f"The name name_func returned ({generated_name}) is too long, using index suffixed names."

--- a/tests/functional/testplan/testing/multitest/test_parametrization.py
+++ b/tests/functional/testplan/testing/multitest/test_parametrization.py
@@ -8,7 +8,9 @@ from testplan.defaults import MAX_TEST_NAME_LENGTH
 from testplan.testing.multitest import MultiTest, testsuite, testcase
 from testplan.testing.multitest.parametrization import (
     MAX_METHOD_NAME_LENGTH,
+    STRICT_PARAM_NAMES_ENV,
     ParametrizationError,
+    ParametrizationNameError,
 )
 from testplan.report import (
     TestReport,
@@ -528,6 +530,65 @@ def test_unwanted_testcase_name(mockplan):
         multitest = MultiTest(name="MyMultitest", suites=[MySuite()])
         mockplan.add(multitest)
         mockplan.run()
+
+
+def test_strict_param_names_report_name_too_long(monkeypatch):
+    """
+    In strict mode, an over-long name returned by ``name_func`` should raise
+    ``ParametrizationNameError`` at decoration time instead of warning.
+    """
+    monkeypatch.setenv(STRICT_PARAM_NAMES_ENV, "1")
+    long_string = "c" * (MAX_METHOD_NAME_LENGTH + 1)
+
+    with pytest.raises(ParametrizationNameError, match="exceeds"):
+
+        @testsuite
+        class MySuite:
+            @testcase(
+                parameters=(1,),
+                name_func=lambda func_name, kwargs: long_string,
+            )
+            def sample_test(self, env, result, val):
+                pass
+
+
+def test_strict_param_names_method_name_too_long(monkeypatch):
+    """
+    In strict mode, parameters that produce an over-long generated method
+    name should raise ``ParametrizationNameError`` at decoration time.
+    """
+    monkeypatch.setenv(STRICT_PARAM_NAMES_ENV, "1")
+
+    with pytest.raises(ParametrizationNameError, match="exceeds"):
+
+        @testsuite
+        class MySuite:
+            @testcase(parameters=("a" * MAX_METHOD_NAME_LENGTH,))
+            def sample_test(self, env, result, val):
+                pass
+
+
+def test_strict_param_names_disabled_still_warns(monkeypatch):
+    """
+    With the env var unset (default), the old warn + index-suffixed fallback
+    behavior should be preserved.
+    """
+    monkeypatch.delenv(STRICT_PARAM_NAMES_ENV, raising=False)
+    long_string = "c" * (MAX_METHOD_NAME_LENGTH + 1)
+
+    with pytest.warns(
+        UserWarning,
+        match=f"The name name_func returned \\({long_string}\\) is too long, using index suffixed names.",
+    ):
+
+        @testsuite
+        class MySuite:
+            @testcase(
+                parameters=(1,),
+                name_func=lambda func_name, kwargs: long_string,
+            )
+            def sample_test(self, env, result, val):
+                pass
 
 
 def test_custom_wrapper():


### PR DESCRIPTION
## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [X] Test
- [ ] Example (both test_plan.py and .rst)
- [X] Documentation (API)
- [X] News fragment present for release notes
- [X] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
