### PR TITLE
Use abc module for abstract base classes

### DIFF
--- a/testplan/cli/utils/actions.py
+++ b/testplan/cli/utils/actions.py
@@ -2,33 +2,37 @@
 Implements base action types.
 """
 
+from abc import ABCMeta, abstractmethod
 from typing import Iterable
 
 from testplan.report import TestReport
 
 
-class ParseSingleAction:
+class ParseSingleAction(metaclass=ABCMeta):
     """
     Base class for single parser action.
     """
 
+    @abstractmethod
     def __call__(self) -> TestReport:
         raise NotImplementedError
 
 
-class ParseMultipleAction:
+class ParseMultipleAction(metaclass=ABCMeta):
     """
     Base class for multiple parser actions.
     """
 
+    @abstractmethod
     def __call__(self) -> Iterable[TestReport]:
         raise NotImplementedError
 
 
-class ProcessResultAction:
+class ProcessResultAction(metaclass=ABCMeta):
     """
     Base class for result processing action.
     """
 
+    @abstractmethod
     def __call__(self, result: TestReport) -> TestReport:
         raise NotImplementedError

--- a/testplan/importers/base.py
+++ b/testplan/importers/base.py
@@ -2,27 +2,31 @@
 Implements base importer classes.
 """
 
+from abc import ABCMeta, abstractmethod
 from typing import Any, TypeVar, Generic, List, Optional
 
 from testplan.report import TestGroupReport, TestReport
 
 
-class ImportedResult:
+class ImportedResult(metaclass=ABCMeta):
     """
     Base class for imported results.
     """
 
+    @abstractmethod
     def as_test_report(self) -> TestReport:
         raise NotImplementedError
 
+    @abstractmethod
     def category(self) -> str:
         raise NotImplementedError
 
+    @abstractmethod
     def results(self) -> List[TestGroupReport]:
         raise NotImplementedError
 
 
-class ResultImporter:
+class ResultImporter(metaclass=ABCMeta):
     """
     Base class for result importer.
     """
@@ -30,6 +34,7 @@ class ResultImporter:
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         pass
 
+    @abstractmethod
     def import_result(self) -> ImportedResult:
         raise NotImplementedError
 
@@ -67,6 +72,7 @@ class ThreePhaseFileImporter(ResultImporter, Generic[T]):
 
     # TODO: this looks like a static method except for CPPUnitResultImporter
     #       maybe we can use self.path only?
+    @abstractmethod
     def _read_data(self, path: str) -> T:
         """
         Reads result from the source file.
@@ -75,6 +81,7 @@ class ThreePhaseFileImporter(ResultImporter, Generic[T]):
         """
         raise NotImplementedError
 
+    @abstractmethod
     def _process_data(self, data: T) -> List[TestGroupReport]:
         """
         Processes data read from the source file.
@@ -84,6 +91,7 @@ class ThreePhaseFileImporter(ResultImporter, Generic[T]):
         raise NotImplementedError
 
     # TODO: raw_data, apparently, is never used maybe we can do without it
+    @abstractmethod
     def _create_result(
         self, raw_data: T, processed_data: List[TestGroupReport]
     ) -> ImportedResult:

--- a/testplan/testing/filtering.py
+++ b/testplan/testing/filtering.py
@@ -5,6 +5,7 @@ import collections
 import fnmatch
 import operator
 import re
+from abc import ABCMeta, abstractmethod
 from enum import Enum, IntEnum, auto
 from typing import (
     TYPE_CHECKING,
@@ -48,7 +49,7 @@ class FilterCategory(IntEnum):
     TAG = auto()
 
 
-class BaseFilter:
+class BaseFilter(metaclass=ABCMeta):
     """
     Base class for filters, supports bitwise
     operators for composing multiple filters.
@@ -56,12 +57,15 @@ class BaseFilter:
     e.g. (FilterA(...) & FilterB(...)) | ~FilterC(...)
     """
 
+    @abstractmethod
     def map(self, f: Callable) -> "BaseFilter":
         raise NotImplementedError
 
+    @abstractmethod
     def filter_test(self, test: Any) -> bool:
         raise NotImplementedError
 
+    @abstractmethod
     def filter(self, test: Any, suite: Any, case: Any) -> bool:
         raise NotImplementedError
 
@@ -169,6 +173,7 @@ class MetaFilter(BaseFilter):
         self.filters = list(map(f, self.filters))
         return self
 
+    @abstractmethod
     def composed_filter(self, _test: Any, _suite: Any, _case: Any) -> bool:
         raise NotImplementedError
 
@@ -249,6 +254,7 @@ class BaseTagFilter(Filter):
     def __repr__(self) -> str:
         return '{}(tags="{}")'.format(self.__class__.__name__, self.tags_orig)
 
+    @abstractmethod
     def get_match_func(self) -> Callable:
         raise NotImplementedError
 

--- a/testplan/testing/ordering.py
+++ b/testplan/testing/ordering.py
@@ -7,6 +7,7 @@ API is available for future compatibility.
 
 import operator
 import random
+from abc import ABCMeta, abstractmethod
 from enum import Enum
 
 from testplan.common.utils.convert import make_tuple
@@ -50,15 +51,18 @@ class SortType(Enum):
         return validate_single(value)
 
 
-class BaseSorter:
+class BaseSorter(metaclass=ABCMeta):
     """Base sorter class"""
 
+    @abstractmethod
     def should_sort_instances(self):
         raise NotImplementedError
 
+    @abstractmethod
     def should_sort_testsuites(self):
         raise NotImplementedError
 
+    @abstractmethod
     def should_sort_testcases(self):
         raise NotImplementedError
 


### PR DESCRIPTION
## Problem

Several base classes in testplan define abstract interfaces by having methods raise `NotImplementedError`, but don't use Python's `abc` module. The practical consequence is that you can instantiate these classes directly (or create a subclass that forgets to implement a required method) without getting any error until the missing method is actually called at runtime.

For example:

```python
from testplan.testing.ordering import BaseSorter
s = BaseSorter()  # no error
s.should_sort_instances()  # NotImplementedError raised here, far from the bug
```

## Fix

Convert the following abstract base classes to use `ABCMeta` and `@abstractmethod`:

| File | Class | Abstract methods |
|------|-------|-----------------|
| `testplan/importers/base.py` | `ImportedResult` | `as_test_report`, `category`, `results` |
| `testplan/importers/base.py` | `ResultImporter` | `import_result` |
| `testplan/importers/base.py` | `ThreePhaseFileImporter` | `_read_data`, `_process_data`, `_create_result` |
| `testplan/testing/filtering.py` | `BaseFilter` | `map`, `filter_test`, `filter` |
| `testplan/testing/filtering.py` | `MetaFilter` | `composed_filter` |
| `testplan/testing/filtering.py` | `BaseTagFilter` | `get_match_func` |
| `testplan/testing/ordering.py` | `BaseSorter` | `should_sort_instances`, `should_sort_testsuites`, `should_sort_testcases` |
| `testplan/cli/utils/actions.py` | `ParseSingleAction`, `ParseMultipleAction`, `ProcessResultAction` | `__call__` |

All existing concrete subclasses already implement every method being marked abstract, so this is a non-breaking change.

Fixes #394