### PR TITLE
Raise TypeError for unknown kwargs passed to Testplan

### DIFF
--- a/testplan/base.py
+++ b/testplan/base.py
@@ -238,6 +238,12 @@ class Testplan(entity.RunnableManager):
         otel_logs: bool = False,
         **options: Any,
     ) -> None:
+        if options:
+            unknown = ", ".join(f"'{k}'" for k in sorted(options))
+            raise TypeError(
+                f"Testplan.__init__() got unexpected keyword argument(s): {unknown}"
+            )
+
         # Set mutable defaults.
         if abort_signals is None:
             abort_signals = entity.DEFAULT_RUNNABLE_ABORT_SIGNALS[:]

--- a/tests/unit/testplan/test_plan_base.py
+++ b/tests/unit/testplan/test_plan_base.py
@@ -133,7 +133,6 @@ def test_testplan_decorator():
 
     @test_plan(
         name="MyPlan1",
-        port=800,
         parse_cmdline=False,
         runpath=default_runpath_mock,
     )
@@ -149,7 +148,7 @@ def test_testplan_decorator():
     pdf_path = "mypdf.pdf"
     with argv_overridden("--pdf", pdf_path):
 
-        @test_plan(name="MyPlan2", port=800, runpath=default_runpath_mock)
+        @test_plan(name="MyPlan2", runpath=default_runpath_mock)
         def main2(plan, parser):
             args = parser.parse_args()
 
@@ -170,12 +169,21 @@ def test_testplan_runpath():
     def runpath_maker(obj):
         return "{sep}tmp{sep}custom".format(sep=os.sep)
 
-    plan = Testplan(name="MyPlan", port=800, parse_cmdline=False)
+    plan = Testplan(name="MyPlan", parse_cmdline=False)
     assert plan.runpath == default_runpath(plan._runnable)
 
     path = "/var/tmp/user"
-    plan = TestplanMock(name="MyPlan", port=800, runpath=path)
+    plan = TestplanMock(name="MyPlan", runpath=path)
     assert plan.runpath == path
 
-    plan = TestplanMock(name="MyPlan", port=800, runpath=runpath_maker)
+    plan = TestplanMock(name="MyPlan", runpath=runpath_maker)
     assert plan.runpath == runpath_maker(plan._runnable)
+
+
+def test_testplan_unknown_kwargs():
+    """Unknown kwargs should raise TypeError immediately, not be silently ignored."""
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        Testplan(name="MyPlan", parse_cmdline=False, foobarbaz=True)
+
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        Testplan(name="MyPlan", parse_cmdline=False, foo=1, bar=2)


### PR DESCRIPTION
## Problem

Passing an unrecognised keyword argument to `Testplan()` or the `@test_plan` decorator silently ignores it rather than raising `TypeError`. For example:

```python
Testplan(name="MyPlan", foobarbaz=True)  # no error raised
```

The root cause is that `TestRunnerConfig` sets `ignore_extra_keys = True` on its schema validator, so the config layer swallows any unknown kwargs without complaint.

## Fix

Add an explicit check at the top of `Testplan.__init__` that raises `TypeError` with a clear message listing the offending names, matching standard Python behaviour for unexpected keyword arguments:

```python
Testplan(name="MyPlan", foobarbaz=True)
# TypeError: Testplan.__init__() got unexpected keyword argument(s): 'foobarbaz'
```

The existing tests that were passing the undocumented `port=800` kwarg (which was also silently ignored) are updated to remove that argument. A new test verifies that unknown kwargs now raise `TypeError`.

Fixes #291