### PR TITLE
fix: read xUnit reports as the documents declare, not via the host locale codec

### DIFF
--- a/doc/newsfragments/1345_changed.xunit_importers_read_utf8.rst
+++ b/doc/newsfragments/1345_changed.xunit_importers_read_utf8.rst
@@ -1,0 +1,1 @@
+xUnit report importers (GoogleTest, JUnit, CppUnit) now read report files as the documents declare themselves rather than through the host locale codec, which crashed on DBCS Windows and silently produced mojibake on cp1252.

--- a/testplan/importers/cppunit.py
+++ b/testplan/importers/cppunit.py
@@ -114,7 +114,9 @@ class CPPUnitResultImporter(ThreePhaseFileImporter[Element]):
         :param path: path to source file
         :return: root node of parsed raw test data
         """
-        with open(path) as report_file:
+        # Binary: cppunit_to_junit accepts bytes and encodes str to UTF-8
+        # anyway, so this drops a locale-dependent decode/encode round trip.
+        with open(path, "rb") as report_file:
             return objectify.fromstring(
                 self.cppunit_to_junit(
                     report_file.read(), self._DEFAULT_SUITE_NAME

--- a/testplan/importers/gtest.py
+++ b/testplan/importers/gtest.py
@@ -36,7 +36,9 @@ class GTestResultImporter(ThreePhaseFileImporter[Element]):
         :param path: path to source file
         :return: root node of parsed raw test data
         """
-        with open(path) as report_file:
+        # Binary, so lxml honours the document's own encoding declaration
+        # rather than the reader's locale codec having already decoded it.
+        with open(path, "rb") as report_file:
             return objectify.parse(report_file).getroot()
 
     def _process_data(self, data: Element) -> List[TestGroupReport]:

--- a/testplan/importers/junit.py
+++ b/testplan/importers/junit.py
@@ -36,7 +36,9 @@ class JUnitResultImporter(ThreePhaseFileImporter):
 
         :param path: path to source file
         """
-        with open(path) as report_file:
+        # Binary, so lxml honours the document's own encoding declaration
+        # rather than the reader's locale codec having already decoded it.
+        with open(path, "rb") as report_file:
             return parse(report_file).getroot()
 
     def _process_data(self, data: Element) -> List[TestGroupReport]:

--- a/testplan/importers/testplan.py
+++ b/testplan/importers/testplan.py
@@ -44,7 +44,7 @@ class TestplanResultImporter(ResultImporter):
 
     def import_result(self) -> ImportedResult:
         """ """
-        with open(self.path) as fp:
+        with open(self.path, encoding="utf-8") as fp:
             result_json = json_loads(fp.read())
             self.fix_attachments_path(result_json)
             result = self.schema.load(result_json)

--- a/testplan/testing/cpp/gtest.py
+++ b/testplan/testing/cpp/gtest.py
@@ -200,7 +200,7 @@ class GTest(ProcessRunnerTest):
         super(GTest, self).update_test_report()
 
         try:
-            with open(self.report_path) as report_xml:
+            with open(self.report_path, encoding="utf-8") as report_xml:
                 self.result.report.xml_string = report_xml.read()
         except Exception:
             self.result.report.xml_string = ""

--- a/testplan/testing/cpp/hobbestest.py
+++ b/testplan/testing/cpp/hobbestest.py
@@ -93,7 +93,7 @@ class HobbesTest(ProcessRunnerTest):
         :return: Json object of parsed raw test data
         :rtype: ``dict`` ot ``list``
         """
-        with open(self.report_path) as report_file:
+        with open(self.report_path, encoding="utf-8") as report_file:
             return json_loads(report_file.read())
 
     def process_test_data(self, test_data):

--- a/tests/unit/testplan/importers/test_report_encoding.py
+++ b/tests/unit/testplan/importers/test_report_encoding.py
@@ -1,0 +1,145 @@
+"""The xUnit importers must read reports as the documents declare themselves.
+
+These files carry an XML prolog announcing UTF-8. Opening them in text mode
+handed the bytes to ``locale.getpreferredencoding()`` before lxml could read
+that prolog, which crashed on a DBCS host and, worse, produced silent mojibake
+on cp1252 - the default ANSI codepage on en-US Windows, including the
+``windows-latest`` CI leg.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+# A euro sign is enough: it is representable in cp1252 (as a different byte
+# sequence, hence mojibake rather than a crash) and unrepresentable in cp950,
+# so the same fixture exercises both failure modes depending on the host.
+NON_ASCII_TESTCASE = "charges_€100_fee"
+
+GTEST_REPORT = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="1" failures="0" errors="0" name="AllTests">
+  <testsuite name="Fees" tests="1" failures="0" errors="0">
+    <testcase name="{name}" status="run" classname="Fees"/>
+  </testsuite>
+</testsuites>
+"""
+
+JUNIT_REPORT = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="Fees" tests="1" failures="0" errors="0" skipped="0">
+    <testcase name="{name}" classname="Fees" time="0.01"/>
+  </testsuite>
+</testsuites>
+"""
+
+# CppUnit names are "Suite::case"; the XSLT splits on "::", so the fixture
+# has to carry the separator or the transformed name comes out empty.
+CPPUNIT_REPORT = """<?xml version="1.0" encoding="UTF-8"?>
+<TestRun>
+  <SuccessfulTests>
+    <Test id="1">
+      <Name>Fees::{name}</Name>
+    </Test>
+  </SuccessfulTests>
+  <Statistics>
+    <Tests>1</Tests>
+    <FailuresTotal>0</FailuresTotal>
+    <Errors>0</Errors>
+    <Failures>0</Failures>
+  </Statistics>
+</TestRun>
+"""
+
+# The importers run in a child interpreter with a legacy locale forced on.
+# Without this the test passes on a UTF-8 host whether or not the fix is
+# present, which is exactly how this survived in CI.
+LEGACY_LOCALE_ENV = {
+    "PYTHONUTF8": "0",
+    "PYTHONCOERCECLOCALE": "0",
+    "LC_ALL": "C",
+    "LANG": "C",
+}
+
+PARSE_SCRIPT = textwrap.dedent(
+    """
+    import sys
+    from lxml import etree
+
+    module_name, path = sys.argv[1], sys.argv[2]
+    if module_name == "gtest":
+        from testplan.importers.gtest import GTestResultImporter as Importer
+    elif module_name == "junit":
+        from testplan.importers.junit import JUnitResultImporter as Importer
+    else:
+        from testplan.importers.cppunit import CPPUnitResultImporter as Importer
+
+    root = Importer(path, name="n", description="d")._read_data(path)
+    sys.stdout.buffer.write(etree.tostring(root, encoding="utf-8"))
+    """
+)
+
+
+@pytest.mark.parametrize(
+    "importer_name, template",
+    [
+        ("gtest", GTEST_REPORT),
+        ("junit", JUNIT_REPORT),
+        ("cppunit", CPPUNIT_REPORT),
+    ],
+)
+def test_importer_reads_utf8_report_under_legacy_locale(
+    importer_name, template, tmp_path
+):
+    """A UTF-8 report imports identically regardless of the host locale."""
+    report = tmp_path / f"{importer_name}.xml"
+    report.write_bytes(
+        template.format(name=NON_ASCII_TESTCASE).encode("utf-8")
+    )
+
+    script = tmp_path / "parse.py"
+    script.write_text(PARSE_SCRIPT, encoding="utf-8")
+
+    completed = subprocess.run(
+        [sys.executable, str(script), importer_name, str(report)],
+        capture_output=True,
+        env={**os.environ, **LEGACY_LOCALE_ENV},
+    )
+
+    # Catches the crash: on a DBCS or ASCII locale the read raises and the
+    # import dies before producing anything.
+    assert completed.returncode == 0, completed.stderr.decode(
+        "utf-8", "replace"
+    )
+
+    # Catches the silent corruption. Assert on the bytes the child produced,
+    # decoded as UTF-8 - comparing strings read back through the same broken
+    # default would round-trip the mojibake and pass either way.
+    assert NON_ASCII_TESTCASE in completed.stdout.decode("utf-8")
+
+
+def test_ascii_report_is_unaffected(tmp_path):
+    """The ASCII path the existing fixtures cover behaves identically.
+
+    Present as a control: it passes with and without the fix, so a failure
+    here means the harness broke rather than the encoding handling.
+    """
+    report = tmp_path / "gtest.xml"
+    report.write_bytes(GTEST_REPORT.format(name="charges_fee").encode("utf-8"))
+
+    script = tmp_path / "parse.py"
+    script.write_text(PARSE_SCRIPT, encoding="utf-8")
+
+    completed = subprocess.run(
+        [sys.executable, str(script), "gtest", str(report)],
+        capture_output=True,
+        env={**os.environ, **LEGACY_LOCALE_ENV},
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(
+        "utf-8", "replace"
+    )
+    assert "charges_fee" in completed.stdout.decode("utf-8")


### PR DESCRIPTION
Closes #1345.

## The defect

The importers opened report files in text mode with no `encoding=`, so CPython decoded them with `locale.getpreferredencoding(False)` before lxml could honour the file's own `<?xml version="1.0" encoding="UTF-8"?>` prolog.

Same 241-byte UTF-8 GoogleTest report, one test named `charges_€100_fee`, read four ways:

| codec | result |
| --- | --- |
| `utf-8` | `name='charges_€100_fee'` |
| `cp950` | **`UnicodeDecodeError: can't decode byte 0xe2`** — import dies |
| `cp1252` | `name='charges_â‚¬100_fee'` — **silent mojibake** |
| `cp437` | `name='charges_Γé¼100_fee'` — **silent mojibake** |
| opened `"rb"` | `name='charges_€100_fee'` |

The crash is the loud case and the rarer one. **cp1252 is the default ANSI codepage on en-US Windows**, which covers most Windows users and the `windows-latest` leg of this project's CI: nothing errors, the test name in the imported report is simply wrong, and anything matching on it downstream silently misses.

It also round-tripped testplan's own output incorrectly, since `exporters/testing/xml/__init__.py:344` already writes these files as UTF-8.

## The change

Six sites, treated as two kinds rather than one:

**XML handed to lxml** — `importers/gtest.py`, `importers/junit.py`, `importers/cppunit.py` now open `"rb"`, so the prolog decides. That is what lxml expects for a self-describing document.

**JSON or plain text** — `importers/testplan.py`, `testing/cpp/gtest.py`, `testing/cpp/hobbestest.py` state `encoding="utf-8"`. Opening these binary would change what the callers receive, so the encoding argument is the right instrument there.

One incidental win: `cppunit_to_junit` is already typed `Union[str, bytes]` and encodes `str` to UTF-8 itself, so the binary read drops a redundant decode/encode round trip rather than adding work.

## The test

Two deliberate choices, because the obvious version of this test is worthless:

**It runs each importer in a child interpreter with `PYTHONUTF8=0 PYTHONCOERCECLOCALE=0 LC_ALL=C LANG=C`.** Without that it passes on a UTF-8 host whether or not the fix is present, which is precisely how this survived in CI.

**It asserts on bytes decoded as UTF-8, never on a string read back through the same default.** A read-back assertion round-trips the mojibake and passes both ways.

Verified by reverting the six sites and re-running: **3 failed / 1 passed** before — one failure per XML importer — and **4 passed** after. The fourth case is ASCII and passes either way; it is there as a control, so a failure in it means the harness broke rather than the encoding handling.

While writing it I got the CppUnit fixture wrong at first: its XSLT splits names on `::`, so a `<Name>` without the separator yields an empty name and the test failed for a reason unrelated to encoding. The fixture now carries `Fees::<name>`, and that is noted in a comment so the next person does not repeat it.

## Checks

`tests/unit/testplan`: **894 passed before, 898 after** — exactly my four — with the same 30 pre-existing errors both times. `tests/unit/testplan/importers`: 11 passed. Newsfragment added as `1345_changed.xunit_importers_read_utf8.rst`. Commit is DCO signed off.

Happy to narrow this to the three `importers/` sites if you would rather keep the diff tighter, or to split the JSON ones into a separate PR.
