### PR TITLE
Fix/dynamic xfail data not to leak between testsuite instances

### DIFF
--- a/doc/newsfragments/3942_changed.xfail_per_suite_instance.rst
+++ b/doc/newsfragments/3942_changed.xfail_per_suite_instance.rst
@@ -1,0 +1,1 @@
+Fix dynamic xfail data (``--xfail-tests`` / ``@test_plan(xfail_tests=...)``) leaking between suite instances.

--- a/testplan/testing/multitest/base.py
+++ b/testplan/testing/multitest/base.py
@@ -4,7 +4,6 @@ import collections.abc
 import concurrent.futures
 import functools
 import itertools
-import types
 import warnings
 from typing import (
     Any,
@@ -426,11 +425,6 @@ class MultiTest(testing_base.Test):
             )
         sorted_suites = self.cfg.test_sorter.sorted_testsuites(self.cfg.suites)
 
-        if hasattr(self.cfg, "xfail_tests") and self.cfg.xfail_tests:
-            xfail_data = self.cfg.xfail_tests
-        else:
-            xfail_data = {}
-
         for suite in sorted_suites:
             testcases = suite.get_testcases()
 
@@ -457,31 +451,6 @@ class MultiTest(testing_base.Test):
                 testcases_to_run = sorted_testcases
 
             if testcases_to_run:
-                for testcase in testcases_to_run:
-                    testcase_instance = ":".join(
-                        [
-                            self.name,
-                            suite.name,
-                            testcase.name,
-                        ]
-                    )
-                    data = xfail_data.get(testcase_instance, None)
-                    if data is not None:
-                        # When a ``@skip_if`` predicate fires, the testcase
-                        # slot holds a plain function (a generated skipped
-                        # case) instead of a bound method, so ``__func__`` is
-                        # absent. Set ``__xfail__`` on whichever we have.
-                        func: Any = (
-                            testcase.__func__
-                            if isinstance(testcase, types.MethodType)
-                            else testcase
-                        )
-                        func.__xfail__ = {
-                            "reason": data["reason"],
-                            "strict": data["strict"],
-                            "condition": data.get("condition"),
-                        }
-
                 ctx.append((suite, testcases_to_run))
 
         if self.cfg.part:
@@ -680,6 +649,14 @@ class MultiTest(testing_base.Test):
             description=self.cfg.description,
             test_suites=suites,
         )
+
+    @functools.cached_property
+    def _dynamic_xfail_tests(self) -> Dict[str, dict]:
+        """
+        Testcase patterns to be xfailed, as specified via ``--xfail-tests``
+        or ``@test_plan(xfail_tests=...)``.
+        """
+        return getattr(self.cfg, "xfail_tests", None) or {}
 
     def apply_xfail_tests(self) -> None:
         """
@@ -1339,10 +1316,17 @@ class MultiTest(testing_base.Test):
             testcase_report.attachments.extend(case_result.attachments)
 
             # If xfailed testcase, force set status_override and update result
-            if hasattr(testcase, "__xfail__"):
+            # the ``@xfail`` decorator takes precedence over ``xfail_tests``
+            # entries, the latter are matched per suite instance
+            xfail_data = getattr(testcase, "__xfail__", None)
+            if xfail_data is None and self._dynamic_xfail_tests:
+                xfail_data = self._dynamic_xfail_tests.get(
+                    ":".join([self.name, testsuite.name, testcase.name])
+                )
+            if xfail_data is not None:
                 testcase_report.xfail(
-                    testcase.__xfail__["strict"],
-                    testcase.__xfail__["condition"],
+                    xfail_data["strict"],
+                    xfail_data.get("condition"),
                 )
 
             if not case_result.passed:

--- a/tests/functional/testplan/testing/multitest/test_xfail.py
+++ b/tests/functional/testplan/testing/multitest/test_xfail.py
@@ -164,6 +164,162 @@ def test_dynamic_xfail():
     assert result.report.entries[2].entries[1].entries[2].xfailed is True
 
 
+@testsuite(name=lambda cls_name, suite: f"{cls_name} - {suite.symbol}")
+class SharedClassSuite:
+    """Suite class instantiated twice, named after a per-instance param."""
+
+    def __init__(self, symbol):
+        self.symbol = symbol
+
+    @testcase
+    def test_fail(self, env, result):
+        result.dict.match(
+            {"foo": 1}, {"foo": 2}, description=f"{self.symbol} dict match"
+        )
+
+    @testcase(parameters=(1,))
+    def test_p(self, env, result, val):
+        result.dict.match(
+            {"foo": 1}, {"foo": 2}, description=f"{self.symbol} dict match"
+        )
+
+
+def test_dynamic_xfail_same_suite_class_twice():
+    """
+    Two instances of the same testsuite class, distinguished by their name
+    function. Only suite A is listed in ``xfail_tests``, thus suite B should
+    stay failed - for plain as well as for parameterized testcases.
+    """
+    plan = TestplanMock(
+        name="dynamic_xfail_same_suite_class_twice",
+        xfail_tests={
+            "MTest:SharedClassSuite - A:test_fail": {
+                "reason": "only listed for suite A",
+                "strict": False,
+            },
+            "MTest:SharedClassSuite - A:test_p <val=1>": {
+                "reason": "only listed for suite A",
+                "strict": False,
+            },
+        },
+    )
+    plan.add(
+        MultiTest(
+            name="MTest",
+            suites=[SharedClassSuite("A"), SharedClassSuite("B")],
+        )
+    )
+
+    result = plan.run()
+
+    suite_a = result.report["MTest"]["SharedClassSuite - A"]
+    suite_b = result.report["MTest"]["SharedClassSuite - B"]
+
+    for case_a, case_b in (
+        (suite_a["test_fail"], suite_b["test_fail"]),
+        (
+            suite_a["test_p"]["test_p__val_1"],
+            suite_b["test_p"]["test_p__val_1"],
+        ),
+    ):
+        assert case_a.status == Status.XFAIL
+        assert case_b.xfailed is False
+        assert case_b.failed is True
+
+
+def test_dynamic_xfail_same_suite_class_twice_different_conditions():
+    """
+    Both instances are listed for xfail, each with a condition matching its
+    own assertion, thus both should be xfailed.
+    """
+    plan = TestplanMock(
+        name="dynamic_xfail_same_suite_class_twice_different_conditions",
+        xfail_tests={
+            f"MTest:SharedClassSuite - {symbol}:test_p <val=1>": {
+                "reason": f"condition matching suite {symbol} assertion",
+                "strict": False,
+                "condition": {
+                    "failed": {
+                        "type": "DictMatch",
+                        "description": f"{symbol} dict match",
+                    }
+                },
+            }
+            for symbol in ("A", "B")
+        },
+    )
+    plan.add(
+        MultiTest(
+            name="MTest",
+            suites=[SharedClassSuite("A"), SharedClassSuite("B")],
+        )
+    )
+
+    result = plan.run()
+
+    for symbol in ("A", "B"):
+        suite_report = result.report["MTest"][f"SharedClassSuite - {symbol}"]
+        case = suite_report["test_p"]["test_p__val_1"]
+        assert case.status == Status.XFAIL
+
+
+@testsuite(name=lambda cls_name, suite: f"{cls_name} - {suite.symbol}")
+class SharedClassDecoratedSuite:
+    """Suite class with a ``@xfail`` decorated testcase, instantiated twice."""
+
+    def __init__(self, symbol):
+        self.symbol = symbol
+
+    @testcase
+    @xfail(
+        "decorated as known to fail",
+        strict=False,
+        condition={
+            "failed": {"type": "DictMatch", "description": "no such assertion"}
+        },
+    )
+    def test_fail(self, env, result):
+        result.dict.match(
+            {"foo": 1}, {"foo": 2}, description=f"{self.symbol} dict match"
+        )
+
+
+def test_decorator_xfail_takes_precedence():
+    """
+    The ``@xfail`` decorator takes precedence over ``xfail_tests`` entries,
+    and its data must not be clobbered by them either. Here the decorator's
+    condition never matches, so both instances stay failed even though suite
+    A is listed for an unconditional xfail.
+    """
+    plan = TestplanMock(
+        name="decorator_xfail_takes_precedence",
+        xfail_tests={
+            "MTest:SharedClassDecoratedSuite - A:test_fail": {
+                "reason": "shadowed by the decorator",
+                "strict": False,
+            },
+        },
+    )
+    plan.add(
+        MultiTest(
+            name="MTest",
+            suites=[
+                SharedClassDecoratedSuite("A"),
+                SharedClassDecoratedSuite("B"),
+            ],
+        )
+    )
+
+    result = plan.run()
+
+    for symbol in ("A", "B"):
+        case = result.report["MTest"][f"SharedClassDecoratedSuite - {symbol}"][
+            "test_fail"
+        ]
+        assert case.xfailed is False
+        assert case.failed is True
+
+
 def test_dynamic_xfail_environment_start_condition_error():
     plan = TestplanMock(
         name="dynamic_xfail_environment_start_condition_error",


### PR DESCRIPTION
## Bug / Requirement Description
^

## Solution description
instead of set __xfail__, have xfail info looked up after every testcase

caveat: precedence flipped

## Checklist:
- [x] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [x] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
