### PR TITLE
Strip URL fragment from local file paths in group_freezed

### DIFF
--- a/testplan/common/remote/remote_runtime.py
+++ b/testplan/common/remote/remote_runtime.py
@@ -206,7 +206,10 @@ class PipBasedBuilder(RuntimeBuilder):
                 # TODO: are svn/hg/... still valid?
                 p_ = p.split(" @ ")[1]
                 if p_.startswith("file://"):
-                    local.append(p_[7:])
+                    # strip any URL fragment (e.g. "#sha256=..." that newer
+                    # uv/pip append to local file URLs) so the path points to
+                    # a real file on disk
+                    local.append(p_[7:].split("#", 1)[0])
                 else:
                     # assuming package index reachable from remote
                     upstream.append(p_)


### PR DESCRIPTION
Newer uv/pip append a "#sha256=..." fragment to local file:// URLs in `uv pip freeze` output. group_freezed() stripped the "file://" scheme but kept the fragment, so the extracted path pointed at a non-existent file (e.g. "foo.whl#sha256=..."). Transferring it to the remote host then failed with rsync exit code 23 ("link_stat ... No such file or directory"), breaking RemotePool / RemoteTestplan runtime setup.

Strip everything from the first "#" so the path points to the real file on disk.

## Bug / Requirement Description
Clearly and concisely describe the problem.

## Solution description
Describe your code changes in detail for reviewers.

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
