### PR TITLE
Send --info listing output to stderr instead of stdout

### DIFF
--- a/testplan/base.py
+++ b/testplan/base.py
@@ -29,7 +29,7 @@ from testplan.common import entity
 from testplan.common.config import ConfigOption
 from testplan.common.utils import logger, path
 from testplan.common.utils.callable import arity
-from testplan.common.utils.logger import TESTPLAN_LOGGER
+
 from testplan.common.utils.validation import has_method, is_subclass
 from testplan.environment import Environments
 from testplan.parser import TestplanParser, FailedTestLevel
@@ -605,7 +605,7 @@ class Testplan(entity.RunnableManager):
                 with open(plan.cfg.test_lister_output, "wt") as file:
                     file.write(output)
             else:
-                TESTPLAN_LOGGER.user_info(output)
+                print(output, file=sys.stderr)
 
 
 test_plan = Testplan.main_wrapper

--- a/testplan/testing/listing.py
+++ b/testplan/testing/listing.py
@@ -5,6 +5,7 @@ This module contains logic for listing representing test context of a plan.
 import dataclasses
 import json
 import os
+import sys
 from argparse import Action, ArgumentParser, Namespace
 from enum import Enum
 from os import PathLike
@@ -21,7 +22,6 @@ from typing import (
 from urllib.parse import urlparse
 
 from testplan.common.utils.json import json_dumps
-from testplan.common.utils.logger import TESTPLAN_LOGGER
 from testplan.common.utils.parser import ArgMixin
 from testplan.testing import tagging
 from testplan.testing.common import TEST_PART_PATTERN_FORMAT_STRING
@@ -59,7 +59,7 @@ class BaseLister(Listertype):
     def log_test_info(self, instance: "Test") -> None:
         output = self.get_output(instance)
         if output:
-            TESTPLAN_LOGGER.user_info(output)
+            print(output, file=sys.stderr)
 
     def get_output(self, instance: "Test") -> str:
         raise NotImplementedError
@@ -314,7 +314,7 @@ class MetadataBasedLister(Listertype):
     def log_test_info(self, metadata: TestPlanMetadata) -> None:
         output = self.get_output(metadata)
         if output:
-            TESTPLAN_LOGGER.user_info(output)
+            print(output, file=sys.stderr)
 
     def get_output(self, metadata: TestPlanMetadata) -> str:
         raise NotImplementedError


### PR DESCRIPTION
## Problem

When running a testplan script with `--info` (or `--list`), the structured test listing output is written to stdout via `TESTPLAN_LOGGER.user_info()`. This uses a `logging.StreamHandler(sys.stdout)` formatter that emits plain text with no prefix, making the listing output visually identical to any `print()` calls from the test code itself. There is no way to tell the two apart by looking at the terminal output.

## Fix

Write listing output to stderr instead of stdout. This is the conventional place for metadata/diagnostic output in CLI tools. It keeps the listing immediately visible in a normal terminal session while making the two output streams separable when needed:

```sh
# See only the listing, discard any test print() output
./my_tests --info 1>/dev/null

# See only test print() output, discard the listing
./my_tests --info 2>/dev/null
```

Changes:
- `BaseLister.log_test_info` now uses `print(..., file=sys.stderr)` instead of `TESTPLAN_LOGGER.user_info()`
- `MetadataBasedLister.log_test_info` same change
- `Testplan._do_listing` (the path taken when no `--test-lister-output` file is configured) same change

When `--test-lister-output` points to a file the behaviour is unchanged — output still goes to that file.

Fixes #668