### PR TITLE
Chore/update ubuntu ver in pr pipeline

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   is_source_changed:
     name: Check if sources has changed
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       is_source_changed: ${{steps.check_source_change.outputs.changed}}
     steps:
@@ -31,7 +31,7 @@ jobs:
   success:
     name: PR Test Completed
     needs: [is_source_changed, test]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: always() && needs.is_source_changed.result == 'success' && (needs.is_source_changed.outputs.is_source_changed == 'false' || needs.Test.result == 'success')
     steps:
       - run: echo ${{needs.is_source_changed.result}} ${{needs.is_source_changed.outputs.is_source_changed}} ${{needs.Test.result}}
@@ -40,7 +40,7 @@ jobs:
   lint_python:
     name: Run lint on python code
     needs: [is_source_changed]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: needs.is_source_changed.outputs.is_source_changed == 'true'
     env:
       LINT_PYTHON_VERSION: "3.10"
@@ -67,7 +67,7 @@ jobs:
   build_ui:
     name: Build UI (with test and lint)
     needs: [is_source_changed]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: needs.is_source_changed.outputs.is_source_changed == 'true'
     env:
       REACT_APP_API_BASE_URL: "/fake/api/endpoint"
@@ -114,16 +114,16 @@ jobs:
       CI: ""
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13']
         package-extras: ['', '[all]']
         exclude:
           - os: windows-latest
             package-extras: ''
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             python-version: '3.11'
             package-extras: '[all]'
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             python-version: '3.12'
             package-extras: '[all]'
       fail-fast: false
@@ -148,13 +148,13 @@ jobs:
           name: ui_bundle
           path: testplan/web_ui/testing/build
       - name: Set up Linux package for tests
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
       - name: Set up Zookeeper for tests
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo apt-get update && sudo apt-get -y install zookeeper zookeeper-bin zookeeperd
       - name: Set up Kafka for tests
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           wget https://archive.apache.org/dist/kafka/3.9.2/kafka_2.13-3.9.2.tgz -O kafka.tgz
           sudo mkdir /opt/kafka

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -152,7 +152,12 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
       - name: Set up Zookeeper for tests
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: sudo apt-get update && sudo apt-get -y install zookeeper zookeeper-bin zookeeperd
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install zookeeper zookeeper-bin
+          zookeeper_log_dir="$RUNNER_TEMP/zookeeper"
+          mkdir -p "$zookeeper_log_dir"
+          echo "ZOO_LOG_DIR=$zookeeper_log_dir" | sudo tee -a /etc/zookeeper/conf/environment
       - name: Set up Kafka for tests
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |

--- a/doc/en/multitest.rst
+++ b/doc/en/multitest.rst
@@ -1014,12 +1014,12 @@ parameterized testcases an empty dictionary is passed for ``kwargs``.
     def sample_test(self, env, result, x, y):
         pass
 
-    def pre_testcase(name, self, env, result, kwargs):
+    def pre_testcase(self, name, env, result, kwargs):
         result.log("Param 1 is {}".format(kwargs.get("x")))
         result.log("Param 2 is {}".format(kwargs.get("y")))
         ...
 
-    def post_testcase(name, self, env, result, kwargs):
+    def post_testcase(self, name, env, result, kwargs):
         ...
 
 .. _parametrization_default_values:

--- a/tests/unit/testplan/testing/multitest/driver/mykafka/test_kafka.py
+++ b/tests/unit/testplan/testing/multitest/driver/mykafka/test_kafka.py
@@ -45,7 +45,7 @@ def zookeeper_server(runpath_module):
     server = zookeeper.ZookeeperStandalone(
         "zk",
         cfg_template=zk_cfg_template,
-        runpath=runpath_module,
+        runpath=os.path.join(runpath_module, "zookeeper"),
         host="localhost",
     )
     with server:
@@ -57,7 +57,7 @@ def kafka_server(zookeeper_server, runpath_module):
     server = kafka.KafkaStandalone(
         "kafka",
         cfg_template=kafka_cfg_template,
-        runpath=runpath_module,
+        runpath=os.path.join(runpath_module, "kafka"),
         host="localhost",
     )
 
@@ -105,7 +105,7 @@ def kraft_kafka_server(runpath_module):
     server = kafka.KafkaStandalone(
         "kafka",
         cfg_template=kraft_kafka_cfg_template,
-        runpath=runpath_module,
+        runpath=os.path.join(runpath_module, "kraft-kafka"),
         host="localhost",
         port=9092,
         controller_port=9093,


### PR DESCRIPTION
## Bug / Requirement Description
^

## Solution description
^
following py39 drop

ubuntu-latest would still be ubuntu-24.04 at the moment

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [x] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
