### PR TITLE
TESTPLAN-3928: Keep remote pool request handling responsive

### DIFF
--- a/testplan/runners/pools/remote.py
+++ b/testplan/runners/pools/remote.py
@@ -444,10 +444,15 @@ class RemotePool(Pool):
                 )
 
     def _early_stop_worker(self, worker: RemoteWorker) -> bool:  # type: ignore[override]
-        if len(worker.assigned) != 0:
+        # Early stopping is an optional capacity optimization. Do not block
+        # the sole request-handling loop when worker recovery owns this lock.
+        if not self._pool_lock.acquire(blocking=False):
             return False
-        worker_uid: str = worker.uid()  # type: ignore[assignment]
-        with self._pool_lock:
+
+        try:
+            if len(worker.assigned) != 0:
+                return False
+            worker_uid: str = worker.uid()  # type: ignore[assignment]
             if self.pool and (worker_uid not in self._stopping_queue):
                 alive_worker_ids = set(
                     [worker.uid() for worker in self.worker_status["active"]]
@@ -464,7 +469,9 @@ class RemotePool(Pool):
                         (self._workers[worker_uid],),
                     )
                     return True
-        return False
+            return False
+        finally:
+            self._pool_lock.release()
 
     def starting(self) -> None:
         self._start_thread_pool()

--- a/tests/unit/testplan/runners/pools/test_pool_remote.py
+++ b/tests/unit/testplan/runners/pools/test_pool_remote.py
@@ -1,0 +1,32 @@
+"""Remote worker pool unit tests."""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+from testplan.runners.pools.remote import RemotePool
+
+
+def test_early_stop_worker_does_not_wait_for_pool_lock():
+    pool = object.__new__(RemotePool)
+    pool._pool_lock = threading.Lock()
+    worker = SimpleNamespace()
+    pool._pool_lock.acquire()
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        result = executor.submit(pool._early_stop_worker, worker)
+        try:
+            assert result.result(timeout=1) is False
+        finally:
+            pool._pool_lock.release()
+
+
+def test_early_stop_worker_releases_pool_lock():
+    pool = object.__new__(RemotePool)
+    pool._pool_lock = threading.Lock()
+    pool.pool = None
+    worker = SimpleNamespace(assigned={"task"})
+
+    assert pool._early_stop_worker(worker) is False
+    assert pool._pool_lock.acquire(blocking=False)
+    pool._pool_lock.release()


### PR DESCRIPTION
Skip optional early worker stopping while recovery owns the pool lock, so the single ZMQ dispatcher can continue acknowledging heartbeats and task results.

User prompt: "fix based on your previous analysis"

Co-authored-by: Agent / gpt_5.4

## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
