### PR TITLE
Use cap for invalid auto-part calculation

### DIFF
--- a/doc/newsfragments/3911_changed.fix_auto_part_negative_runtime.rst
+++ b/doc/newsfragments/3911_changed.fix_auto_part_negative_runtime.rst
@@ -1,0 +1,1 @@
+Fall back to the calculated auto-part cap when setup and teardown consume the entire part runtime limit.

--- a/testplan/runnable/base.py
+++ b/testplan/runnable/base.py
@@ -1114,24 +1114,29 @@ class TestRunner(Runnable):
                 )
             )
 """
-                    try:
+                    available_execution_time = (
+                        auto_part_runtime_limit
+                        - time_info["setup_time"]
+                        - time_info["teardown_time"]
+                    )
+                    if available_execution_time <= 0:
+                        self.logger.error(
+                            f"Cannot calculate auto-part count for {uid} "
+                            "because setup and teardown take at least the "
+                            "entire part runtime; "
+                            f"set to cap {cap}. {formula}"
+                        )
+                        num_of_parts = cap
+                    else:
                         num_of_parts = math.ceil(
                             time_info["execution_time"]
-                            / (
-                                auto_part_runtime_limit
-                                - time_info["setup_time"]
-                                - time_info["teardown_time"]
-                            )
+                            / available_execution_time
                         )
-                    except ZeroDivisionError:
-                        self.logger.error(
-                            f"ZeroDivisionError occurred when calculating num_of_parts for {uid}, set to 1. {formula}"
-                        )
-                        num_of_parts = 1
 
                     if num_of_parts < 1:
                         self.logger.error(
-                            f"Calculated num_of_parts for {uid} is {num_of_parts}, set to 1. {formula}"
+                            f"Calculated num_of_parts for {uid} is "
+                            f"{num_of_parts}, set to 1. {formula}"
                         )
                         num_of_parts = 1
 

--- a/tests/functional/testplan/runners/pools/test_auto_part.py
+++ b/tests/functional/testplan/runners/pools/test_auto_part.py
@@ -125,11 +125,11 @@ def test_auto_parts_zero_neg_parts():
             name_pattern=r".*auto_parts_tasks\.py$",
             resource="MyPool",
         )
-        assert len(pool.added_items) == 1
+        assert len(pool.added_items) == 3
         for task in pool.added_items.values():
-            assert task.weight == 100
+            assert task.weight == 67
         mockplan.run()
-        assert pool.size == 1
+        assert pool.size == 2
 
 
 def test_auto_parts_cap_parts():
@@ -275,11 +275,45 @@ def test_auto_parts_zero_neg_parts_with_teardown_time():
             name_pattern=r".*auto_parts_tasks\.py$",
             resource="MyPool",
         )
-        assert len(pool.added_items) == 1
+        assert len(pool.added_items) == 3
         for task in pool.added_items.values():
-            assert task.weight == 100
+            assert task.weight == 67
         mockplan.run()
-        assert pool.size == 1
+        assert pool.size == 2
+
+
+def test_auto_parts_runtime_limit_less_than_setup_and_teardown(monkeypatch):
+    with tempfile.TemporaryDirectory() as runpath:
+        mockplan = TestplanMock(
+            "plan",
+            runpath=runpath,
+            auto_part_runtime_limit="auto",
+            plan_runtime_target=200,
+            runtime_data={
+                "Proj1-suite": {
+                    "execution_time": 10739.373514,
+                    "setup_time": 1770.940957,
+                    "teardown_time": 29.46139,
+                }
+            },
+        )
+        pool = ProcessPool(name="MyPool", size="auto")
+        mockplan.add_resource(pool)
+        errors = []
+        monkeypatch.setattr(mockplan.runnable.logger, "error", errors.append)
+        current_folder = Path(__file__).resolve().parent
+        mockplan.schedule_all(
+            path=current_folder / "discover_tasks",
+            name_pattern=r".*auto_parts_tasks\.py$",
+            resource="MyPool",
+        )
+
+        assert len(pool.added_items) == 10
+        assert (
+            "Cannot calculate auto-part count for Proj1-suite because setup "
+            "and teardown take at least the entire part runtime; set to cap "
+            "10."
+        ) in errors[0]
 
 
 def test_auto_parts_cap_parts_with_teardown_time():


### PR DESCRIPTION
fix a corner case where setup+teardown > part limit

## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
